### PR TITLE
feat: add Architecture Elevator info dialog system

### DIFF
--- a/src/scenes/HubScene.ts
+++ b/src/scenes/HubScene.ts
@@ -6,6 +6,31 @@ import { Elevator } from '../entities/Elevator';
 import { HUD } from '../ui/HUD';
 import { ElevatorButtons } from '../ui/ElevatorButtons';
 import { ProgressionSystem } from '../systems/ProgressionSystem';
+import { InfoDialog, InfoDialogContent } from '../ui/InfoDialog';
+import { InfoIcon } from '../ui/InfoIcon';
+import { hasBeenSeen, markSeen } from '../systems/InfoDialogManager';
+
+const ELEVATOR_INFO_ID = 'architecture-elevator';
+
+const ELEVATOR_INFO_CONTENT: InfoDialogContent = {
+  id: ELEVATOR_INFO_ID,
+  title: 'The Architecture Elevator',
+  body:
+    'Gregor Hohpe coined the term "Architecture Elevator" to describe ' +
+    'how software architects must ride between the penthouse \u2014 where ' +
+    'business strategy and organizational decisions are made \u2014 and the ' +
+    'engine room \u2014 where the technology is built and operated.\n\n' +
+    'An effective architect doesn\'t just live on one floor. They translate ' +
+    'between executives who speak in business outcomes and engineers who ' +
+    'speak in systems and code. The elevator ride connects these worlds.\n\n' +
+    'In this game you literally ride the elevator between floors \u2014 each ' +
+    'one representing a different team and set of architectural challenges.',
+  links: [
+    { label: 'The Software Architect Elevator (Book)', url: 'https://architectelevator.com/book/' },
+    { label: 'Gregor Hohpe\u2019s Blog', url: 'https://architectelevator.com/' },
+    { label: 'Architecture Elevator Article', url: 'https://martinfowler.com/articles/architect-elevator.html' },
+  ],
+};
 
 /**
  * Hub / Elevator-shaft scene — Impossible-Mission style.
@@ -27,6 +52,12 @@ export class HubScene extends Phaser.Scene {
 
   /** On-screen elevator buttons (shared component). */
   private elevatorButtons?: ElevatorButtons;
+
+  /** Info dialog state. */
+  private showElevatorInfoOnFirstRide = false;
+  private dialogOpen = false;
+  private activeDialog?: InfoDialog;
+  private infoIcon?: InfoIcon;
 
   /** The shaft is wider in the 128-px world. */
   private static readonly SHAFT_WIDTH = 220;
@@ -65,6 +96,8 @@ export class HubScene extends Phaser.Scene {
     this.cameras.main.startFollow(this.player.sprite, true, 0.1, 0.1);
     this.cameras.main.setBounds(0, 0, GAME_WIDTH, worldHeight);
     this.cameras.main.fadeIn(500, 0, 0, 0);
+
+    this.setupElevatorInfo();
   }
 
   /* ---- background ---- */
