### PR TITLE
feat: add location-aware background music with standalone EventBus

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -70,6 +70,49 @@ Player progress is saved to localStorage via `src/systems/SaveManager.ts`. When 
 3. Call `this.persist()` in ProgressionSystem after any state mutation that should survive a reload.
 4. **Do not** import `SaveManager` from scene code — interact with persistence only through `ProgressionSystem`'s public API. The one exception is `hasSave()` for UI checks (e.g. showing a "Continue" button).
 
+### EventBus Pattern
+
+The project uses a standalone `EventBus` (`src/systems/EventBus.ts`) for loose coupling between game systems. It has no Phaser dependency and is imported as a singleton.
+
+**When to use the EventBus:**
+- Triggering side effects (audio, particles, UI feedback) from gameplay actions
+- Any case where the emitter shouldn't know about the consumer
+- Cross-system communication where direct imports create circular or tight coupling
+
+**When NOT to use the EventBus:**
+- Direct parent-child communication (pass callbacks or use Phaser's built-in scene events)
+- Single-use wiring where a direct function call is clearer
+- Performance-critical per-frame logic (event dispatch has overhead vs direct calls)
+
+**Audio events follow this convention:**
+- `sfx:<action>` — sound effects (e.g., `sfx:jump`, `sfx:collect`)
+- `music:play` — play a music track by key
+- `music:stop` — stop current music
+
+**To add a new sound effect:**
+1. Generate the sound in `SoundGenerator.ts` and register it in `generateSounds()`
+2. Add the event→key mapping in `src/config/audioConfig.ts` under `SFX_EVENTS`
+3. Emit the event from the relevant entity/system: `eventBus.emit('sfx:myevent')`
+
+**To add music for a new scene:**
+1. Generate the track in `MusicGenerator.ts` and register it in `generateMusic()`
+2. Add the scene→music mapping in `src/config/audioConfig.ts` under `SCENE_MUSIC`
+3. The `MusicPlugin` handles playback automatically — no scene code changes needed
+
+### Audio Architecture
+
+Audio is fully decoupled via the EventBus. `AudioManager` is a purely reactive subscriber — no module calls it directly. Music is triggered automatically by `MusicPlugin` (a Phaser ScenePlugin) on scene transitions. SFX are triggered by entities emitting events on the EventBus.
+
+All audio (SFX and music) is procedurally generated at runtime in `SoundGenerator.ts` and `MusicGenerator.ts` — the project has zero external audio files.
+
+### AI Collaboration Guidelines
+
+When responding to ideas or feature requests:
+- **Always challenge ideas critically** — identify trade-offs, edge cases, and simpler alternatives before implementing
+- **Provide options with pros and cons** — don't just implement the first approach; present at least 2 options for non-trivial decisions
+- **Push back on over-engineering** — if a simpler solution exists, present it alongside the complex one
+- **Question assumptions** — ask "do we actually need this?" before building abstractions
+
 ## Vibe Coding Workflow
 
 This project is developed through conversational AI assistance. When prompting:

--- a/public/music/README.md
+++ b/public/music/README.md
@@ -1,0 +1,44 @@
+# Music Assets
+
+Background music is currently generated procedurally at runtime (see `src/systems/MusicGenerator.ts`). To replace with higher-quality tracks, download CC0/royalty-free MP3s from the sources below and update `BootScene.preload()` to load them via `this.load.audio()` instead of `generateMusic()`.
+
+## 80s Retro Synth (default game music)
+
+Used in: MenuScene, Floor1Scene, Floor2Scene
+
+| Source | Link |
+|--------|------|
+| OpenGameArt — Retro Synthwave Loops | https://opengameart.org/content/retro-synthwave-loops |
+| OpenGameArt — CC0 Retro Music | https://opengameart.org/content/cc0-retro-music |
+| OpenGameArt — Calm Ambient 2 (Synthwave 15k) | https://opengameart.org/content/calm-ambient-2-synthwave-15k |
+| OpenGameArt — 8-bit Music Pack (Loopable) | https://opengameart.org/content/8-bit-music-pack-loopable |
+| Pixabay — Synthwave Loop | https://pixabay.com/music/search/synthwave%20loop/ |
+| Pixabay — 80s Synth | https://pixabay.com/music/search/80s%20synth/ |
+| Pixabay — Retrogaming | https://pixabay.com/music/search/retrogaming/ |
+
+## Jazzy Elevator Music (HubScene)
+
+Used in: HubScene (elevator shaft)
+
+| Source | Link |
+|--------|------|
+| Pixabay — Jazz Lounge Elevator Music | https://pixabay.com/music/elevator-music-jazz-lounge-elevator-music-332339/ |
+| Pixabay — Lounge Jazz Elevator Music | https://pixabay.com/music/elevator-music-lounge-jazz-elevator-music-342629/ |
+| Pixabay — Elevator Music Search | https://pixabay.com/music/search/elevator%20music%20jazz/ |
+| Archive.org — Elevator Music (Kevin MacLeod, CC0) | https://archive.org/details/elevator-musicchosic.com |
+| Archive.org — Elevator Music Bossa Nova | https://archive.org/details/elevator-music-bossa-nova-background-music-version-60s |
+
+## How to replace procedural music with MP3 files
+
+1. Download tracks and save them as `public/music/retro_synth.mp3` and `public/music/elevator_jazz.mp3`
+2. In `src/scenes/BootScene.ts`, replace `generateMusic(this)` with:
+   ```typescript
+   this.load.audio('music_retro_synth', 'music/retro_synth.mp3');
+   this.load.audio('music_elevator_jazz', 'music/elevator_jazz.mp3');
+   ```
+3. Remove the `generateMusic` import from BootScene
+4. Everything else (EventBus, MusicPlugin, AudioManager) works unchanged
+
+## Licensing
+
+All sources listed above offer CC0 or royalty-free tracks. Always verify the license on the specific track you download. Even for CC0 content, it's good practice to credit the author here.

--- a/src/config/audioConfig.ts
+++ b/src/config/audioConfig.ts
@@ -1,0 +1,24 @@
+/**
+ * Central audio configuration — single source of truth for all audio mappings.
+ *
+ * To add a new sound effect:
+ *   1. Generate or load the sound in SoundGenerator / BootScene.preload()
+ *   2. Add the event-to-key mapping in SFX_EVENTS below
+ *   3. Emit the event from the relevant entity / system via eventBus
+ */
+
+/** Scene key → background music Phaser audio key. */
+export const SCENE_MUSIC: Record<string, string> = {
+  MenuScene:   'music_retro_synth',
+  HubScene:    'music_elevator_jazz',
+  Floor1Scene: 'music_retro_synth',
+  Floor2Scene: 'music_retro_synth',
+};
+
+/** EventBus event name → Phaser SFX audio key. */
+export const SFX_EVENTS: Record<string, string> = {
+  'sfx:jump': 'jump',
+};
+
+/** Default volume for background music (0–1). */
+export const MUSIC_VOLUME = 0.35;

--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -1,7 +1,7 @@
 import * as Phaser from 'phaser';
 import { PLAYER_SPEED } from '../config/gameConfig';
 import { InputManager } from '../systems/InputManager';
-import type { AudioManager } from '../systems/AudioManager';
+import { eventBus } from '../systems/EventBus';
 
 type PlayerAnimState = 'idle' | 'walk' | 'flip' | 'fall';
 
@@ -27,7 +27,6 @@ export class Player {
   private currentAnim: PlayerAnimState = 'idle';
   private facingRight = true;
   private dustEmitter?: Phaser.GameObjects.Particles.ParticleEmitter;
-  private audio: AudioManager;
 
   /** True while the player is mid-flip (scripted arc). */
   private isFlipping = false;
@@ -45,12 +44,6 @@ export class Player {
     this.sprite.setOffset(HITBOX_MARGIN_X, HITBOX_MARGIN_Y);
     this.sprite.setCollideWorldBounds(true);
     this.sprite.setDepth(10);
-
-    const audio = scene.registry.get('audio') as AudioManager | undefined;
-    if (!audio) {
-      throw new Error('AudioManager is not registered in the scene registry under "audio".');
-    }
-    this.audio = audio;
 
     this.createAnimations();
     this.createDustEmitter();
@@ -173,7 +166,7 @@ export class Player {
     this.sprite.setFlipX(!this.facingRight);
 
     this.emitDust();
-    this.audio.playSfx('jump');
+    eventBus.emit('sfx:jump');
   }
 
   private updateFlip(delta: number): void {

--- a/src/main.ts
+++ b/src/main.ts
@@ -5,6 +5,7 @@ import { MenuScene } from './scenes/MenuScene';
 import { HubScene } from './scenes/HubScene';
 import { Floor1Scene } from './scenes/Floor1Scene';
 import { Floor2Scene } from './scenes/Floor2Scene';
+import { MusicPlugin } from './plugins/MusicPlugin';
 
 const config: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
@@ -26,6 +27,9 @@ const config: Phaser.Types.Core.GameConfig = {
     autoCenter: Phaser.Scale.CENTER_BOTH,
   },
   scene: [BootScene, MenuScene, HubScene, Floor1Scene, Floor2Scene],
+  plugins: {
+    scene: [{ key: 'MusicPlugin', plugin: MusicPlugin, mapping: 'music' }],
+  },
 };
 
 new Phaser.Game(config);

--- a/src/plugins/MusicPlugin.ts
+++ b/src/plugins/MusicPlugin.ts
@@ -1,0 +1,24 @@
+import * as Phaser from 'phaser';
+import { SCENE_MUSIC } from '../config/audioConfig';
+import { eventBus } from '../systems/EventBus';
+
+/**
+ * Phaser ScenePlugin — bridges the framework's scene lifecycle to the
+ * standalone EventBus.
+ *
+ * Auto-attached to every scene via the game config. On each scene's
+ * `create` event it looks up SCENE_MUSIC and emits `music:play` on the
+ * EventBus. Scenes themselves never touch audio code.
+ */
+export class MusicPlugin extends Phaser.Plugins.ScenePlugin {
+  boot(): void {
+    this.systems!.events.on('create', this.onSceneCreate, this);
+  }
+
+  private onSceneCreate(): void {
+    const musicKey = SCENE_MUSIC[this.scene!.scene.key];
+    if (musicKey) {
+      eventBus.emit('music:play', musicKey);
+    }
+  }
+}

--- a/src/scenes/BootScene.ts
+++ b/src/scenes/BootScene.ts
@@ -1,6 +1,7 @@
 import * as Phaser from 'phaser';
 import { generateSprites } from '../systems/SpriteGenerator';
 import { generateSounds } from '../systems/SoundGenerator';
+import { generateMusic } from '../systems/MusicGenerator';
 import { AudioManager } from '../systems/AudioManager';
 import { COLORS } from '../config/gameConfig';
 
@@ -48,14 +49,17 @@ export class BootScene extends Phaser.Scene {
 
     // Generate procedural audio and queue for Phaser's loader
     generateSounds(this);
+    generateMusic(this);
   }
 
   create(): void {
     // Generate all sprites programmatically
     generateSprites(this);
 
-    // Initialize audio manager (shared across all scenes via registry)
-    this.registry.set('audio', new AudioManager(this.sound));
+    // Initialize audio manager and wire it to the EventBus
+    const audio = new AudioManager(this.sound);
+    audio.registerEventListeners();
+    this.registry.set('audio', audio);
 
     this.scene.start('MenuScene');
   }

--- a/src/systems/AudioManager.ts
+++ b/src/systems/AudioManager.ts
@@ -1,35 +1,62 @@
 import * as Phaser from 'phaser';
+import { eventBus } from './EventBus';
+import { SFX_EVENTS, MUSIC_VOLUME } from '../config/audioConfig';
 
 /**
  * Thin wrapper around Phaser's sound manager.
- * Stored in the scene registry so any scene/entity can access it.
+ *
+ * Purely reactive — subscribes to EventBus events and plays audio in
+ * response. No other module should call its methods directly; all audio
+ * is triggered through the EventBus.
  */
 export class AudioManager {
   private sound: Phaser.Sound.BaseSoundManager;
   private currentMusic: Phaser.Sound.BaseSound | null = null;
+  private currentMusicKey: string | null = null;
 
   constructor(sound: Phaser.Sound.BaseSoundManager) {
     this.sound = sound;
   }
 
+  /**
+   * Subscribe to EventBus events defined in audioConfig.
+   * Call once after construction (from BootScene).
+   */
+  registerEventListeners(): void {
+    eventBus.on('music:play', (key: unknown) => {
+      if (typeof key === 'string') this.playMusic(key);
+    });
+
+    eventBus.on('music:stop', () => {
+      this.stopMusic();
+    });
+
+    for (const [event, sfxKey] of Object.entries(SFX_EVENTS)) {
+      eventBus.on(event, () => this.playSfx(sfxKey));
+    }
+  }
+
   /** Play a one-shot sound effect. */
-  playSfx(key: string): void {
+  private playSfx(key: string): void {
     this.sound.play(key);
   }
 
-  /** Start looping background music (stops any current track). */
-  playMusic(key: string): void {
+  /** Start looping background music. Skips if the same track is already playing. */
+  private playMusic(key: string, volume: number = MUSIC_VOLUME): void {
+    if (this.currentMusicKey === key && this.currentMusic) return;
     this.stopMusic();
-    this.currentMusic = this.sound.add(key, { loop: true });
+    this.currentMusic = this.sound.add(key, { loop: true, volume });
     this.currentMusic.play();
+    this.currentMusicKey = key;
   }
 
   /** Stop the current music track. */
-  stopMusic(): void {
+  private stopMusic(): void {
     if (this.currentMusic) {
       this.currentMusic.stop();
       this.currentMusic.destroy();
       this.currentMusic = null;
+      this.currentMusicKey = null;
     }
   }
 

--- a/src/systems/EventBus.ts
+++ b/src/systems/EventBus.ts
@@ -1,0 +1,35 @@
+/**
+ * Standalone event bus — zero framework dependencies.
+ *
+ * Provides pub/sub for loose coupling between game systems.
+ * Imported as a singleton so any module can emit or listen
+ * without needing a Phaser scene or game reference.
+ */
+
+type Callback = (...args: unknown[]) => void;
+
+class EventBus {
+  private listeners = new Map<string, Set<Callback>>();
+
+  /** Subscribe to an event. */
+  on(event: string, fn: Callback): this {
+    if (!this.listeners.has(event)) this.listeners.set(event, new Set());
+    this.listeners.get(event)!.add(fn);
+    return this;
+  }
+
+  /** Unsubscribe from an event. */
+  off(event: string, fn: Callback): this {
+    this.listeners.get(event)?.delete(fn);
+    return this;
+  }
+
+  /** Emit an event to all subscribers. */
+  emit(event: string, ...args: unknown[]): this {
+    this.listeners.get(event)?.forEach(fn => fn(...args));
+    return this;
+  }
+}
+
+/** Singleton game event bus — import anywhere, no framework dependency. */
+export const eventBus = new EventBus();

--- a/src/systems/MusicGenerator.ts
+++ b/src/systems/MusicGenerator.ts
@@ -6,7 +6,11 @@ import { loadWav, encodeWAV } from './SoundGenerator';
  * from mathematical waveforms. No external audio files needed.
  */
 
-const SAMPLE_RATE = 44100;
+/**
+ * 22050 Hz is plenty for retro synth & lounge music, and keeps
+ * synchronous generation fast (~330 k samples per 15 s track).
+ */
+const SAMPLE_RATE = 22050;
 
 /* ------------------------------------------------------------------ */
 /*  Waveform primitives                                               */
@@ -86,7 +90,7 @@ export function generateMusic(scene: Phaser.Scene): void {
 function generateRetroSynth(): ArrayBuffer {
   const bpm = 128;
   const beatsPerChord = 8; // 2 bars per chord
-  // Chord progression: Cm - Ab - Eb - Bb (repeat twice = 64 beats)
+  // Chord progression: Cm - Ab - Eb - Bb (single pass, loops via Phaser)
   const chordProgression = [
     { bass: C2,  arp: [C4, Eb4, G4, C5, G4, Eb4] },
     { bass: Ab2, arp: [Ab3, C4, Eb4, Ab4, Eb4, C4] },
@@ -94,9 +98,9 @@ function generateRetroSynth(): ArrayBuffer {
     { bass: Bb2, arp: [Bb3, D4, F4, Bb4, F4, D4] },
   ];
 
-  const totalBeats = chordProgression.length * beatsPerChord * 2; // 64 beats
+  const totalBeats = chordProgression.length * beatsPerChord; // 32 beats — one pass
   const beatDur = 60 / bpm;
-  const duration = totalBeats * beatDur; // 30 seconds
+  const duration = totalBeats * beatDur; // ~15 seconds
   const numSamples = Math.floor(SAMPLE_RATE * duration);
   const samples = new Float32Array(numSamples);
 
@@ -165,9 +169,9 @@ function generateElevatorJazz(): ArrayBuffer {
     { bass: [G2, Bb3, D3, G2],    pad: [G3, Bb3, D4, F4] },  // Gm7
   ];
 
-  const totalBeats = chordProgression.length * beatsPerChord; // 48 beats
+  const totalBeats = chordProgression.length * beatsPerChord / 2; // 24 beats — 3 chords
   const beatDur = 60 / bpm;
-  const duration = totalBeats * beatDur; // ~30.3 seconds
+  const duration = totalBeats * beatDur; // ~15.2 seconds
   const numSamples = Math.floor(SAMPLE_RATE * duration);
   const samples = new Float32Array(numSamples);
 

--- a/src/systems/MusicGenerator.ts
+++ b/src/systems/MusicGenerator.ts
@@ -1,0 +1,235 @@
+import * as Phaser from 'phaser';
+import { loadWav, encodeWAV } from './SoundGenerator';
+
+/**
+ * Procedural music generator — creates looping background tracks
+ * from mathematical waveforms. No external audio files needed.
+ */
+
+const SAMPLE_RATE = 44100;
+
+/* ------------------------------------------------------------------ */
+/*  Waveform primitives                                               */
+/* ------------------------------------------------------------------ */
+
+function square(phase: number): number {
+  return Math.sin(phase) >= 0 ? 1 : -1;
+}
+
+function sawtooth(phase: number): number {
+  return 2 * ((phase / (2 * Math.PI)) % 1) - 1;
+}
+
+function triangle(phase: number): number {
+  const t = (phase / (2 * Math.PI)) % 1;
+  return 4 * Math.abs(t - 0.5) - 1;
+}
+
+function sine(phase: number): number {
+  return Math.sin(phase);
+}
+
+/** Simple low-pass by averaging with previous sample. */
+function lowPass(samples: Float32Array, amount: number): void {
+  let prev = 0;
+  for (let i = 0; i < samples.length; i++) {
+    samples[i] = prev + amount * (samples[i] - prev);
+    prev = samples[i];
+  }
+}
+
+/* ------------------------------------------------------------------ */
+/*  Note helpers                                                      */
+/* ------------------------------------------------------------------ */
+
+/** MIDI note number → frequency (A4 = 69 = 440 Hz). */
+function midiToFreq(note: number): number {
+  return 440 * Math.pow(2, (note - 69) / 12);
+}
+
+// Convenient MIDI note names
+const C2 = 36, D2 = 38, Eb2 = 39, F2 = 41, G2 = 43, Ab2 = 44, Bb2 = 46;
+const C3 = 48, D3 = 50, Eb3 = 51, F3 = 53, G3 = 55, Ab3 = 56, A3 = 57, Bb3 = 58;
+const C4 = 60, D4 = 62, Eb4 = 63, E4 = 64, F4 = 65, G4 = 67, Ab4 = 68, A4 = 69, Bb4 = 70;
+const C5 = 72, D5 = 74, Eb5 = 75, G5 = 79;
+
+/* ------------------------------------------------------------------ */
+/*  Envelope                                                          */
+/* ------------------------------------------------------------------ */
+
+/** Simple attack-release envelope for a note at a given position. */
+function noteEnvelope(
+  tInNote: number, noteDuration: number,
+  attack: number, release: number,
+): number {
+  if (tInNote < attack) return tInNote / attack;
+  if (tInNote > noteDuration - release) {
+    return Math.max(0, (noteDuration - tInNote) / release);
+  }
+  return 1;
+}
+
+/* ------------------------------------------------------------------ */
+/*  Public API                                                        */
+/* ------------------------------------------------------------------ */
+
+/** Generate all music tracks and queue them for Phaser's audio loader. */
+export function generateMusic(scene: Phaser.Scene): void {
+  loadWav(scene, 'music_retro_synth', generateRetroSynth());
+  loadWav(scene, 'music_elevator_jazz', generateElevatorJazz());
+}
+
+/* ------------------------------------------------------------------ */
+/*  80s Retro Synth — default game music                              */
+/* ------------------------------------------------------------------ */
+
+function generateRetroSynth(): ArrayBuffer {
+  const bpm = 128;
+  const beatsPerChord = 8; // 2 bars per chord
+  // Chord progression: Cm - Ab - Eb - Bb (repeat twice = 64 beats)
+  const chordProgression = [
+    { bass: C2,  arp: [C4, Eb4, G4, C5, G4, Eb4] },
+    { bass: Ab2, arp: [Ab3, C4, Eb4, Ab4, Eb4, C4] },
+    { bass: Eb2, arp: [Eb4, G4, Bb4, Eb5, Bb4, G4] },
+    { bass: Bb2, arp: [Bb3, D4, F4, Bb4, F4, D4] },
+  ];
+
+  const totalBeats = chordProgression.length * beatsPerChord * 2; // 64 beats
+  const beatDur = 60 / bpm;
+  const duration = totalBeats * beatDur; // 30 seconds
+  const numSamples = Math.floor(SAMPLE_RATE * duration);
+  const samples = new Float32Array(numSamples);
+
+  // Persistent phase accumulators to avoid clicks
+  let arpPhase = 0;
+  let bassPhase = 0;
+  let padPhase1 = 0;
+  let padPhase2 = 0;
+
+  for (let i = 0; i < numSamples; i++) {
+    const t = i / SAMPLE_RATE;
+    const beat = t / beatDur;
+    const chordIdx = Math.floor(beat / beatsPerChord) % chordProgression.length;
+    const chord = chordProgression[chordIdx];
+
+    // --- Arpeggio (square wave, 16th notes) ---
+    const arpNotesPerBeat = 4;
+    const arpNoteIdx = Math.floor(beat * arpNotesPerBeat) % chord.arp.length;
+    const arpFreq = midiToFreq(chord.arp[arpNoteIdx]);
+    const arpNoteDur = beatDur / arpNotesPerBeat;
+    const tInArpNote = (t % arpNoteDur);
+    const arpEnv = noteEnvelope(tInArpNote, arpNoteDur, 0.005, arpNoteDur * 0.3);
+
+    arpPhase += (2 * Math.PI * arpFreq) / SAMPLE_RATE;
+    const arpSample = square(arpPhase) * arpEnv * 0.10;
+
+    // --- Bass (sawtooth, 8th notes on root) ---
+    const bassFreq = midiToFreq(chord.bass);
+    const bassNoteDur = beatDur / 2;
+    const tInBassNote = t % bassNoteDur;
+    const bassEnv = noteEnvelope(tInBassNote, bassNoteDur, 0.01, bassNoteDur * 0.2);
+
+    bassPhase += (2 * Math.PI * bassFreq) / SAMPLE_RATE;
+    const bassSample = sawtooth(bassPhase) * bassEnv * 0.12;
+
+    // --- Pad (soft triangle chord, root + 5th) ---
+    const padFreq1 = midiToFreq(chord.arp[0]);
+    const padFreq2 = midiToFreq(chord.arp[2]);
+    padPhase1 += (2 * Math.PI * padFreq1) / SAMPLE_RATE;
+    padPhase2 += (2 * Math.PI * padFreq2) / SAMPLE_RATE;
+    const padSample = (triangle(padPhase1) + triangle(padPhase2)) * 0.04;
+
+    samples[i] = arpSample + bassSample + padSample;
+  }
+
+  // Gentle low-pass to tame harshness
+  lowPass(samples, 0.6);
+
+  return encodeWAV(samples, SAMPLE_RATE);
+}
+
+/* ------------------------------------------------------------------ */
+/*  Jazzy Elevator Music — HubScene                                   */
+/* ------------------------------------------------------------------ */
+
+function generateElevatorJazz(): ArrayBuffer {
+  const bpm = 95;
+  const beatsPerChord = 8; // 2 bars per chord
+  // Jazz progression: Fmaj7 - Gm7 - Am7 - Bbmaj7 - Am7 - Gm7
+  const chordProgression = [
+    { bass: [F2, A3, C3, F2],     pad: [F3, A3, C4, E4] },   // Fmaj7
+    { bass: [G2, Bb3, D3, G2],    pad: [G3, Bb3, D4, F4] },  // Gm7
+    { bass: [A3, C3, A3, G2],     pad: [A3, C4, E4, G4] },   // Am7
+    { bass: [Bb2, D3, F3, Bb2],   pad: [Bb3, D4, F4, A4] },  // Bbmaj7
+    { bass: [A3, C3, E4, A3],     pad: [A3, C4, E4, G4] },   // Am7
+    { bass: [G2, Bb3, D3, G2],    pad: [G3, Bb3, D4, F4] },  // Gm7
+  ];
+
+  const totalBeats = chordProgression.length * beatsPerChord; // 48 beats
+  const beatDur = 60 / bpm;
+  const duration = totalBeats * beatDur; // ~30.3 seconds
+  const numSamples = Math.floor(SAMPLE_RATE * duration);
+  const samples = new Float32Array(numSamples);
+
+  // Phase accumulators
+  let bassPhase = 0;
+  const padPhases = [0, 0, 0, 0];
+  let melodyPhase = 0;
+
+  // Simple melody line (quarter notes, chord tones with passing tones)
+  const melodyPattern = [
+    [F4, A4, C5, A4, G4, F4, E4, D4],     // over Fmaj7
+    [G4, Bb4, D5, Bb4, A4, G4, F4, D4],   // over Gm7
+    [A4, C5, E4, C5, D5, C5, A4, G4],     // over Am7
+    [Bb4, D5, F4, D5, C5, Bb4, A4, F4],   // over Bbmaj7
+    [A4, C5, E4, G4, A4, E4, C5, A4],     // over Am7
+    [G4, Bb4, D4, F4, G4, D4, Bb4, G4],   // over Gm7
+  ];
+
+  for (let i = 0; i < numSamples; i++) {
+    const t = i / SAMPLE_RATE;
+    const beat = t / beatDur;
+    const chordIdx = Math.floor(beat / beatsPerChord) % chordProgression.length;
+    const chord = chordProgression[chordIdx];
+    const beatInChord = beat - Math.floor(beat / beatsPerChord) * beatsPerChord;
+
+    // --- Walking bass (quarter notes) ---
+    const bassNoteIdx = Math.floor(beatInChord) % chord.bass.length;
+    const bassFreq = midiToFreq(chord.bass[bassNoteIdx]);
+    const tInBassNote = (beatInChord % 1) * beatDur;
+    const bassEnv = noteEnvelope(tInBassNote, beatDur, 0.02, beatDur * 0.15);
+
+    bassPhase += (2 * Math.PI * bassFreq) / SAMPLE_RATE;
+    // Mix triangle + sine for warm bass
+    const bassSample = (triangle(bassPhase) * 0.6 + sine(bassPhase) * 0.4) * bassEnv * 0.13;
+
+    // --- Pad (sine chord, whole notes with slow attack) ---
+    let padSample = 0;
+    for (let p = 0; p < chord.pad.length; p++) {
+      const padFreq = midiToFreq(chord.pad[p]);
+      padPhases[p] += (2 * Math.PI * padFreq) / SAMPLE_RATE;
+      padSample += sine(padPhases[p]);
+    }
+    const padChordDur = beatsPerChord * beatDur;
+    const tInChord = beatInChord * beatDur;
+    const padEnv = noteEnvelope(tInChord, padChordDur, 0.3, 0.3);
+    padSample = (padSample / chord.pad.length) * padEnv * 0.08;
+
+    // --- Melody (quarter notes, sine + slight triangle) ---
+    const melody = melodyPattern[chordIdx];
+    const melNoteIdx = Math.floor(beatInChord) % melody.length;
+    const melFreq = midiToFreq(melody[melNoteIdx]);
+    const tInMelNote = (beatInChord % 1) * beatDur;
+    const melEnv = noteEnvelope(tInMelNote, beatDur, 0.03, beatDur * 0.4);
+
+    melodyPhase += (2 * Math.PI * melFreq) / SAMPLE_RATE;
+    const melSample = (sine(melodyPhase) * 0.7 + triangle(melodyPhase) * 0.3) * melEnv * 0.09;
+
+    samples[i] = bassSample + padSample + melSample;
+  }
+
+  // Smooth low-pass for warm jazz feel
+  lowPass(samples, 0.4);
+
+  return encodeWAV(samples, SAMPLE_RATE);
+}

--- a/src/systems/SoundGenerator.ts
+++ b/src/systems/SoundGenerator.ts
@@ -13,7 +13,7 @@ export function generateSounds(scene: Phaser.Scene): void {
   loadWav(scene, 'jump', generateJumpSound());
 }
 
-function loadWav(scene: Phaser.Scene, key: string, wav: ArrayBuffer): void {
+export function loadWav(scene: Phaser.Scene, key: string, wav: ArrayBuffer): void {
   const blob = new Blob([wav], { type: 'audio/wav' });
   const url = URL.createObjectURL(blob);
 
@@ -62,7 +62,7 @@ function generateJumpSound(): ArrayBuffer {
 }
 
 /** Encode raw Float32 samples as a 16-bit PCM WAV file. */
-function encodeWAV(samples: Float32Array, sampleRate: number): ArrayBuffer {
+export function encodeWAV(samples: Float32Array, sampleRate: number): ArrayBuffer {
   const numChannels = 1;
   const bitsPerSample = 16;
   const byteRate = sampleRate * numChannels * (bitsPerSample / 8);


### PR DESCRIPTION
Add a decoupled audio architecture using a standalone EventBus for
loose coupling between game systems:

- EventBus: framework-independent pub/sub singleton (no Phaser dep)
- MusicPlugin: Phaser ScenePlugin that auto-plays music on scene
  transitions by emitting events on the EventBus
- AudioManager: now purely reactive, subscribes to EventBus events
  instead of being called directly
- audioConfig: central config mapping scenes to music and events to SFX
- MusicGenerator: procedural generation of two looping music tracks
  - 80s retro synth (default for Menu, Floor1, Floor2)
  - Jazzy elevator music (HubScene)
- Player no longer imports AudioManager; emits sfx events via EventBus
- Updated copilot-instructions with EventBus pattern docs and AI
  collaboration guidelines

https://claude.ai/code/session_01TsqGgzNMwUbYSA6wfmoteF