### PR TITLE
feat: add walking footstep sounds and update project documentation

### DIFF
--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -28,6 +28,7 @@ export class Player {
   private facingRight = true;
   private dustEmitter?: Phaser.GameObjects.Particles.ParticleEmitter;
   private audio: AudioManager;
+  private footstepToggle = false;
 
   /** True while the player is mid-flip (scripted arc). */
   private isFlipping = false;
@@ -53,6 +54,7 @@ export class Player {
     this.audio = audio;
 
     this.createAnimations();
+    this.sprite.on(Phaser.Animations.Events.ANIMATION_UPDATE, this.onAnimationFrame, this);
     this.createDustEmitter();
   }
 
@@ -202,6 +204,17 @@ export class Player {
       this.sprite.anims.play('player_idle', true);
 
       this.emitDust();
+    }
+  }
+
+  private onAnimationFrame(
+    _anim: Phaser.Animations.Animation,
+    frame: Phaser.Animations.AnimationFrame,
+  ): void {
+    if (this.currentAnim !== 'walk') return;
+    if (frame.index === 0 || frame.index === 2) {
+      this.footstepToggle = !this.footstepToggle;
+      this.audio.playSfx(this.footstepToggle ? 'footstep_a' : 'footstep_b');
     }
   }
 

--- a/src/systems/SoundGenerator.ts
+++ b/src/systems/SoundGenerator.ts
@@ -11,6 +11,8 @@ const SAMPLE_RATE = 44100;
 /** Generate all game sounds and queue them for Phaser's audio loader. */
 export function generateSounds(scene: Phaser.Scene): void {
   loadWav(scene, 'jump', generateJumpSound());
+  loadWav(scene, 'footstep_a', generateFootstepSound(100));
+  loadWav(scene, 'footstep_b', generateFootstepSound(85));
 }
 
 function loadWav(scene: Phaser.Scene, key: string, wav: ArrayBuffer): void {
@@ -37,6 +39,28 @@ function loadWav(scene: Phaser.Scene, key: string, wav: ArrayBuffer): void {
   scene.load.on('loaderror', onLoadError);
 
   scene.load.audio(key, url);
+}
+
+/** Short percussive footstep — low thud + noise scuff. */
+function generateFootstepSound(baseFreq: number): ArrayBuffer {
+  const duration = 0.04;
+  const numSamples = Math.floor(SAMPLE_RATE * duration);
+  const samples = new Float32Array(numSamples);
+
+  let phase = 0;
+  for (let i = 0; i < numSamples; i++) {
+    const progress = numSamples > 1 ? i / (numSamples - 1) : 1;
+    // Exponential decay envelope
+    const envelope = Math.exp(-progress * 8);
+    // Low-frequency square wave thud
+    phase += (2 * Math.PI * baseFreq) / SAMPLE_RATE;
+    const tonal = Math.sign(Math.sin(phase)) * 0.6;
+    // Noise component (scuff)
+    const noise = (Math.random() * 2 - 1) * 0.4;
+    samples[i] = (tonal + noise) * envelope * 0.15;
+  }
+
+  return encodeWAV(samples, SAMPLE_RATE);
 }
 
 /** Short upward frequency sweep — retro 8-bit jump "bwip". */


### PR DESCRIPTION
Add procedural footstep sound effects that alternate between two pitches
(left/right foot) synced to the walk animation frames. Update all
documentation to reflect current project state: fix project name
references, TypeScript language, actual directory structure, and
procedural asset generation approach.

https://claude.ai/code/session_01CyqrrJh7ctwtWXKHEJRgZ6