@@ -195,6 +228,12 @@ export class HubScene extends Phaser.Scene {
   update(_time: number, delta: number): void {
     if (this.isTransitioning) return;
 
+    // Check for I key even while dialog is open (consumed by edge-detector)
+    const inputMgr = this.player.getInputManager();
+    const infoPressed = inputMgr.isInfoJustPressed();
+
+    if (this.dialogOpen) return;
+
     this.player.update(delta);
     this.hud.update();
 
@@ -204,12 +243,25 @@ export class HubScene extends Phaser.Scene {
 
     this.playerOnElevator = onElevator;
 
+    // First-ride info dialog trigger
+    if (this.playerOnElevator && this.showElevatorInfoOnFirstRide) {
+      this.showElevatorInfoOnFirstRide = false;
+      this.openElevatorInfoDialog();
+      return;
+    }
+
+    // I key opens info dialog when icon is visible
+    if (infoPressed && this.infoIcon && !this.dialogOpen) {
+      this.openElevatorInfoDialog();
+      return;
+    }
+
     // Show / hide elevator buttons (resets pressed state when hiding)
     this.elevatorButtons?.setVisible(this.playerOnElevator);
 
     // Ride elevator with Up/Down keys or on-screen buttons when standing on it
     if (this.playerOnElevator) {
-      const input = this.player.getInputManager().getState();
+      const input = inputMgr.getState();
       const btnState = this.elevatorButtons?.getState();
       const up = input.up || (btnState?.up ?? false);
       const down = input.down || (btnState?.down ?? false);
@@ -265,6 +317,38 @@ export class HubScene extends Phaser.Scene {
         }
       }
     }
+  }
+
+  /* ---- info dialog ---- */
+  private setupElevatorInfo(): void {
+    if (hasBeenSeen(ELEVATOR_INFO_ID)) {
+      this.showElevatorInfoOnFirstRide = false;
+      this.createInfoIcon();
+    } else {
+      this.showElevatorInfoOnFirstRide = true;
+    }
+  }
+
+  private openElevatorInfoDialog(): void {
+    if (this.dialogOpen) return;
+    this.dialogOpen = true;
+
+    this.activeDialog = new InfoDialog(this, ELEVATOR_INFO_CONTENT, () => {
+      this.dialogOpen = false;
+      this.activeDialog = undefined;
+
+      if (!this.infoIcon) {
+        markSeen(ELEVATOR_INFO_ID);
+        this.createInfoIcon();
+      }
+    });
+  }
+
+  private createInfoIcon(): void {
+    // Position near the bottom instruction bar, left of center
+    this.infoIcon = new InfoIcon(this, GAME_WIDTH / 2 + 310, GAME_HEIGHT - 30, () => {
+      this.openElevatorInfoDialog();
+    });
   }
 
   private enterFloor(floorId: FloorId): void {

--- a/src/scenes/HubScene.ts
+++ b/src/scenes/HubScene.ts
@@ -53,7 +53,6 @@ export class HubScene extends Phaser.Scene {
   /** On-screen elevator buttons (shared component). */
   private elevatorButtons?: ElevatorButtons;
 
-  /** Info dialog state. */
   private showElevatorInfoOnFirstRide = false;
   private dialogOpen = false;
   private activeDialog?: InfoDialog;
@@ -228,7 +227,6 @@ export class HubScene extends Phaser.Scene {
   update(_time: number, delta: number): void {
     if (this.isTransitioning) return;
 
-    // Check for I key even while dialog is open (consumed by edge-detector)
     const inputMgr = this.player.getInputManager();
     const infoPressed = inputMgr.isInfoJustPressed();
 
@@ -243,14 +241,12 @@ export class HubScene extends Phaser.Scene {
 
     this.playerOnElevator = onElevator;
 
-    // First-ride info dialog trigger
     if (this.playerOnElevator && this.showElevatorInfoOnFirstRide) {
       this.showElevatorInfoOnFirstRide = false;
       this.openElevatorInfoDialog();
       return;
     }
 
-    // I key opens info dialog when icon is visible
     if (infoPressed && this.infoIcon && !this.dialogOpen) {
       this.openElevatorInfoDialog();
       return;
@@ -345,7 +341,6 @@ export class HubScene extends Phaser.Scene {
   }
 
   private createInfoIcon(): void {
-    // Position near the bottom instruction bar, left of center
     this.infoIcon = new InfoIcon(this, GAME_WIDTH / 2 + 310, GAME_HEIGHT - 30, () => {
       this.openElevatorInfoDialog();
     });

--- a/src/systems/InfoDialogManager.ts
+++ b/src/systems/InfoDialogManager.ts
@@ -1,10 +1,3 @@
-/**
- * Tracks which info dialogs the player has already seen.
- *
- * Uses a separate localStorage key from the game save so dialog
- * state persists even if the player resets their game progress.
- */
-
 import type { KVStorage } from './SaveManager';
 
 const STORAGE_KEY = 'architect_info_seen_v1';
@@ -25,7 +18,7 @@ function loadSeen(): Set<string> {
 }
 
 function persist(seen: Set<string>): void {
-  try { getStorage().setItem(STORAGE_KEY, JSON.stringify([...seen])); } catch { /* quota */ }
+  try { getStorage().setItem(STORAGE_KEY, JSON.stringify([...seen])); } catch { /* */ }
 }
 
 export function hasBeenSeen(id: string): boolean {
@@ -39,5 +32,5 @@ export function markSeen(id: string): void {
 }
 
 export function resetAll(): void {
-  try { getStorage().removeItem(STORAGE_KEY); } catch { /* noop */ }
+  try { getStorage().removeItem(STORAGE_KEY); } catch { /* */ }
 }

--- a/src/systems/InfoDialogManager.ts
+++ b/src/systems/InfoDialogManager.ts
@@ -1,0 +1,43 @@
+/**
+ * Tracks which info dialogs the player has already seen.
+ *
+ * Uses a separate localStorage key from the game save so dialog
+ * state persists even if the player resets their game progress.
+ */
+
+import type { KVStorage } from './SaveManager';
+
+const STORAGE_KEY = 'architect_info_seen_v1';
+
+let storage: KVStorage | null = null;
+
+function getStorage(): KVStorage {
+  if (storage) return storage;
+  try { storage = globalThis.localStorage; return storage; }
+  catch { return { getItem: () => null, setItem: () => {}, removeItem: () => {} }; }
+}
+
+function loadSeen(): Set<string> {
+  try {
+    const raw = getStorage().getItem(STORAGE_KEY);
+    return raw ? new Set(JSON.parse(raw) as string[]) : new Set();
+  } catch { return new Set(); }
+}
+
+function persist(seen: Set<string>): void {
+  try { getStorage().setItem(STORAGE_KEY, JSON.stringify([...seen])); } catch { /* quota */ }
+}
+
+export function hasBeenSeen(id: string): boolean {
+  return loadSeen().has(id);
+}
+
+export function markSeen(id: string): void {
+  const seen = loadSeen();
+  seen.add(id);
+  persist(seen);
+}
+
+export function resetAll(): void {
+  try { getStorage().removeItem(STORAGE_KEY); } catch { /* noop */ }
+}

--- a/src/systems/InputManager.ts
+++ b/src/systems/InputManager.ts
@@ -19,8 +19,10 @@ export class InputManager {
   };
   private spaceKey!: Phaser.Input.Keyboard.Key;
   private interactKey!: Phaser.Input.Keyboard.Key;
+  private infoKey!: Phaser.Input.Keyboard.Key;
   private jumpJustPressedFlag = false;
   private interactJustPressedFlag = false;
+  private infoJustPressedFlag = false;
 
   constructor(scene: Phaser.Scene) {
     if (!scene.input.keyboard) return;
@@ -34,6 +36,7 @@ export class InputManager {
     };
     this.spaceKey = scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.SPACE);
     this.interactKey = scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.E);
+    this.infoKey = scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.I);
   }
 
   getState(): InputState {
@@ -67,6 +70,18 @@ export class InputManager {
     }
     if (!interactDown) {
       this.interactJustPressedFlag = false;
+    }
+    return false;
+  }
+
+  isInfoJustPressed(): boolean {
+    const infoDown = this.infoKey?.isDown || false;
+    if (infoDown && !this.infoJustPressedFlag) {
+      this.infoJustPressedFlag = true;
+      return true;
+    }
+    if (!infoDown) {
+      this.infoJustPressedFlag = false;
     }
     return false;
   }

--- a/src/ui/InfoDialog.ts
+++ b/src/ui/InfoDialog.ts
@@ -56,9 +56,14 @@ export class InfoDialog {
     const LINK_LINE_H = 30;
     const CLOSE_BAR_H = 44;
 
-    const bodyMeasure = this.scene.add.text(0, 0, content.body, {
-      fontFamily: 'monospace', fontSize: '15px', color: '#c0c8d4',
-      wordWrap: { width: panelW - PADDING * 2 }, lineSpacing: 6,
+    const bodyMeasure = this.scene.make.text({
+      x: 0, y: 0,
+      text: content.body,
+      style: {
+        fontFamily: 'monospace', fontSize: '15px', color: '#c0c8d4',
+        wordWrap: { width: panelW - PADDING * 2 }, lineSpacing: 6,
+      },
+      add: false,
     });
     const bodyH = bodyMeasure.height;
     bodyMeasure.destroy();
@@ -66,8 +71,9 @@ export class InfoDialog {
     const linksCount = content.links?.length ?? 0;
     const linksSectionH = linksCount > 0 ? 28 + linksCount * LINK_LINE_H + 8 : 0;
 
-    panelH = 28 + 18 + bodyH + 16 + linksSectionH + CLOSE_BAR_H + PADDING * 2;
-    const panelY = (GAME_HEIGHT - panelH) / 2;
+    const MAX_PANEL_H = GAME_HEIGHT - 40;
+    panelH = Math.min(28 + 18 + bodyH + 16 + linksSectionH + CLOSE_BAR_H + PADDING * 2, MAX_PANEL_H);
+    const panelY = Math.max(20, (GAME_HEIGHT - panelH) / 2);
 
     const bg = this.scene.add.graphics();
     bg.fillStyle(0x0a0a2a, 0.95);
@@ -106,7 +112,7 @@ export class InfoDialog {
         linkText.on('pointerover', () => linkText.setColor('#88ddff'));
         linkText.on('pointerout', () => linkText.setColor('#44aaff'));
         linkText.on('pointerdown', () => {
-          window.open(link.url, '_blank');
+          window.open(link.url, '_blank', 'noopener,noreferrer');
         });
 
         this.container.add(linkText);

--- a/src/ui/InfoDialog.ts
+++ b/src/ui/InfoDialog.ts
@@ -13,12 +13,6 @@ export interface InfoDialogContent {
   links?: InfoDialogLink[];
 }
 
-/**
- * Reusable modal info dialog rendered as a Phaser overlay.
- *
- * Shows a title, word-wrapped body text, optional clickable links,
- * and a close button. Closes on ESC or clicking [X].
- */
 export class InfoDialog {
   private scene: Phaser.Scene;
   private container: Phaser.GameObjects.Container;
@@ -40,32 +34,28 @@ export class InfoDialog {
     this.buildPanel(content);
     this.registerEscKey();
 
-    // Fade in
     scene.tweens.add({ targets: this.container, alpha: 1, duration: 200 });
   }
 
-  /* ---- overlay (dims the game) ---- */
   private buildOverlay(): void {
     const overlay = this.scene.add.rectangle(
       GAME_WIDTH / 2, GAME_HEIGHT / 2,
       GAME_WIDTH, GAME_HEIGHT,
       0x000000, 0.65,
     );
-    overlay.setInteractive(); // absorb clicks behind the panel
+    overlay.setInteractive();
     this.container.add(overlay);
   }
 
-  /* ---- main panel ---- */
   private buildPanel(content: InfoDialogContent): void {
     const panelW = 620;
     const panelX = (GAME_WIDTH - panelW) / 2;
-    let panelH = 0; // will be computed dynamically
+    let panelH = 0;
 
     const PADDING = 32;
     const LINK_LINE_H = 30;
     const CLOSE_BAR_H = 44;
 
-    // --- Measure body height first ---
     const bodyMeasure = this.scene.add.text(0, 0, content.body, {
       fontFamily: 'monospace', fontSize: '15px', color: '#c0c8d4',
       wordWrap: { width: panelW - PADDING * 2 }, lineSpacing: 6,
@@ -76,11 +66,9 @@ export class InfoDialog {
     const linksCount = content.links?.length ?? 0;
     const linksSectionH = linksCount > 0 ? 28 + linksCount * LINK_LINE_H + 8 : 0;
 
-    // title(28) + gap(18) + body + gap(16) + links + closeBar
     panelH = 28 + 18 + bodyH + 16 + linksSectionH + CLOSE_BAR_H + PADDING * 2;
     const panelY = (GAME_HEIGHT - panelH) / 2;
 
-    // Background
     const bg = this.scene.add.graphics();
     bg.fillStyle(0x0a0a2a, 0.95);
     bg.fillRoundedRect(panelX, panelY, panelW, panelH, 10);
@@ -90,14 +78,12 @@ export class InfoDialog {
 
     let curY = panelY + PADDING;
 
-    // Title
     const title = this.scene.add.text(GAME_WIDTH / 2, curY, content.title, {
       fontFamily: 'monospace', fontSize: '24px', color: '#00d4ff', fontStyle: 'bold',
     }).setOrigin(0.5, 0);
     this.container.add(title);
     curY += 28 + 18;
 
-    // Body
     const body = this.scene.add.text(panelX + PADDING, curY, content.body, {
       fontFamily: 'monospace', fontSize: '15px', color: '#c0c8d4',
       wordWrap: { width: panelW - PADDING * 2 }, lineSpacing: 6,
@@ -105,7 +91,6 @@ export class InfoDialog {
     this.container.add(body);
     curY += bodyH + 16;
 
-    // Links
     if (content.links && content.links.length > 0) {
       const linksHeader = this.scene.add.text(panelX + PADDING, curY, 'Learn more:', {
         fontFamily: 'monospace', fontSize: '13px', color: '#7799aa', fontStyle: 'bold',
@@ -129,7 +114,6 @@ export class InfoDialog {
       }
     }
 
-    // Close button — bottom center
     curY = panelY + panelH - CLOSE_BAR_H - 4;
     const closeText = this.scene.add.text(GAME_WIDTH / 2, curY, '[ESC]  Close', {
       fontFamily: 'monospace', fontSize: '14px', color: '#556677',
@@ -140,7 +124,6 @@ export class InfoDialog {
     closeText.on('pointerdown', () => this.close());
     this.container.add(closeText);
 
-    // [X] top-right
     const xBtn = this.scene.add.text(panelX + panelW - 18, panelY + 10, 'X', {
       fontFamily: 'monospace', fontSize: '16px', color: '#556677', fontStyle: 'bold',
     }).setOrigin(0.5, 0).setInteractive({ useHandCursor: true });
@@ -151,7 +134,6 @@ export class InfoDialog {
     this.container.add(xBtn);
   }
 
-  /* ---- keyboard ---- */
   private registerEscKey(): void {
     if (!this.scene.input.keyboard) return;
     this.escKey = this.scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ESC);
@@ -161,7 +143,6 @@ export class InfoDialog {
     this.scene.events.on('update', this.escHandler);
   }
 
-  /* ---- public ---- */
   close(): void {
     if (this.destroyed) return;
     this.destroyed = true;

--- a/src/ui/InfoDialog.ts
+++ b/src/ui/InfoDialog.ts
@@ -1,0 +1,182 @@
+import * as Phaser from 'phaser';
+import { GAME_WIDTH, GAME_HEIGHT } from '../config/gameConfig';
+
+export interface InfoDialogLink {
+  label: string;
+  url: string;
+}
+
+export interface InfoDialogContent {
+  id: string;
+  title: string;
+  body: string;
+  links?: InfoDialogLink[];
+}
+
+/**
+ * Reusable modal info dialog rendered as a Phaser overlay.
+ *
+ * Shows a title, word-wrapped body text, optional clickable links,
+ * and a close button. Closes on ESC or clicking [X].
+ */
+export class InfoDialog {
+  private scene: Phaser.Scene;
+  private container: Phaser.GameObjects.Container;
+  private escKey: Phaser.Input.Keyboard.Key | null = null;
+  private escHandler: (() => void) | null = null;
+  private onClose?: () => void;
+  private destroyed = false;
+
+  constructor(scene: Phaser.Scene, content: InfoDialogContent, onClose?: () => void) {
+    this.scene = scene;
+    this.onClose = onClose;
+
+    this.container = scene.add.container(0, 0);
+    this.container.setDepth(200);
+    this.container.setScrollFactor(0);
+    this.container.setAlpha(0);
+
+    this.buildOverlay();
+    this.buildPanel(content);
+    this.registerEscKey();
+
+    // Fade in
+    scene.tweens.add({ targets: this.container, alpha: 1, duration: 200 });
+  }
+
+  /* ---- overlay (dims the game) ---- */
+  private buildOverlay(): void {
+    const overlay = this.scene.add.rectangle(
+      GAME_WIDTH / 2, GAME_HEIGHT / 2,
+      GAME_WIDTH, GAME_HEIGHT,
+      0x000000, 0.65,
+    );
+    overlay.setInteractive(); // absorb clicks behind the panel
+    this.container.add(overlay);
+  }
+
+  /* ---- main panel ---- */
+  private buildPanel(content: InfoDialogContent): void {
+    const panelW = 620;
+    const panelX = (GAME_WIDTH - panelW) / 2;
+    let panelH = 0; // will be computed dynamically
+
+    const PADDING = 32;
+    const LINK_LINE_H = 30;
+    const CLOSE_BAR_H = 44;
+
+    // --- Measure body height first ---
+    const bodyMeasure = this.scene.add.text(0, 0, content.body, {
+      fontFamily: 'monospace', fontSize: '15px', color: '#c0c8d4',
+      wordWrap: { width: panelW - PADDING * 2 }, lineSpacing: 6,
+    });
+    const bodyH = bodyMeasure.height;
+    bodyMeasure.destroy();
+
+    const linksCount = content.links?.length ?? 0;
+    const linksSectionH = linksCount > 0 ? 28 + linksCount * LINK_LINE_H + 8 : 0;
+
+    // title(28) + gap(18) + body + gap(16) + links + closeBar
+    panelH = 28 + 18 + bodyH + 16 + linksSectionH + CLOSE_BAR_H + PADDING * 2;
+    const panelY = (GAME_HEIGHT - panelH) / 2;
+
+    // Background
+    const bg = this.scene.add.graphics();
+    bg.fillStyle(0x0a0a2a, 0.95);
+    bg.fillRoundedRect(panelX, panelY, panelW, panelH, 10);
+    bg.lineStyle(2, 0x00aaff, 0.7);
+    bg.strokeRoundedRect(panelX, panelY, panelW, panelH, 10);
+    this.container.add(bg);
+
+    let curY = panelY + PADDING;
+
+    // Title
+    const title = this.scene.add.text(GAME_WIDTH / 2, curY, content.title, {
+      fontFamily: 'monospace', fontSize: '24px', color: '#00d4ff', fontStyle: 'bold',
+    }).setOrigin(0.5, 0);
+    this.container.add(title);
+    curY += 28 + 18;
+
+    // Body
+    const body = this.scene.add.text(panelX + PADDING, curY, content.body, {
+      fontFamily: 'monospace', fontSize: '15px', color: '#c0c8d4',
+      wordWrap: { width: panelW - PADDING * 2 }, lineSpacing: 6,
+    });
+    this.container.add(body);
+    curY += bodyH + 16;
+
+    // Links
+    if (content.links && content.links.length > 0) {
+      const linksHeader = this.scene.add.text(panelX + PADDING, curY, 'Learn more:', {
+        fontFamily: 'monospace', fontSize: '13px', color: '#7799aa', fontStyle: 'bold',
+      });
+      this.container.add(linksHeader);
+      curY += 24;
+
+      for (const link of content.links) {
+        const linkText = this.scene.add.text(panelX + PADDING + 10, curY, `▸ ${link.label}`, {
+          fontFamily: 'monospace', fontSize: '14px', color: '#44aaff',
+        }).setInteractive({ useHandCursor: true });
+
+        linkText.on('pointerover', () => linkText.setColor('#88ddff'));
+        linkText.on('pointerout', () => linkText.setColor('#44aaff'));
+        linkText.on('pointerdown', () => {
+          window.open(link.url, '_blank');
+        });
+
+        this.container.add(linkText);
+        curY += LINK_LINE_H;
+      }
+    }
+
+    // Close button — bottom center
+    curY = panelY + panelH - CLOSE_BAR_H - 4;
+    const closeText = this.scene.add.text(GAME_WIDTH / 2, curY, '[ESC]  Close', {
+      fontFamily: 'monospace', fontSize: '14px', color: '#556677',
+    }).setOrigin(0.5, 0).setInteractive({ useHandCursor: true });
+
+    closeText.on('pointerover', () => closeText.setColor('#88aacc'));
+    closeText.on('pointerout', () => closeText.setColor('#556677'));
+    closeText.on('pointerdown', () => this.close());
+    this.container.add(closeText);
+
+    // [X] top-right
+    const xBtn = this.scene.add.text(panelX + panelW - 18, panelY + 10, 'X', {
+      fontFamily: 'monospace', fontSize: '16px', color: '#556677', fontStyle: 'bold',
+    }).setOrigin(0.5, 0).setInteractive({ useHandCursor: true });
+
+    xBtn.on('pointerover', () => xBtn.setColor('#ff6666'));
+    xBtn.on('pointerout', () => xBtn.setColor('#556677'));
+    xBtn.on('pointerdown', () => this.close());
+    this.container.add(xBtn);
+  }
+
+  /* ---- keyboard ---- */
+  private registerEscKey(): void {
+    if (!this.scene.input.keyboard) return;
+    this.escKey = this.scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ESC);
+    this.escHandler = () => {
+      if (this.escKey?.isDown) this.close();
+    };
+    this.scene.events.on('update', this.escHandler);
+  }
+
+  /* ---- public ---- */
+  close(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    if (this.escHandler) {
+      this.scene.events.off('update', this.escHandler);
+    }
+    if (this.escKey) {
+      this.escKey.destroy();
+    }
+    this.scene.tweens.add({
+      targets: this.container, alpha: 0, duration: 150,
+      onComplete: () => {
+        this.container.destroy();
+        this.onClose?.();
+      },
+    });
+  }
+}

--- a/src/ui/InfoIcon.ts
+++ b/src/ui/InfoIcon.ts
@@ -2,11 +2,9 @@ import * as Phaser from 'phaser';
 
 export class InfoIcon {
   private container: Phaser.GameObjects.Container;
-  private scene: Phaser.Scene;
   private pulseTween: Phaser.Tweens.Tween;
 
   constructor(scene: Phaser.Scene, x: number, y: number, onClick: () => void) {
-    this.scene = scene;
     this.container = scene.add.container(x, y);
     this.container.setDepth(55);
     this.container.setScrollFactor(0);

--- a/src/ui/InfoIcon.ts
+++ b/src/ui/InfoIcon.ts
@@ -1,0 +1,58 @@
+import * as Phaser from 'phaser';
+
+/**
+ * Small clickable "i" icon that pulses gently.
+ * Click or press I to trigger the callback.
+ */
+export class InfoIcon {
+  private container: Phaser.GameObjects.Container;
+  private scene: Phaser.Scene;
+  private pulseTween: Phaser.Tweens.Tween;
+
+  constructor(scene: Phaser.Scene, x: number, y: number, onClick: () => void) {
+    this.scene = scene;
+    this.container = scene.add.container(x, y);
+    this.container.setDepth(55);
+    this.container.setScrollFactor(0);
+
+    // Circle background
+    const circle = scene.add.graphics();
+    circle.fillStyle(0x0a0a2a, 0.85);
+    circle.fillCircle(0, 0, 14);
+    circle.lineStyle(1.5, 0x00aaff, 0.7);
+    circle.strokeCircle(0, 0, 14);
+    this.container.add(circle);
+
+    // "i" letter
+    const label = scene.add.text(0, 0, 'i', {
+      fontFamily: 'monospace', fontSize: '16px',
+      color: '#00aaff', fontStyle: 'bold',
+    }).setOrigin(0.5);
+    this.container.add(label);
+
+    // Hit area
+    const hitArea = scene.add.rectangle(0, 0, 32, 32)
+      .setInteractive({ useHandCursor: true })
+      .setAlpha(0.001);
+
+    hitArea.on('pointerover', () => label.setColor('#88ddff'));
+    hitArea.on('pointerout', () => label.setColor('#00aaff'));
+    hitArea.on('pointerdown', () => onClick());
+    this.container.add(hitArea);
+
+    // Subtle pulse
+    this.pulseTween = scene.tweens.add({
+      targets: this.container, alpha: { from: 1, to: 0.55 },
+      duration: 1400, yoyo: true, repeat: -1, ease: 'Sine.easeInOut',
+    });
+  }
+
+  setVisible(visible: boolean): void {
+    this.container.setVisible(visible);
+  }
+
+  destroy(): void {
+    this.pulseTween.destroy();
+    this.container.destroy();
+  }
+}

--- a/src/ui/InfoIcon.ts
+++ b/src/ui/InfoIcon.ts
@@ -1,9 +1,5 @@
 import * as Phaser from 'phaser';
 
-/**
- * Small clickable "i" icon that pulses gently.
- * Click or press I to trigger the callback.
- */
 export class InfoIcon {
   private container: Phaser.GameObjects.Container;
   private scene: Phaser.Scene;
@@ -15,7 +11,6 @@ export class InfoIcon {
     this.container.setDepth(55);
     this.container.setScrollFactor(0);
 
-    // Circle background
     const circle = scene.add.graphics();
     circle.fillStyle(0x0a0a2a, 0.85);
     circle.fillCircle(0, 0, 14);
@@ -23,14 +18,12 @@ export class InfoIcon {
     circle.strokeCircle(0, 0, 14);
     this.container.add(circle);
 
-    // "i" letter
     const label = scene.add.text(0, 0, 'i', {
       fontFamily: 'monospace', fontSize: '16px',
       color: '#00aaff', fontStyle: 'bold',
     }).setOrigin(0.5);
     this.container.add(label);
 
-    // Hit area
     const hitArea = scene.add.rectangle(0, 0, 32, 32)
       .setInteractive({ useHandCursor: true })
       .setAlpha(0.001);
@@ -40,7 +33,6 @@ export class InfoIcon {
     hitArea.on('pointerdown', () => onClick());
     this.container.add(hitArea);
 
-    // Subtle pulse
     this.pulseTween = scene.tweens.add({
       targets: this.container, alpha: { from: 1, to: 0.55 },
       duration: 1400, yoyo: true, repeat: -1, ease: 'Sine.easeInOut',


### PR DESCRIPTION
Introduce a reusable info dialog system for surfacing educational
content during gameplay. The first dialog explains Gregor Hohpe's
"Architecture Elevator" concept with links to his book and blog.

- InfoDialogManager: tracks seen dialogs in localStorage (separate
  from game save so it persists across resets)
- InfoDialog: modal overlay with title, word-wrapped body, clickable
  links, and ESC/X close — styled to match the game aesthetic
- InfoIcon: pulsing "i" button shown after first viewing; click or
  press I to reopen the dialog
- First ride on the hub elevator auto-shows the dialog; subsequent
  visits show only the icon

https://claude.ai/code/session_01TCGJKYKqCoivCbDmL2e5SB