### PR TITLE
Add multiple-choice quiz system for info points

### DIFF
--- a/src/config/audioConfig.ts
+++ b/src/config/audioConfig.ts
@@ -17,9 +17,13 @@ export const SCENE_MUSIC: Record<string, string> = {
 
 /** EventBus event name → Phaser SFX audio key. */
 export const SFX_EVENTS: Record<string, string> = {
-  'sfx:jump':       'jump',
-  'sfx:footstep_a': 'footstep_a',
-  'sfx:footstep_b': 'footstep_b',
+  'sfx:jump':         'jump',
+  'sfx:footstep_a':   'footstep_a',
+  'sfx:footstep_b':   'footstep_b',
+  'sfx:quiz_correct': 'quiz_correct',
+  'sfx:quiz_wrong':   'quiz_wrong',
+  'sfx:quiz_success': 'quiz_success',
+  'sfx:quiz_fail':    'quiz_fail',
 };
 
 /** Default volume for background music (0–1). */

--- a/src/config/infoContent.ts
+++ b/src/config/infoContent.ts
@@ -1,0 +1,158 @@
+import { InfoDialogContent } from '../ui/InfoDialog';
+import { FLOORS, FloorId } from './gameConfig';
+
+/**
+ * Centralized info point content for all floors.
+ *
+ * Each entry includes the educational body text, optional external links,
+ * and optional extended "deep dive" content that hard quiz questions reference.
+ */
+
+export interface InfoPointDef {
+  content: InfoDialogContent;
+  floorId: FloorId;
+}
+
+export const INFO_POINTS: Record<string, InfoPointDef> = {
+  'architecture-elevator': {
+    floorId: FLOORS.LOBBY,
+    content: {
+      id: 'architecture-elevator',
+      title: 'The Architecture Elevator',
+      body:
+        'Gregor Hohpe coined the term "Architecture Elevator" to describe ' +
+        'how software architects must ride between the penthouse \u2014 where ' +
+        'business strategy and organizational decisions are made \u2014 and the ' +
+        'engine room \u2014 where the technology is built and operated.\n\n' +
+        'An effective architect doesn\'t just live on one floor. They translate ' +
+        'between executives who speak in business outcomes and engineers who ' +
+        'speak in systems and code. The elevator ride connects these worlds.\n\n' +
+        'In this game you literally ride the elevator between floors \u2014 each ' +
+        'one representing a different team and set of architectural challenges.',
+      links: [
+        { label: 'The Software Architect Elevator (Book)', url: 'https://architectelevator.com/book/' },
+        { label: 'Gregor Hohpe\u2019s Blog', url: 'https://architectelevator.com/' },
+        { label: 'Architecture Elevator Article', url: 'https://martinfowler.com/articles/architect-elevator.html' },
+      ],
+      extendedInfo: {
+        title: 'Deep Dive: The Architecture Elevator',
+        body:
+          'The Architecture Elevator metaphor goes deeper than just "talking to ' +
+          'different people". Hohpe identifies several key patterns:\n\n' +
+          'Riding the elevator means actively translating context. When you go up, ' +
+          'you translate technical constraints into business impact. When you go ' +
+          'down, you translate business goals into technical direction.\n\n' +
+          'The "penthouse" isn\'t just the C-suite \u2014 it represents strategic ' +
+          'thinking about markets, competitive advantage, and organizational ' +
+          'transformation. The "engine room" isn\'t just coding \u2014 it\'s about ' +
+          'operational reality, technical debt, and system constraints.\n\n' +
+          'Architects who only stay in the penthouse become "ivory tower" architects ' +
+          'whose designs don\'t work in practice. Those who never leave the engine ' +
+          'room miss the strategic context that should guide technical decisions.\n\n' +
+          'A key insight: the elevator ride itself is where the most value is ' +
+          'created. The act of connecting floors \u2014 of ensuring that strategy ' +
+          'and implementation are aligned \u2014 is the architect\'s unique contribution.',
+      },
+    },
+  },
+
+  'platform-engineering': {
+    floorId: FLOORS.PLATFORM_TEAM,
+    content: {
+      id: 'platform-engineering',
+      title: 'Platform Engineering',
+      body:
+        'Platform Engineering is the discipline of building and maintaining ' +
+        'an Internal Developer Platform (IDP) \u2014 a self-service layer of ' +
+        'tools, services, and workflows that enables development teams to ' +
+        'deliver software faster and more reliably.\n\n' +
+        'Instead of every team building their own CI/CD pipelines, monitoring ' +
+        'stacks, and infrastructure provisioning, a Platform Team creates ' +
+        'golden paths \u2014 pre-configured, opinionated workflows that encode ' +
+        'best practices while still allowing flexibility.\n\n' +
+        'The key principle is "You build it, you run it" combined with ' +
+        '"We make running it easy." The platform reduces cognitive load on ' +
+        'development teams so they can focus on business logic rather than ' +
+        'infrastructure plumbing.',
+      links: [
+        { label: 'Team Topologies (Book)', url: 'https://teamtopologies.com/' },
+        { label: 'Platform Engineering on the CNCF', url: 'https://tag-app-delivery.cncf.io/whitepapers/platforms/' },
+        { label: 'What is Platform Engineering?', url: 'https://platformengineering.org/blog/what-is-platform-engineering' },
+      ],
+      extendedInfo: {
+        title: 'Deep Dive: Platform Engineering',
+        body:
+          'Platform Engineering draws heavily from Team Topologies by Matthew ' +
+          'Skelton and Manuel Pais. The book identifies four fundamental team ' +
+          'types: Stream-aligned, Enabling, Complicated Subsystem, and Platform.\n\n' +
+          'A Platform Team\'s primary interaction mode is "X-as-a-Service" \u2014 they ' +
+          'provide capabilities that stream-aligned teams consume with minimal ' +
+          'coordination. This reduces the cognitive load on delivery teams.\n\n' +
+          'The "Thinnest Viable Platform" (TVP) concept is crucial: start with ' +
+          'the smallest platform that provides value. This might be as simple as ' +
+          'a wiki page with best-practice documentation, evolving toward self-service ' +
+          'APIs and developer portals as needs grow.\n\n' +
+          'Key metrics for platform success include: developer onboarding time, ' +
+          'time to first deploy, change failure rate, and developer satisfaction ' +
+          '(often measured via Developer Experience surveys). A good platform is ' +
+          'one that developers voluntarily choose to use.\n\n' +
+          'Anti-patterns include: mandating platform use without providing value, ' +
+          'building too much too early, and treating the platform as a pure ' +
+          'infrastructure concern rather than a product with internal customers.',
+      },
+    },
+  },
+
+  'cloud-architecture': {
+    floorId: FLOORS.CLOUD_TEAM,
+    content: {
+      id: 'cloud-architecture',
+      title: 'Cloud-Native Architecture',
+      body:
+        'Cloud-native architecture is an approach to building and running ' +
+        'applications that fully exploits the advantages of cloud computing: ' +
+        'on-demand resources, elasticity, and managed services.\n\n' +
+        'The Cloud Native Computing Foundation (CNCF) defines cloud-native ' +
+        'technologies as those that empower organizations to build scalable ' +
+        'applications in modern environments like public, private, and hybrid ' +
+        'clouds using containers, service meshes, microservices, immutable ' +
+        'infrastructure, and declarative APIs.\n\n' +
+        'A key mindset shift is "design for failure." In the cloud, individual ' +
+        'components will fail \u2014 the architecture must ensure the system as ' +
+        'a whole remains available. This leads to patterns like circuit breakers, ' +
+        'retry with backoff, bulkheads, and graceful degradation.',
+      links: [
+        { label: 'CNCF Cloud Native Definition', url: 'https://github.com/cncf/toc/blob/main/DEFINITION.md' },
+        { label: 'The Twelve-Factor App', url: 'https://12factor.net/' },
+        { label: 'Cloud Design Patterns (Microsoft)', url: 'https://learn.microsoft.com/en-us/azure/architecture/patterns/' },
+      ],
+      extendedInfo: {
+        title: 'Deep Dive: Cloud-Native Architecture',
+        body:
+          'The Twelve-Factor App methodology, created by Heroku co-founder Adam ' +
+          'Wiggins, provides foundational principles for cloud-native apps:\n\n' +
+          '1. Codebase: One codebase tracked in VCS, many deploys\n' +
+          '2. Dependencies: Explicitly declare and isolate dependencies\n' +
+          '3. Config: Store config in the environment\n' +
+          '4. Backing services: Treat them as attached resources\n' +
+          '5. Build, release, run: Strictly separate build and run stages\n' +
+          '6. Processes: Execute as stateless processes\n' +
+          '7. Port binding: Export services via port binding\n' +
+          '8. Concurrency: Scale out via the process model\n' +
+          '9. Disposability: Maximize robustness with fast startup and graceful shutdown\n' +
+          '10. Dev/prod parity: Keep development and production as similar as possible\n' +
+          '11. Logs: Treat logs as event streams\n' +
+          '12. Admin processes: Run admin tasks as one-off processes\n\n' +
+          'Beyond twelve-factor, cloud-native architecture embraces the "cattle ' +
+          'not pets" philosophy: servers and containers are disposable and ' +
+          'replaceable (cattle), not unique and hand-maintained (pets). This ' +
+          'enables immutable infrastructure where updates mean replacing ' +
+          'instances rather than patching them in place.\n\n' +
+          'The circuit breaker pattern (popularized by Michael Nygard in "Release ' +
+          'It!") prevents cascading failures: when a downstream service fails ' +
+          'repeatedly, the circuit "opens" and requests fail fast instead of ' +
+          'timing out, giving the failing service time to recover.',
+      },
+    },
+  },
+};

--- a/src/config/quizData.ts
+++ b/src/config/quizData.ts
@@ -1,0 +1,419 @@
+/**
+ * Quiz question pools for each info point.
+ *
+ * Each quiz attempt draws 1 easy + 1 medium + 1 hard = 3 questions.
+ * Scoring: 2/3 pass (3 AU), 3/3 perfect (5 AU), 0-1 fail (0 AU).
+ */
+
+export type QuizDifficulty = 'easy' | 'medium' | 'hard';
+
+export interface QuizQuestion {
+  id: string;
+  difficulty: QuizDifficulty;
+  question: string;
+  choices: string[];       // always 4
+  correctIndex: number;    // 0-3
+  explanation: string;
+}
+
+export interface QuizDefinition {
+  infoId: string;
+  questions: QuizQuestion[];
+}
+
+/** AU awarded per quiz result. */
+export const QUIZ_REWARDS = {
+  pass: 3,       // 2 out of 3 correct
+  perfect: 5,    // 3 out of 3 correct
+  fail: 0,       // 0-1 correct
+} as const;
+
+/** Cooldown between quiz retry attempts in milliseconds. */
+export const QUIZ_COOLDOWN_MS = 30_000;
+
+/** Number of questions per quiz attempt. */
+export const QUIZ_QUESTION_COUNT = 3;
+
+export const QUIZ_DATA: Record<string, QuizDefinition> = {
+  /* --------------------------------------------------------- */
+  /*  Architecture Elevator                                     */
+  /* --------------------------------------------------------- */
+  'architecture-elevator': {
+    infoId: 'architecture-elevator',
+    questions: [
+      // ---- EASY ----
+      {
+        id: 'ae-e1',
+        difficulty: 'easy',
+        question: 'Who coined the term "Architecture Elevator"?',
+        choices: ['Martin Fowler', 'Gregor Hohpe', 'Sam Newman', 'Kent Beck'],
+        correctIndex: 1,
+        explanation: 'Gregor Hohpe coined the term to describe how architects ride between business strategy and technical implementation.',
+      },
+      {
+        id: 'ae-e2',
+        difficulty: 'easy',
+        question: 'What does the "penthouse" represent in the Architecture Elevator metaphor?',
+        choices: [
+          'The testing environment',
+          'The production servers',
+          'Business strategy and organizational decisions',
+          'The development team\'s workspace',
+        ],
+        correctIndex: 2,
+        explanation: 'The penthouse represents the strategic level where business decisions are made.',
+      },
+      {
+        id: 'ae-e3',
+        difficulty: 'easy',
+        question: 'What does the "engine room" represent in the Architecture Elevator?',
+        choices: [
+          'The HR department',
+          'Where technology is built and operated',
+          'The project management office',
+          'The executive boardroom',
+        ],
+        correctIndex: 1,
+        explanation: 'The engine room is where the technology is built and operated — the hands-on technical level.',
+      },
+      // ---- MEDIUM ----
+      {
+        id: 'ae-m1',
+        difficulty: 'medium',
+        question: 'Why must an effective architect "ride the elevator" between floors?',
+        choices: [
+          'To get exercise during the workday',
+          'To translate between business outcomes and technical systems',
+          'To avoid being in too many meetings',
+          'To monitor network infrastructure on each floor',
+        ],
+        correctIndex: 1,
+        explanation: 'Architects translate between executives who speak in business outcomes and engineers who speak in systems and code.',
+      },
+      {
+        id: 'ae-m2',
+        difficulty: 'medium',
+        question: 'What happens when an architect only stays in the "penthouse"?',
+        choices: [
+          'They become a more effective leader',
+          'They gain better technical skills',
+          'They become an "ivory tower" architect whose designs don\'t work in practice',
+          'They save time by avoiding implementation details',
+        ],
+        correctIndex: 2,
+        explanation: 'Architects who never leave the penthouse create impractical designs disconnected from operational reality.',
+      },
+      {
+        id: 'ae-m3',
+        difficulty: 'medium',
+        question: 'What is the unique value that an architect creates according to the elevator metaphor?',
+        choices: [
+          'Writing the most code',
+          'Connecting floors — ensuring strategy and implementation are aligned',
+          'Managing the largest team',
+          'Choosing the newest technologies',
+        ],
+        correctIndex: 1,
+        explanation: 'The elevator ride itself — connecting strategy and implementation — is where architects create the most value.',
+      },
+      // ---- HARD ----
+      {
+        id: 'ae-h1',
+        difficulty: 'hard',
+        question: 'According to the deep dive, what does "riding up" the elevator specifically involve?',
+        choices: [
+          'Reporting status updates to management',
+          'Translating technical constraints into business impact',
+          'Escalating bugs to the operations team',
+          'Requesting larger budgets for infrastructure',
+        ],
+        correctIndex: 1,
+        explanation: 'Going up means translating technical constraints into business impact — making technology relevant to strategy.',
+      },
+      {
+        id: 'ae-h2',
+        difficulty: 'hard',
+        question: 'What risk faces an architect who never leaves the "engine room"?',
+        choices: [
+          'They get promoted too quickly',
+          'They become too popular with developers',
+          'They miss the strategic context that should guide technical decisions',
+          'They run out of technical challenges',
+        ],
+        correctIndex: 2,
+        explanation: 'Staying only in the engine room means missing strategic context, leading to technically sound but strategically misaligned decisions.',
+      },
+      {
+        id: 'ae-h3',
+        difficulty: 'hard',
+        question: 'The penthouse represents more than just the C-suite. What broader concept does it encompass?',
+        choices: [
+          'Only the CEO\'s office',
+          'Strategic thinking about markets, competitive advantage, and organizational transformation',
+          'The cloud infrastructure control panel',
+          'The software testing pyramid',
+        ],
+        correctIndex: 1,
+        explanation: 'The penthouse encompasses strategic thinking about markets, competitive advantage, and organizational transformation — not just executives.',
+      },
+    ],
+  },
+
+  /* --------------------------------------------------------- */
+  /*  Platform Engineering                                      */
+  /* --------------------------------------------------------- */
+  'platform-engineering': {
+    infoId: 'platform-engineering',
+    questions: [
+      // ---- EASY ----
+      {
+        id: 'pe-e1',
+        difficulty: 'easy',
+        question: 'What does IDP stand for in the context of Platform Engineering?',
+        choices: [
+          'Internet Data Protocol',
+          'Internal Developer Platform',
+          'Integrated Deployment Pipeline',
+          'Infrastructure Design Pattern',
+        ],
+        correctIndex: 1,
+        explanation: 'IDP stands for Internal Developer Platform — a self-service layer for development teams.',
+      },
+      {
+        id: 'pe-e2',
+        difficulty: 'easy',
+        question: 'What are "golden paths" in platform engineering?',
+        choices: [
+          'Physical pathways in the office',
+          'Pre-configured, opinionated workflows that encode best practices',
+          'Premium-tier cloud service plans',
+          'Network routing protocols',
+        ],
+        correctIndex: 1,
+        explanation: 'Golden paths are pre-configured workflows that encode best practices while still allowing flexibility.',
+      },
+      {
+        id: 'pe-e3',
+        difficulty: 'easy',
+        question: 'What key principle does a platform team follow regarding development teams?',
+        choices: [
+          'All code must be reviewed by the platform team',
+          'Development teams should never touch infrastructure',
+          'Reduce cognitive load so teams focus on business logic',
+          'Every team must use the same programming language',
+        ],
+        correctIndex: 2,
+        explanation: 'The platform reduces cognitive load on development teams so they can focus on business logic rather than infrastructure plumbing.',
+      },
+      // ---- MEDIUM ----
+      {
+        id: 'pe-m1',
+        difficulty: 'medium',
+        question: 'Instead of every team building their own CI/CD pipelines, what does a platform team provide?',
+        choices: [
+          'A mandate that no CI/CD is needed',
+          'Pre-configured, reusable golden path workflows',
+          'A single monolithic deployment pipeline for all teams',
+          'Outsourced DevOps consulting',
+        ],
+        correctIndex: 1,
+        explanation: 'Platform teams create golden paths — reusable, pre-configured workflows — so individual teams don\'t reinvent the wheel.',
+      },
+      {
+        id: 'pe-m2',
+        difficulty: 'medium',
+        question: 'What is the combined philosophy behind platform engineering?',
+        choices: [
+          '"Move fast and break things"',
+          '"You build it, you run it" combined with "We make running it easy"',
+          '"Don\'t repeat yourself" and "Keep it simple"',
+          '"Fail fast" and "Ship often"',
+        ],
+        correctIndex: 1,
+        explanation: 'Platform engineering combines ownership ("you build it, you run it") with support ("we make running it easy").',
+      },
+      {
+        id: 'pe-m3',
+        difficulty: 'medium',
+        question: 'What is an anti-pattern in platform engineering?',
+        choices: [
+          'Making the platform optional',
+          'Starting with a small platform',
+          'Mandating platform use without providing value',
+          'Measuring developer satisfaction',
+        ],
+        correctIndex: 2,
+        explanation: 'Forcing teams to use a platform that doesn\'t provide clear value is a common anti-pattern that breeds resentment.',
+      },
+      // ---- HARD ----
+      {
+        id: 'pe-h1',
+        difficulty: 'hard',
+        question: 'According to Team Topologies, what is a Platform Team\'s primary interaction mode?',
+        choices: [
+          'Collaboration',
+          'Facilitation',
+          'X-as-a-Service',
+          'Pair programming',
+        ],
+        correctIndex: 2,
+        explanation: 'Platform Teams provide capabilities via "X-as-a-Service" — teams consume with minimal coordination.',
+      },
+      {
+        id: 'pe-h2',
+        difficulty: 'hard',
+        question: 'What is the "Thinnest Viable Platform" (TVP) concept?',
+        choices: [
+          'Using the cheapest possible cloud provider',
+          'Starting with the smallest platform that provides value, possibly just documentation',
+          'Removing all features except deployment',
+          'Running on the minimum number of servers',
+        ],
+        correctIndex: 1,
+        explanation: 'TVP means starting small — even a wiki page with best practices — and evolving toward self-service APIs as needs grow.',
+      },
+      {
+        id: 'pe-h3',
+        difficulty: 'hard',
+        question: 'Which of these is a key metric for platform success according to the deep dive?',
+        choices: [
+          'Lines of code written per day',
+          'Number of microservices deployed',
+          'Developer onboarding time and developer satisfaction',
+          'Total number of cloud resources provisioned',
+        ],
+        correctIndex: 2,
+        explanation: 'Key metrics include onboarding time, time to first deploy, change failure rate, and developer satisfaction surveys.',
+      },
+    ],
+  },
+
+  /* --------------------------------------------------------- */
+  /*  Cloud-Native Architecture                                 */
+  /* --------------------------------------------------------- */
+  'cloud-architecture': {
+    infoId: 'cloud-architecture',
+    questions: [
+      // ---- EASY ----
+      {
+        id: 'ca-e1',
+        difficulty: 'easy',
+        question: 'What organization defines cloud-native technologies?',
+        choices: [
+          'IEEE',
+          'W3C',
+          'Cloud Native Computing Foundation (CNCF)',
+          'ISO',
+        ],
+        correctIndex: 2,
+        explanation: 'The CNCF (Cloud Native Computing Foundation) defines cloud-native technologies and maintains the cloud-native landscape.',
+      },
+      {
+        id: 'ca-e2',
+        difficulty: 'easy',
+        question: 'What is a key mindset shift in cloud-native architecture?',
+        choices: [
+          'Design for zero bugs',
+          'Design for failure',
+          'Design for maximum speed',
+          'Design for lowest cost',
+        ],
+        correctIndex: 1,
+        explanation: '"Design for failure" acknowledges that individual components will fail, so the system must remain available as a whole.',
+      },
+      {
+        id: 'ca-e3',
+        difficulty: 'easy',
+        question: 'Which of these is NOT mentioned as a cloud-native technology?',
+        choices: [
+          'Containers',
+          'Microservices',
+          'Blockchain',
+          'Service meshes',
+        ],
+        correctIndex: 2,
+        explanation: 'Containers, microservices, service meshes, and declarative APIs are all mentioned. Blockchain is not a cloud-native technology.',
+      },
+      // ---- MEDIUM ----
+      {
+        id: 'ca-m1',
+        difficulty: 'medium',
+        question: 'What does the circuit breaker pattern prevent?',
+        choices: [
+          'Unauthorized access to services',
+          'Data corruption in databases',
+          'Cascading failures across services',
+          'Excessive memory usage',
+        ],
+        correctIndex: 2,
+        explanation: 'Circuit breakers prevent cascading failures by failing fast when a downstream service is unresponsive, giving it time to recover.',
+      },
+      {
+        id: 'ca-m2',
+        difficulty: 'medium',
+        question: 'Which pattern involves requests failing fast instead of timing out when a service is down?',
+        choices: [
+          'Bulkhead pattern',
+          'Circuit breaker pattern',
+          'Retry pattern',
+          'Sidecar pattern',
+        ],
+        correctIndex: 1,
+        explanation: 'When a circuit breaker "opens," requests fail immediately instead of waiting for a timeout, preventing resource exhaustion.',
+      },
+      {
+        id: 'ca-m3',
+        difficulty: 'medium',
+        question: 'What kind of infrastructure does cloud-native architecture favor?',
+        choices: [
+          'Mutable infrastructure with in-place updates',
+          'On-premises hardware only',
+          'Immutable infrastructure with declarative APIs',
+          'Manual server provisioning',
+        ],
+        correctIndex: 2,
+        explanation: 'Cloud-native favors immutable infrastructure and declarative APIs for consistent, reproducible environments.',
+      },
+      // ---- HARD ----
+      {
+        id: 'ca-h1',
+        difficulty: 'hard',
+        question: 'According to the Twelve-Factor App, how should configuration be stored?',
+        choices: [
+          'In XML files bundled with the application',
+          'In the environment (environment variables)',
+          'Hardcoded in the source code',
+          'In a shared database table',
+        ],
+        correctIndex: 1,
+        explanation: 'Factor 3 says "Store config in the environment" — config that varies between deploys should be in env vars, not code.',
+      },
+      {
+        id: 'ca-h2',
+        difficulty: 'hard',
+        question: 'What does "cattle not pets" mean in cloud-native philosophy?',
+        choices: [
+          'Use animal-themed server naming conventions',
+          'Servers are disposable and replaceable, not unique and hand-maintained',
+          'Monitor servers like you would livestock',
+          'Deploy applications in herds of containers',
+        ],
+        correctIndex: 1,
+        explanation: '"Cattle not pets" means servers/containers are disposable and interchangeable, enabling immutable infrastructure.',
+      },
+      {
+        id: 'ca-h3',
+        difficulty: 'hard',
+        question: 'Who wrote "Release It!" which popularized the circuit breaker pattern for software?',
+        choices: [
+          'Martin Fowler',
+          'Eric Evans',
+          'Michael Nygard',
+          'Robert C. Martin',
+        ],
+        correctIndex: 2,
+        explanation: 'Michael Nygard popularized the circuit breaker pattern in his book "Release It!" about building resilient software.',
+      },
+    ],
+  },
+};

--- a/src/config/quizData.ts
+++ b/src/config/quizData.ts
@@ -34,6 +34,9 @@ export const QUIZ_COOLDOWN_MS = 30_000;
 /** Number of questions per quiz attempt. */
 export const QUIZ_QUESTION_COUNT = 3;
 
+/** Minimum correct answers required to pass a quiz. */
+export const QUIZ_PASS_THRESHOLD = 2;
+
 export const QUIZ_DATA: Record<string, QuizDefinition> = {
   /* --------------------------------------------------------- */
   /*  Architecture Elevator                                     */

--- a/src/scenes/Floor1Scene.ts
+++ b/src/scenes/Floor1Scene.ts
@@ -62,6 +62,10 @@ export class Floor1Scene extends LevelScene {
         { x: 700, y: T3 - 40 },
         { x: 1050, y: T3 - 40 },
       ],
+
+      infoPoints: [
+        { x: 300, y: G, contentId: 'platform-engineering' },
+      ],
     };
   }
 }

--- a/src/scenes/Floor2Scene.ts
+++ b/src/scenes/Floor2Scene.ts
@@ -74,6 +74,10 @@ export class Floor2Scene extends LevelScene {
         { x: 450, y: T4 - 40 },
         { x: 900, y: T4 - 40 },
       ],
+
+      infoPoints: [
+        { x: 900, y: G, contentId: 'cloud-architecture' },
+      ],
     };
   }
 }

--- a/src/scenes/HubScene.ts
+++ b/src/scenes/HubScene.ts
@@ -1,36 +1,20 @@
 import * as Phaser from 'phaser';
 import { GAME_WIDTH, GAME_HEIGHT, FLOORS, TILE_SIZE, COLORS, FloorId } from '../config/gameConfig';
 import { LEVEL_DATA } from '../config/levelData';
+import { INFO_POINTS } from '../config/infoContent';
+import { QUIZ_DATA } from '../config/quizData';
 import { Player } from '../entities/Player';
 import { Elevator } from '../entities/Elevator';
 import { HUD } from '../ui/HUD';
 import { ElevatorButtons } from '../ui/ElevatorButtons';
 import { ProgressionSystem } from '../systems/ProgressionSystem';
-import { InfoDialog, InfoDialogContent } from '../ui/InfoDialog';
+import { InfoDialog } from '../ui/InfoDialog';
+import { QuizDialog } from '../ui/QuizDialog';
 import { InfoIcon } from '../ui/InfoIcon';
 import { hasBeenSeen, markSeen } from '../systems/InfoDialogManager';
+import { isQuizPassed, canRetryQuiz, getCooldownRemaining } from '../systems/QuizManager';
 
 const ELEVATOR_INFO_ID = 'architecture-elevator';
-
-const ELEVATOR_INFO_CONTENT: InfoDialogContent = {
-  id: ELEVATOR_INFO_ID,
-  title: 'The Architecture Elevator',
-  body:
-    'Gregor Hohpe coined the term "Architecture Elevator" to describe ' +
-    'how software architects must ride between the penthouse \u2014 where ' +
-    'business strategy and organizational decisions are made \u2014 and the ' +
-    'engine room \u2014 where the technology is built and operated.\n\n' +
-    'An effective architect doesn\'t just live on one floor. They translate ' +
-    'between executives who speak in business outcomes and engineers who ' +
-    'speak in systems and code. The elevator ride connects these worlds.\n\n' +
-    'In this game you literally ride the elevator between floors \u2014 each ' +
-    'one representing a different team and set of architectural challenges.',
-  links: [
-    { label: 'The Software Architect Elevator (Book)', url: 'https://architectelevator.com/book/' },
-    { label: 'Gregor Hohpe\u2019s Blog', url: 'https://architectelevator.com/' },
-    { label: 'Architecture Elevator Article', url: 'https://martinfowler.com/articles/architect-elevator.html' },
-  ],
-};
 
 /**
  * Hub / Elevator-shaft scene — Impossible-Mission style.
@@ -56,6 +40,7 @@ export class HubScene extends Phaser.Scene {
   private showElevatorInfoOnFirstRide = false;
   private dialogOpen = false;
   private activeDialog?: InfoDialog;
+  private activeQuiz?: QuizDialog;
   private infoIcon?: InfoIcon;
 
   /** The shaft is wider in the 128-px world. */
@@ -81,6 +66,7 @@ export class HubScene extends Phaser.Scene {
   create(): void {
     this.isTransitioning = false;
     this.playerOnElevator = false;
+    this.dialogOpen = false;
     this.cameras.main.setBackgroundColor(COLORS.background);
 
     const worldHeight = 1600;
@@ -168,7 +154,7 @@ export class HubScene extends Phaser.Scene {
       // Floor opening label (right side, next to shaft)
       if (fId !== FLOORS.LOBBY) {
         const arrowColor = unlocked ? '#00ff88' : '#ff4444';
-        const label = unlocked ? '→ ENTER' : `LOCKED: ${this.progression.getAUNeededForFloor(fId)} AU`;
+        const label = unlocked ? '\u2192 ENTER' : `LOCKED: ${this.progression.getAUNeededForFloor(fId)} AU`;
         this.add.text(cx + sw / 2 + 20, y - 50, label, {
           fontFamily: 'monospace', fontSize: '14px', color: arrowColor,
         }).setDepth(5);
@@ -207,7 +193,7 @@ export class HubScene extends Phaser.Scene {
     this.hud = new HUD(this, this.progression);
 
     // Instruction text (scroll-fixed)
-    this.add.text(GAME_WIDTH / 2, GAME_HEIGHT - 30, '↑↓  Ride Elevator  |  ← →  Walk  |  SPACE  Flip', {
+    this.add.text(GAME_WIDTH / 2, GAME_HEIGHT - 30, '\u2191\u2193  Ride Elevator  |  \u2190 \u2192  Walk  |  SPACE  Flip', {
       fontFamily: 'monospace', fontSize: '13px', color: '#556677',
     }).setOrigin(0.5).setDepth(50).setScrollFactor(0);
 
@@ -243,12 +229,12 @@ export class HubScene extends Phaser.Scene {
 
     if (this.playerOnElevator && this.showElevatorInfoOnFirstRide) {
       this.showElevatorInfoOnFirstRide = false;
-      this.openElevatorInfoDialog();
+      this.openInfoDialog(ELEVATOR_INFO_ID);
       return;
     }
 
     if (infoPressed && this.infoIcon && !this.dialogOpen) {
-      this.openElevatorInfoDialog();
+      this.openInfoDialog(ELEVATOR_INFO_ID);
       return;
     }
 
@@ -325,25 +311,70 @@ export class HubScene extends Phaser.Scene {
     }
   }
 
-  private openElevatorInfoDialog(): void {
+  private openInfoDialog(infoId: string): void {
     if (this.dialogOpen) return;
     this.dialogOpen = true;
 
-    this.activeDialog = new InfoDialog(this, ELEVATOR_INFO_CONTENT, () => {
-      this.dialogOpen = false;
-      this.activeDialog = undefined;
+    const infoDef = INFO_POINTS[infoId];
+    if (!infoDef) { this.dialogOpen = false; return; }
 
-      if (!this.infoIcon) {
-        markSeen(ELEVATOR_INFO_ID);
-        this.createInfoIcon();
-      }
+    const hasQuiz = !!QUIZ_DATA[infoId];
+
+    this.activeDialog = new InfoDialog(
+      this,
+      infoDef.content,
+      () => {
+        this.dialogOpen = false;
+        this.activeDialog = undefined;
+
+        if (!this.infoIcon) {
+          markSeen(infoId);
+          this.createInfoIcon();
+        }
+      },
+      hasQuiz ? {
+        onQuizStart: () => this.openQuizDialog(infoId),
+        quizStatus: {
+          passed: isQuizPassed(infoId),
+          canRetry: canRetryQuiz(infoId),
+          cooldownSeconds: Math.ceil(getCooldownRemaining(infoId) / 1000),
+        },
+      } : undefined,
+    );
+  }
+
+  private openQuizDialog(infoId: string): void {
+    if (this.dialogOpen) return;
+    this.dialogOpen = true;
+
+    const infoDef = INFO_POINTS[infoId];
+    if (!infoDef) { this.dialogOpen = false; return; }
+
+    this.activeQuiz = new QuizDialog(this, {
+      infoId,
+      floorId: infoDef.floorId,
+      progression: this.progression,
+      onClose: () => {
+        this.dialogOpen = false;
+        this.activeQuiz = undefined;
+        // Update the info icon badge after quiz
+        this.updateInfoIconBadge(infoId);
+      },
     });
   }
 
   private createInfoIcon(): void {
     this.infoIcon = new InfoIcon(this, GAME_WIDTH / 2 + 310, GAME_HEIGHT - 30, () => {
-      this.openElevatorInfoDialog();
+      this.openInfoDialog(ELEVATOR_INFO_ID);
     });
+    this.updateInfoIconBadge(ELEVATOR_INFO_ID);
+  }
+
+  private updateInfoIconBadge(infoId: string): void {
+    if (!this.infoIcon) return;
+    if (QUIZ_DATA[infoId]) {
+      this.infoIcon.setQuizBadge(this, isQuizPassed(infoId));
+    }
   }
 
   private enterFloor(floorId: FloorId): void {

--- a/src/scenes/HubScene.ts
+++ b/src/scenes/HubScene.ts
@@ -90,7 +90,6 @@ export class HubScene extends Phaser.Scene {
     const cx = GAME_WIDTH / 2;
     const sw = HubScene.SHAFT_WIDTH;
 
-    // Dark shaft interior
     for (let y = 0; y < worldHeight; y += TILE_SIZE) {
       this.add.tileSprite(cx, y, sw, TILE_SIZE, 'elevator_shaft').setDepth(0);
     }
@@ -100,7 +99,6 @@ export class HubScene extends Phaser.Scene {
     rail.fillStyle(0x00aaff, 0.6);
     rail.fillRect(cx - sw / 2 - 8, 0, 8, worldHeight);
     rail.fillRect(cx + sw / 2, 0, 8, worldHeight);
-    // Inner rail lines
     rail.lineStyle(2, 0x005588, 0.4);
     rail.lineBetween(cx - sw / 2 + 20, 0, cx - sw / 2 + 20, worldHeight);
     rail.lineBetween(cx + sw / 2 - 20, 0, cx + sw / 2 - 20, worldHeight);
@@ -127,18 +125,15 @@ export class HubScene extends Phaser.Scene {
       const fd = LEVEL_DATA[fId];
       const unlocked = this.progression.isFloorUnlocked(fId);
 
-      // Left-side platforms
       for (let x = 0; x < cx - sw / 2; x += TILE_SIZE) {
         const t = this.platforms.create(x + TILE_SIZE / 2, y, 'platform_tile') as Phaser.Physics.Arcade.Image;
         t.setDepth(2).refreshBody();
       }
-      // Right-side platforms
       for (let x = cx + sw / 2; x < GAME_WIDTH; x += TILE_SIZE) {
         const t = this.platforms.create(x + TILE_SIZE / 2, y, 'platform_tile') as Phaser.Physics.Arcade.Image;
         t.setDepth(2).refreshBody();
       }
 
-      // Floor label (left side)
       this.add.text(20, y - 60, `F${fId}`, {
         fontFamily: 'monospace', fontSize: '28px',
         color: COLORS.hudText, fontStyle: 'bold',
@@ -151,7 +146,6 @@ export class HubScene extends Phaser.Scene {
         }).setDepth(5);
       }
 
-      // Floor opening label (right side, next to shaft)
       if (fId !== FLOORS.LOBBY) {
         const arrowColor = unlocked ? '#00ff88' : '#ff4444';
         const label = unlocked ? '\u2192 ENTER' : `LOCKED: ${this.progression.getAUNeededForFloor(fId)} AU`;
@@ -221,7 +215,6 @@ export class HubScene extends Phaser.Scene {
     this.player.update(delta);
     this.hud.update();
 
-    // Check if player is on elevator
     const body = this.player.sprite.body as Phaser.Physics.Arcade.Body;
     const onElevator = body.blocked.down && this.isOverElevator();
 
@@ -249,14 +242,10 @@ export class HubScene extends Phaser.Scene {
       const down = input.down || (btnState?.down ?? false);
       this.elevator.ride(up, down);
     } else {
-      // Stop elevator movement when player steps off
       this.elevator.ride(false, false);
     }
 
-    // Update cab visuals
     this.elevator.updateVisuals();
-
-    // Check if player walked off the elevator onto a floor platform
     this.checkFloorEntry();
   }
 
@@ -283,7 +272,6 @@ export class HubScene extends Phaser.Scene {
     // Player must be outside the shaft
     if (px > cx - sw / 2 + 20 && px < cx + sw / 2 - 20) return;
 
-    // Find closest floor
     const worldHeight = 1600;
     const positions = this.getFloorYPositions(worldHeight);
 
@@ -291,7 +279,6 @@ export class HubScene extends Phaser.Scene {
       const fId = Number(floorId) as FloorId;
       if (fId === FLOORS.LOBBY) continue;
 
-      // Player's feet should be near the floor platform
       if (Math.abs(py - (floorY - 64)) < 40) {
         if (this.progression.isFloorUnlocked(fId)) {
           this.enterFloor(fId);
@@ -357,7 +344,6 @@ export class HubScene extends Phaser.Scene {
       onClose: () => {
         this.dialogOpen = false;
         this.activeQuiz = undefined;
-        // Update the info icon badge after quiz
         this.updateInfoIconBadge(infoId);
       },
     });

--- a/src/scenes/LevelScene.ts
+++ b/src/scenes/LevelScene.ts
@@ -1,11 +1,18 @@
 import * as Phaser from 'phaser';
 import { GAME_WIDTH, GAME_HEIGHT, TILE_SIZE, ELEVATOR_SPEED, FLOORS, FloorId } from '../config/gameConfig';
 import { LEVEL_DATA, FloorData } from '../config/levelData';
+import { INFO_POINTS } from '../config/infoContent';
+import { QUIZ_DATA } from '../config/quizData';
 import { Player } from '../entities/Player';
 import { Token } from '../entities/Token';
 import { HUD } from '../ui/HUD';
 import { ElevatorButtons } from '../ui/ElevatorButtons';
+import { InfoDialog } from '../ui/InfoDialog';
+import { QuizDialog } from '../ui/QuizDialog';
+import { InfoIcon } from '../ui/InfoIcon';
 import { ProgressionSystem } from '../systems/ProgressionSystem';
+import { hasBeenSeen, markSeen } from '../systems/InfoDialogManager';
+import { isQuizPassed, canRetryQuiz, getCooldownRemaining } from '../systems/QuizManager';
 
 export interface RoomElevator {
   x: number;
@@ -22,6 +29,8 @@ export interface LevelConfig {
   playerStart: { x: number; y: number };
   /** Small in-room elevators connecting platform tiers. */
   roomElevators: RoomElevator[];
+  /** Info points placed in the level. */
+  infoPoints?: Array<{ x: number; y: number; contentId: string }>;
 }
 
 /**
@@ -59,6 +68,10 @@ export class LevelScene extends Phaser.Scene {
   /** On-screen elevator buttons (shared component). */
   private liftButtons?: ElevatorButtons;
 
+  /** Info / quiz dialog state. */
+  private dialogOpen = false;
+  private infoIcons: Array<{ icon: InfoIcon; contentId: string }> = [];
+
   constructor(key: string, floorId: FloorId) {
     super({ key });
     this.floorId = floorId;
@@ -71,6 +84,8 @@ export class LevelScene extends Phaser.Scene {
     this.auCollected = 0;
     this.roomLifts = [];
     this.activeRoomLift = -1;
+    this.dialogOpen = false;
+    this.infoIcons = [];
   }
 
   create(): void {
@@ -86,6 +101,7 @@ export class LevelScene extends Phaser.Scene {
     this.createExit();
     this.createPlayer();
     this.createUI();
+    this.createInfoPoints();
 
     // Fixed camera (no follow, no scroll)
     this.cameras.main.setScroll(0, 0);
@@ -193,7 +209,7 @@ export class LevelScene extends Phaser.Scene {
   protected createExit(): void {
     const c = this.getLevelConfig();
     this.exitDoor = this.add.image(c.exitPosition.x, c.exitPosition.y, 'door_exit').setDepth(4);
-    this.add.text(c.exitPosition.x, c.exitPosition.y - 70, '← ELEVATOR', {
+    this.add.text(c.exitPosition.x, c.exitPosition.y - 70, '\u2190 ELEVATOR', {
       fontFamily: 'monospace', fontSize: '14px', color: '#aaddff',
     }).setOrigin(0.5).setDepth(5);
   }
@@ -215,6 +231,76 @@ export class LevelScene extends Phaser.Scene {
   protected createUI(): void {
     this.hud = new HUD(this, this.progression);
     this.liftButtons = new ElevatorButtons(this, 48);
+  }
+
+  /* ---- info points ---- */
+  protected createInfoPoints(): void {
+    const config = this.getLevelConfig();
+    if (!config.infoPoints) return;
+
+    for (const ip of config.infoPoints) {
+      const icon = new InfoIcon(this, ip.x, ip.y - 40, () => {
+        this.openInfoDialog(ip.contentId);
+      });
+
+      // Auto-show if already seen (icon always visible); update badge
+      if (QUIZ_DATA[ip.contentId]) {
+        icon.setQuizBadge(this, isQuizPassed(ip.contentId));
+      }
+
+      this.infoIcons.push({ icon, contentId: ip.contentId });
+    }
+  }
+
+  private openInfoDialog(contentId: string): void {
+    if (this.dialogOpen) return;
+    this.dialogOpen = true;
+
+    const infoDef = INFO_POINTS[contentId];
+    if (!infoDef) { this.dialogOpen = false; return; }
+
+    markSeen(contentId);
+
+    const hasQuiz = !!QUIZ_DATA[contentId];
+
+    new InfoDialog(
+      this,
+      infoDef.content,
+      () => {
+        this.dialogOpen = false;
+      },
+      hasQuiz ? {
+        onQuizStart: () => this.openQuizDialog(contentId),
+        quizStatus: {
+          passed: isQuizPassed(contentId),
+          canRetry: canRetryQuiz(contentId),
+          cooldownSeconds: Math.ceil(getCooldownRemaining(contentId) / 1000),
+        },
+      } : undefined,
+    );
+  }
+
+  private openQuizDialog(contentId: string): void {
+    if (this.dialogOpen) return;
+    this.dialogOpen = true;
+
+    const infoDef = INFO_POINTS[contentId];
+    if (!infoDef) { this.dialogOpen = false; return; }
+
+    new QuizDialog(this, {
+      infoId: contentId,
+      floorId: infoDef.floorId,
+      progression: this.progression,
+      onClose: () => {
+        this.dialogOpen = false;
+        // Update badges
+        for (const entry of this.infoIcons) {
+          if (entry.contentId === contentId && QUIZ_DATA[contentId]) {
+            entry.icon.setQuizBadge(this, isQuizPassed(contentId));
+          }
+        }
+      },
+    });
   }
 
   /* ---- banner ---- */
@@ -261,6 +347,7 @@ export class LevelScene extends Phaser.Scene {
   /* ---- update loop ---- */
   update(_time: number, delta: number): void {
     if (this.isTransitioning) return;
+    if (this.dialogOpen) return;
 
     this.player.update(delta);
     this.hud.update();
@@ -335,7 +422,7 @@ export class LevelScene extends Phaser.Scene {
       this.exitDoor.x, this.exitDoor.y,
     );
     if (d < 90) {
-      this.interactPrompt?.setText('Press E → Elevator').setPosition(
+      this.interactPrompt?.setText('Press E \u2192 Elevator').setPosition(
         this.exitDoor.x - 60, this.exitDoor.y - 90,
       ).setVisible(true);
       if (this.player.getInputManager().isInteractJustPressed()) this.returnToHub();

--- a/src/scenes/LevelScene.ts
+++ b/src/scenes/LevelScene.ts
@@ -115,7 +115,6 @@ export class LevelScene extends Phaser.Scene {
       this,
     );
 
-    // Colliders for each room elevator
     for (let i = 0; i < this.roomLifts.length; i++) {
       const idx = i;
       this.physics.add.collider(this.player.sprite, this.roomLifts[i].platform, () => {
@@ -129,10 +128,8 @@ export class LevelScene extends Phaser.Scene {
 
   /* ---- background ---- */
   protected createBackground(): void {
-    // Room walls
     const g = this.add.graphics().setDepth(0);
 
-    // Fill background
     g.fillStyle(this.floorData.theme.backgroundColor);
     g.fillRect(0, 0, GAME_WIDTH, GAME_HEIGHT);
 
@@ -172,17 +169,14 @@ export class LevelScene extends Phaser.Scene {
   protected createRoomElevators(): void {
     const config = this.getLevelConfig();
     for (const re of config.roomElevators) {
-      // Shaft background
       const shaft = this.add.graphics().setDepth(1);
       const shaftW = 80;
       shaft.fillStyle(0x060610, 0.85);
       shaft.fillRect(re.x - shaftW / 2, re.minY, shaftW, re.maxY - re.minY + 16);
-      // Shaft rails
       shaft.lineStyle(2, 0x00aaff, 0.5);
       shaft.lineBetween(re.x - shaftW / 2, re.minY, re.x - shaftW / 2, re.maxY + 16);
       shaft.lineBetween(re.x + shaftW / 2, re.minY, re.x + shaftW / 2, re.maxY + 16);
 
-      // Elevator platform
       const plat = this.physics.add.image(re.x, re.startY, 'room_elevator_platform');
       plat.setImmovable(true);
       (plat.body as Phaser.Physics.Arcade.Body).setAllowGravity(false);
@@ -293,7 +287,6 @@ export class LevelScene extends Phaser.Scene {
       progression: this.progression,
       onClose: () => {
         this.dialogOpen = false;
-        // Update badges
         for (const entry of this.infoIcons) {
           if (entry.contentId === contentId && QUIZ_DATA[contentId]) {
             entry.icon.setQuizBadge(this, isQuizPassed(contentId));
@@ -382,7 +375,6 @@ export class LevelScene extends Phaser.Scene {
 
     if (!onLift) {
       this.activeRoomLift = -1;
-      // Stop all lifts
       for (const lift of this.roomLifts) {
         lift.platform.setVelocityY(0);
       }
@@ -404,7 +396,6 @@ export class LevelScene extends Phaser.Scene {
       lift.platform.setVelocityY(0);
     }
 
-    // Clamp to shaft bounds
     if (lift.platform.y <= lift.minY) {
       lift.platform.y = lift.minY;
       lift.platform.setVelocityY(0);

--- a/src/scenes/LevelScene.ts
+++ b/src/scenes/LevelScene.ts
@@ -11,7 +11,7 @@ import { InfoDialog } from '../ui/InfoDialog';
 import { QuizDialog } from '../ui/QuizDialog';
 import { InfoIcon } from '../ui/InfoIcon';
 import { ProgressionSystem } from '../systems/ProgressionSystem';
-import { hasBeenSeen, markSeen } from '../systems/InfoDialogManager';
+import { markSeen } from '../systems/InfoDialogManager';
 import { isQuizPassed, canRetryQuiz, getCooldownRemaining } from '../systems/QuizManager';
 
 export interface RoomElevator {
@@ -237,7 +237,7 @@ export class LevelScene extends Phaser.Scene {
         this.openInfoDialog(ip.contentId);
       });
 
-      // Auto-show if already seen (icon always visible); update badge
+      // Update quiz badge if quiz data exists for this info point
       if (QUIZ_DATA[ip.contentId]) {
         icon.setQuizBadge(this, isQuizPassed(ip.contentId));
       }

--- a/src/systems/ProgressionSystem.ts
+++ b/src/systems/ProgressionSystem.ts
@@ -45,8 +45,12 @@ export class ProgressionSystem {
       if (this.tokensFor(floorId).has(tokenIndex)) return;
       this.tokensFor(floorId).add(tokenIndex);
     }
-    this.state.totalAU++;
-    this.state.floorAU[floorId]++;
+    this.addAU(floorId, 1);
+  }
+
+  addAU(floorId: FloorId, amount: number): void {
+    this.state.totalAU += amount;
+    this.state.floorAU[floorId] += amount;
     this.checkUnlocks();
     this.persist();
   }

--- a/src/systems/QuizManager.ts
+++ b/src/systems/QuizManager.ts
@@ -1,0 +1,80 @@
+/**
+ * Quiz state persistence — tracks completion, scores, and retry cooldowns.
+ *
+ * Follows the same module-level pattern as InfoDialogManager.ts:
+ * own localStorage key, pure functions, no class needed.
+ */
+
+import type { KVStorage } from './SaveManager';
+import { QUIZ_COOLDOWN_MS } from '../config/quizData';
+
+const STORAGE_KEY = 'architect_quiz_v1';
+
+interface QuizRecord {
+  passed: boolean;
+  bestScore: number;
+  lastAttemptTime: number;   // Date.now() milliseconds
+  attempts: number;
+}
+
+type QuizStore = Record<string, QuizRecord>;
+
+let storage: KVStorage | null = null;
+
+function getStorage(): KVStorage {
+  if (storage) return storage;
+  try { storage = globalThis.localStorage; return storage; }
+  catch { return { getItem: () => null, setItem: () => {}, removeItem: () => {} }; }
+}
+
+function loadStore(): QuizStore {
+  try {
+    const raw = getStorage().getItem(STORAGE_KEY);
+    return raw ? JSON.parse(raw) as QuizStore : {};
+  } catch { return {}; }
+}
+
+function persist(store: QuizStore): void {
+  try { getStorage().setItem(STORAGE_KEY, JSON.stringify(store)); } catch { /* quota */ }
+}
+
+export function getQuizRecord(infoId: string): QuizRecord | null {
+  return loadStore()[infoId] ?? null;
+}
+
+export function isQuizPassed(infoId: string): boolean {
+  return loadStore()[infoId]?.passed ?? false;
+}
+
+export function canRetryQuiz(infoId: string): boolean {
+  const record = loadStore()[infoId];
+  if (!record) return true;  // never attempted
+  return Date.now() - record.lastAttemptTime >= QUIZ_COOLDOWN_MS;
+}
+
+/** Returns milliseconds remaining before retry is allowed. 0 if ready. */
+export function getCooldownRemaining(infoId: string): number {
+  const record = loadStore()[infoId];
+  if (!record) return 0;
+  const elapsed = Date.now() - record.lastAttemptTime;
+  return Math.max(0, QUIZ_COOLDOWN_MS - elapsed);
+}
+
+export function saveQuizResult(infoId: string, score: number, total: number): void {
+  const store = loadStore();
+  const existing = store[infoId];
+  const passed = score >= 2;
+
+  store[infoId] = {
+    passed: passed || (existing?.passed ?? false),
+    bestScore: Math.max(score, existing?.bestScore ?? 0),
+    lastAttemptTime: Date.now(),
+    attempts: (existing?.attempts ?? 0) + 1,
+  };
+
+  persist(store);
+}
+
+export function resetAllQuizzes(): void {
+  try { getStorage().removeItem(STORAGE_KEY); } catch { /* noop */ }
+}

--- a/src/systems/QuizManager.ts
+++ b/src/systems/QuizManager.ts
@@ -6,7 +6,7 @@
  */
 
 import type { KVStorage } from './SaveManager';
-import { QUIZ_COOLDOWN_MS } from '../config/quizData';
+import { QUIZ_COOLDOWN_MS, QUIZ_PASS_THRESHOLD } from '../config/quizData';
 
 const STORAGE_KEY = 'architect_quiz_v1';
 
@@ -60,10 +60,10 @@ export function getCooldownRemaining(infoId: string): number {
   return Math.max(0, QUIZ_COOLDOWN_MS - elapsed);
 }
 
-export function saveQuizResult(infoId: string, score: number, total: number): void {
+export function saveQuizResult(infoId: string, score: number): void {
   const store = loadStore();
   const existing = store[infoId];
-  const passed = score >= 2;
+  const passed = score >= QUIZ_PASS_THRESHOLD;
 
   store[infoId] = {
     passed: passed || (existing?.passed ?? false),

--- a/src/systems/SoundGenerator.ts
+++ b/src/systems/SoundGenerator.ts
@@ -13,6 +13,10 @@ export function generateSounds(scene: Phaser.Scene): void {
   loadWav(scene, 'jump', generateJumpSound());
   loadWav(scene, 'footstep_a', generateFootstepSound(100));
   loadWav(scene, 'footstep_b', generateFootstepSound(85));
+  loadWav(scene, 'quiz_correct', generateQuizCorrectSound());
+  loadWav(scene, 'quiz_wrong', generateQuizWrongSound());
+  loadWav(scene, 'quiz_success', generateQuizSuccessSound());
+  loadWav(scene, 'quiz_fail', generateQuizFailSound());
 }
 
 export function loadWav(scene: Phaser.Scene, key: string, wav: ArrayBuffer): void {
@@ -80,6 +84,107 @@ function generateJumpSound(): ArrayBuffer {
     // Linear decay envelope
     const envelope = 1 - progress;
     samples[i] = wave * envelope * 0.3;
+  }
+
+  return encodeWAV(samples, SAMPLE_RATE);
+}
+
+/** Short ascending ding — triangle wave for correct quiz answer. */
+function generateQuizCorrectSound(): ArrayBuffer {
+  const duration = 0.12;
+  const numSamples = Math.floor(SAMPLE_RATE * duration);
+  const samples = new Float32Array(numSamples);
+
+  let phase = 0;
+  for (let i = 0; i < numSamples; i++) {
+    const progress = numSamples > 1 ? i / (numSamples - 1) : 1;
+    // Ascending sweep 660 → 880 Hz (triangle wave)
+    const freq = 660 + 220 * progress;
+    phase += (2 * Math.PI * freq) / SAMPLE_RATE;
+    const wave = (2 / Math.PI) * Math.asin(Math.sin(phase));
+    const envelope = 1 - progress * 0.7;
+    samples[i] = wave * envelope * 0.2;
+  }
+
+  return encodeWAV(samples, SAMPLE_RATE);
+}
+
+/** Low buzz — square wave for wrong quiz answer. */
+function generateQuizWrongSound(): ArrayBuffer {
+  const duration = 0.18;
+  const numSamples = Math.floor(SAMPLE_RATE * duration);
+  const samples = new Float32Array(numSamples);
+
+  let phase = 0;
+  for (let i = 0; i < numSamples; i++) {
+    const progress = numSamples > 1 ? i / (numSamples - 1) : 1;
+    const freq = 160 - 30 * progress;
+    phase += (2 * Math.PI * freq) / SAMPLE_RATE;
+    const wave = Math.sign(Math.sin(phase));
+    const envelope = Math.exp(-progress * 4);
+    samples[i] = wave * envelope * 0.15;
+  }
+
+  return encodeWAV(samples, SAMPLE_RATE);
+}
+
+/** Ascending major arpeggio fanfare — celebratory quiz pass sound. */
+function generateQuizSuccessSound(): ArrayBuffer {
+  const duration = 0.7;
+  const numSamples = Math.floor(SAMPLE_RATE * duration);
+  const samples = new Float32Array(numSamples);
+
+  // C5=523, E5=659, G5=784, C6=1047
+  const notes = [523, 659, 784, 1047];
+  const noteLen = Math.floor(numSamples / notes.length);
+
+  let phase = 0;
+  for (let i = 0; i < numSamples; i++) {
+    const noteIdx = Math.min(Math.floor(i / noteLen), notes.length - 1);
+    const noteProgress = (i - noteIdx * noteLen) / noteLen;
+    const freq = notes[noteIdx];
+
+    phase += (2 * Math.PI * freq) / SAMPLE_RATE;
+    // Square wave with a touch of triangle for warmth
+    const square = Math.sign(Math.sin(phase));
+    const triangle = (2 / Math.PI) * Math.asin(Math.sin(phase));
+    const wave = square * 0.6 + triangle * 0.4;
+
+    // Per-note envelope: quick attack, sustain, soft tail on last note
+    let envelope: number;
+    if (noteIdx === notes.length - 1) {
+      envelope = Math.exp(-noteProgress * 2.5);
+    } else {
+      const attack = Math.min(noteProgress * 20, 1);
+      envelope = attack * (1 - noteProgress * 0.3);
+    }
+    samples[i] = wave * envelope * 0.25;
+  }
+
+  return encodeWAV(samples, SAMPLE_RATE);
+}
+
+/** Two descending notes — somber quiz fail sound. */
+function generateQuizFailSound(): ArrayBuffer {
+  const duration = 0.35;
+  const numSamples = Math.floor(SAMPLE_RATE * duration);
+  const samples = new Float32Array(numSamples);
+
+  // E4=330, C4=262
+  const notes = [330, 262];
+  const noteLen = Math.floor(numSamples / notes.length);
+
+  let phase = 0;
+  for (let i = 0; i < numSamples; i++) {
+    const noteIdx = Math.min(Math.floor(i / noteLen), notes.length - 1);
+    const noteProgress = (i - noteIdx * noteLen) / noteLen;
+    const freq = notes[noteIdx];
+
+    phase += (2 * Math.PI * freq) / SAMPLE_RATE;
+    const wave = Math.sign(Math.sin(phase));
+    const attack = Math.min(noteProgress * 15, 1);
+    const envelope = attack * Math.exp(-noteProgress * 3);
+    samples[i] = wave * envelope * 0.2;
   }
 
   return encodeWAV(samples, SAMPLE_RATE);

--- a/src/ui/InfoDialog.ts
+++ b/src/ui/InfoDialog.ts
@@ -11,6 +11,21 @@ export interface InfoDialogContent {
   title: string;
   body: string;
   links?: InfoDialogLink[];
+  extendedInfo?: {
+    title: string;
+    body: string;
+  };
+}
+
+export interface QuizButtonState {
+  passed: boolean;
+  canRetry: boolean;
+  cooldownSeconds: number;
+}
+
+export interface InfoDialogOptions {
+  onQuizStart?: () => void;
+  quizStatus?: QuizButtonState;
 }
 
 export class InfoDialog {
@@ -20,8 +35,15 @@ export class InfoDialog {
   private escHandler: (() => void) | null = null;
   private onClose?: () => void;
   private destroyed = false;
+  private extendedExpanded = false;
+  private cooldownTimer?: Phaser.Time.TimerEvent;
 
-  constructor(scene: Phaser.Scene, content: InfoDialogContent, onClose?: () => void) {
+  constructor(
+    scene: Phaser.Scene,
+    content: InfoDialogContent,
+    onClose?: () => void,
+    options?: InfoDialogOptions,
+  ) {
     this.scene = scene;
     this.onClose = onClose;
 
@@ -31,7 +53,7 @@ export class InfoDialog {
     this.container.setAlpha(0);
 
     this.buildOverlay();
-    this.buildPanel(content);
+    this.buildPanel(content, options);
     this.registerEscKey();
 
     scene.tweens.add({ targets: this.container, alpha: 1, duration: 200 });
@@ -47,10 +69,9 @@ export class InfoDialog {
     this.container.add(overlay);
   }
 
-  private buildPanel(content: InfoDialogContent): void {
+  private buildPanel(content: InfoDialogContent, options?: InfoDialogOptions): void {
     const panelW = 620;
     const panelX = (GAME_WIDTH - panelW) / 2;
-    let panelH = 0;
 
     const PADDING = 32;
     const LINK_LINE_H = 30;
@@ -71,8 +92,19 @@ export class InfoDialog {
     const linksCount = content.links?.length ?? 0;
     const linksSectionH = linksCount > 0 ? 28 + linksCount * LINK_LINE_H + 8 : 0;
 
+    // Extended info toggle adds a small line
+    const hasExtended = !!content.extendedInfo;
+    const extendedToggleH = hasExtended ? 36 : 0;
+
+    // Quiz button adds a line
+    const hasQuiz = !!options?.onQuizStart;
+    const quizBtnH = hasQuiz ? 40 : 0;
+
     const MAX_PANEL_H = GAME_HEIGHT - 40;
-    panelH = Math.min(28 + 18 + bodyH + 16 + linksSectionH + CLOSE_BAR_H + PADDING * 2, MAX_PANEL_H);
+    let panelH = Math.min(
+      28 + 18 + bodyH + 16 + linksSectionH + extendedToggleH + quizBtnH + CLOSE_BAR_H + PADDING * 2,
+      MAX_PANEL_H,
+    );
     const panelY = Math.max(20, (GAME_HEIGHT - panelH) / 2);
 
     const bg = this.scene.add.graphics();
@@ -105,7 +137,7 @@ export class InfoDialog {
       curY += 24;
 
       for (const link of content.links) {
-        const linkText = this.scene.add.text(panelX + PADDING + 10, curY, `▸ ${link.label}`, {
+        const linkText = this.scene.add.text(panelX + PADDING + 10, curY, `\u25b8 ${link.label}`, {
           fontFamily: 'monospace', fontSize: '14px', color: '#44aaff',
         }).setInteractive({ useHandCursor: true });
 
@@ -118,6 +150,151 @@ export class InfoDialog {
         this.container.add(linkText);
         curY += LINK_LINE_H;
       }
+    }
+
+    // Extended info toggle
+    if (hasExtended && content.extendedInfo) {
+      const extInfo = content.extendedInfo;
+      curY += 4;
+
+      const toggleText = this.scene.add.text(panelX + PADDING, curY, '[+]  Deep Dive', {
+        fontFamily: 'monospace', fontSize: '14px', color: '#00aaff', fontStyle: 'bold',
+      }).setInteractive({ useHandCursor: true });
+      this.container.add(toggleText);
+
+      toggleText.on('pointerover', () => toggleText.setColor('#88ddff'));
+      toggleText.on('pointerout', () => toggleText.setColor('#00aaff'));
+
+      // Extended content container (initially hidden)
+      const extContainer = this.scene.add.container(0, 0);
+      extContainer.setVisible(false);
+      this.container.add(extContainer);
+
+      const extBodyMeasure = this.scene.make.text({
+        x: 0, y: 0, text: extInfo.body,
+        style: { fontFamily: 'monospace', fontSize: '14px', color: '#a0b0c0',
+          wordWrap: { width: panelW - PADDING * 2 - 16 }, lineSpacing: 5 },
+        add: false,
+      });
+      const extBodyH = extBodyMeasure.height;
+      extBodyMeasure.destroy();
+
+      toggleText.on('pointerdown', () => {
+        this.extendedExpanded = !this.extendedExpanded;
+
+        if (this.extendedExpanded) {
+          toggleText.setText('[-]  Deep Dive');
+
+          // Build extended content
+          let ey = curY + 28;
+
+          const extTitle = this.scene.add.text(panelX + PADDING + 12, ey, extInfo.title, {
+            fontFamily: 'monospace', fontSize: '15px', color: '#00d4ff', fontStyle: 'bold',
+          });
+          extContainer.add(extTitle);
+          ey += 24;
+
+          const extBorder = this.scene.add.graphics();
+          extBorder.fillStyle(0x00aaff, 0.4);
+          extBorder.fillRect(panelX + PADDING + 4, ey - 2, 3, extBodyH + 4);
+          extContainer.add(extBorder);
+
+          const extBody = this.scene.add.text(panelX + PADDING + 16, ey, extInfo.body, {
+            fontFamily: 'monospace', fontSize: '14px', color: '#a0b0c0',
+            wordWrap: { width: panelW - PADDING * 2 - 16 }, lineSpacing: 5,
+          });
+          extContainer.add(extBody);
+
+          extContainer.setVisible(true);
+
+          // Resize panel
+          const newPanelH = Math.min(panelH + extBodyH + 36, MAX_PANEL_H);
+          bg.clear();
+          bg.fillStyle(0x0a0a2a, 0.95);
+          bg.fillRoundedRect(panelX, panelY, panelW, newPanelH, 10);
+          bg.lineStyle(2, 0x00aaff, 0.7);
+          bg.strokeRoundedRect(panelX, panelY, panelW, newPanelH, 10);
+        } else {
+          toggleText.setText('[+]  Deep Dive');
+          extContainer.removeAll(true);
+          extContainer.setVisible(false);
+
+          // Restore panel
+          bg.clear();
+          bg.fillStyle(0x0a0a2a, 0.95);
+          bg.fillRoundedRect(panelX, panelY, panelW, panelH, 10);
+          bg.lineStyle(2, 0x00aaff, 0.7);
+          bg.strokeRoundedRect(panelX, panelY, panelW, panelH, 10);
+        }
+      });
+
+      curY += extendedToggleH;
+    }
+
+    // Quiz button
+    if (hasQuiz && options?.onQuizStart) {
+      const quizStatus = options.quizStatus;
+      let quizLabel: string;
+      let quizColor: string;
+      let clickable = true;
+
+      if (quizStatus?.passed) {
+        quizLabel = '[\u2713  QUIZ PASSED]';
+        quizColor = '#44ff88';
+      } else if (quizStatus && !quizStatus.canRetry && quizStatus.cooldownSeconds > 0) {
+        quizLabel = `[RETRY IN ${quizStatus.cooldownSeconds}s]`;
+        quizColor = '#556677';
+        clickable = false;
+      } else {
+        quizLabel = '[\u2606  TAKE QUIZ]';
+        quizColor = '#ffd700';
+      }
+
+      const quizBtn = this.scene.add.text(GAME_WIDTH / 2, curY, quizLabel, {
+        fontFamily: 'monospace', fontSize: '15px', color: quizColor, fontStyle: 'bold',
+      }).setOrigin(0.5, 0);
+      this.container.add(quizBtn);
+
+      if (clickable) {
+        quizBtn.setInteractive({ useHandCursor: true });
+        const onQuizStart = options.onQuizStart;
+        const hoverColor = quizStatus?.passed ? '#88ffbb' : '#ffed4a';
+        quizBtn.on('pointerover', () => quizBtn.setColor(hoverColor));
+        quizBtn.on('pointerout', () => quizBtn.setColor(quizColor));
+        quizBtn.on('pointerdown', () => {
+          this.close();
+          // Slight delay so close animation finishes before quiz opens
+          this.scene.time.delayedCall(200, () => onQuizStart());
+        });
+      }
+
+      // If on cooldown, update the label every second
+      if (quizStatus && !quizStatus.canRetry && quizStatus.cooldownSeconds > 0) {
+        let remaining = quizStatus.cooldownSeconds;
+        this.cooldownTimer = this.scene.time.addEvent({
+          delay: 1000,
+          repeat: remaining - 1,
+          callback: () => {
+            remaining--;
+            if (remaining <= 0) {
+              quizBtn.setText('[\u2606  TAKE QUIZ]');
+              quizBtn.setColor('#ffd700');
+              quizBtn.setInteractive({ useHandCursor: true });
+              const onQuizStart = options!.onQuizStart!;
+              quizBtn.on('pointerover', () => quizBtn.setColor('#ffed4a'));
+              quizBtn.on('pointerout', () => quizBtn.setColor('#ffd700'));
+              quizBtn.on('pointerdown', () => {
+                this.close();
+                this.scene.time.delayedCall(200, () => onQuizStart());
+              });
+            } else {
+              quizBtn.setText(`[RETRY IN ${remaining}s]`);
+            }
+          },
+        });
+      }
+
+      curY += quizBtnH;
     }
 
     curY = panelY + panelH - CLOSE_BAR_H - 4;
@@ -152,6 +329,9 @@ export class InfoDialog {
   close(): void {
     if (this.destroyed) return;
     this.destroyed = true;
+    if (this.cooldownTimer) {
+      this.cooldownTimer.destroy();
+    }
     if (this.escHandler) {
       this.scene.events.off('update', this.escHandler);
     }

--- a/src/ui/InfoDialog.ts
+++ b/src/ui/InfoDialog.ts
@@ -92,11 +92,9 @@ export class InfoDialog {
     const linksCount = content.links?.length ?? 0;
     const linksSectionH = linksCount > 0 ? 28 + linksCount * LINK_LINE_H + 8 : 0;
 
-    // Extended info toggle adds a small line
     const hasExtended = !!content.extendedInfo;
     const extendedToggleH = hasExtended ? 36 : 0;
 
-    // Quiz button adds a line
     const hasQuiz = !!options?.onQuizStart;
     const quizBtnH = hasQuiz ? 40 : 0;
 
@@ -152,7 +150,6 @@ export class InfoDialog {
       }
     }
 
-    // Extended info toggle
     if (hasExtended && content.extendedInfo) {
       const extInfo = content.extendedInfo;
       curY += 4;
@@ -165,7 +162,6 @@ export class InfoDialog {
       toggleText.on('pointerover', () => toggleText.setColor('#88ddff'));
       toggleText.on('pointerout', () => toggleText.setColor('#00aaff'));
 
-      // Extended content container (initially hidden)
       const extContainer = this.scene.add.container(0, 0);
       extContainer.setVisible(false);
       this.container.add(extContainer);
@@ -185,7 +181,6 @@ export class InfoDialog {
         if (this.extendedExpanded) {
           toggleText.setText('[-]  Deep Dive');
 
-          // Build extended content
           let ey = curY + 28;
 
           const extTitle = this.scene.add.text(panelX + PADDING + 12, ey, extInfo.title, {
@@ -207,7 +202,6 @@ export class InfoDialog {
 
           extContainer.setVisible(true);
 
-          // Resize panel
           const newPanelH = Math.min(panelH + extBodyH + 36, MAX_PANEL_H);
           bg.clear();
           bg.fillStyle(0x0a0a2a, 0.95);
@@ -219,7 +213,6 @@ export class InfoDialog {
           extContainer.removeAll(true);
           extContainer.setVisible(false);
 
-          // Restore panel
           bg.clear();
           bg.fillStyle(0x0a0a2a, 0.95);
           bg.fillRoundedRect(panelX, panelY, panelW, panelH, 10);

--- a/src/ui/InfoDialog.ts
+++ b/src/ui/InfoDialog.ts
@@ -154,7 +154,8 @@ export class InfoDialog {
       const extInfo = content.extendedInfo;
       curY += 4;
 
-      const toggleText = this.scene.add.text(panelX + PADDING, curY, '[+]  Deep Dive', {
+      const toggleY = curY;
+      const toggleText = this.scene.add.text(panelX + PADDING, toggleY, '[+]  Deep Dive', {
         fontFamily: 'monospace', fontSize: '14px', color: '#00aaff', fontStyle: 'bold',
       }).setInteractive({ useHandCursor: true });
       this.container.add(toggleText);
@@ -181,7 +182,7 @@ export class InfoDialog {
         if (this.extendedExpanded) {
           toggleText.setText('[-]  Deep Dive');
 
-          let ey = curY + 28;
+          let ey = toggleY + 28;
 
           const extTitle = this.scene.add.text(panelX + PADDING + 12, ey, extInfo.title, {
             fontFamily: 'monospace', fontSize: '15px', color: '#00d4ff', fontStyle: 'bold',

--- a/src/ui/InfoIcon.ts
+++ b/src/ui/InfoIcon.ts
@@ -3,6 +3,7 @@ import * as Phaser from 'phaser';
 export class InfoIcon {
   private container: Phaser.GameObjects.Container;
   private pulseTween: Phaser.Tweens.Tween;
+  private badge?: Phaser.GameObjects.Container;
 
   constructor(scene: Phaser.Scene, x: number, y: number, onClick: () => void) {
     this.container = scene.add.container(x, y);
@@ -35,6 +36,34 @@ export class InfoIcon {
       targets: this.container, alpha: { from: 1, to: 0.55 },
       duration: 1400, yoyo: true, repeat: -1, ease: 'Sine.easeInOut',
     });
+  }
+
+  /** Show a small badge on the info icon indicating quiz status. */
+  setQuizBadge(scene: Phaser.Scene, passed: boolean): void {
+    if (this.badge) {
+      this.badge.destroy();
+      this.badge = undefined;
+    }
+
+    this.badge = scene.add.container(10, -10);
+
+    const badgeBg = scene.add.graphics();
+    if (passed) {
+      badgeBg.fillStyle(0x228b22, 1);
+      badgeBg.fillCircle(0, 0, 7);
+    } else {
+      badgeBg.fillStyle(0xdaa520, 1);
+      badgeBg.fillCircle(0, 0, 7);
+    }
+    this.badge.add(badgeBg);
+
+    const badgeLabel = scene.add.text(0, 0, passed ? '\u2713' : '?', {
+      fontFamily: 'monospace', fontSize: passed ? '10px' : '11px',
+      color: '#ffffff', fontStyle: 'bold',
+    }).setOrigin(0.5);
+    this.badge.add(badgeLabel);
+
+    this.container.add(this.badge);
   }
 
   setVisible(visible: boolean): void {

--- a/src/ui/QuizDialog.ts
+++ b/src/ui/QuizDialog.ts
@@ -101,7 +101,6 @@ export class QuizDialog {
     const CHOICE_H = 52;
     const CHOICE_GAP = 8;
 
-    // Measure question text height
     const qMeasure = this.scene.make.text({
       x: 0, y: 0,
       text: q.question,
@@ -112,14 +111,12 @@ export class QuizDialog {
     const qHeight = qMeasure.height;
     qMeasure.destroy();
 
-    // Calculate panel height
     const headerH = 70;
     const choicesH = 4 * CHOICE_H + 3 * CHOICE_GAP;
     const closeBarH = 44;
     const panelH = Math.min(headerH + qHeight + 20 + choicesH + closeBarH + PADDING * 2, GAME_HEIGHT - 40);
     const panelY = Math.max(20, (GAME_HEIGHT - panelH) / 2);
 
-    // Panel background
     const bg = this.scene.add.graphics();
     bg.fillStyle(0x0a0a2a, 0.95);
     bg.fillRoundedRect(panelX, panelY, PANEL_W, panelH, 10);
@@ -129,7 +126,6 @@ export class QuizDialog {
 
     let curY = panelY + PADDING;
 
-    // Header: "Question X / N"
     const header = this.scene.add.text(
       GAME_WIDTH / 2, curY,
       `Question ${this.currentIndex + 1} / ${this.questions.length}`,
@@ -137,7 +133,6 @@ export class QuizDialog {
     ).setOrigin(0.5, 0);
     this.container.add(header);
 
-    // Difficulty badge
     const diffColors: Record<QuizDifficulty, string> = {
       easy: '#44ff88', medium: '#ffdd44', hard: '#ff6644',
     };
@@ -150,7 +145,6 @@ export class QuizDialog {
 
     curY += headerH;
 
-    // Question text
     const qText = this.scene.add.text(panelX + PADDING, curY, q.question, {
       fontFamily: 'monospace', fontSize: '16px', color: '#c0c8d4',
       wordWrap: { width: PANEL_W - PADDING * 2 }, lineSpacing: 6,
@@ -158,13 +152,11 @@ export class QuizDialog {
     this.container.add(qText);
     curY += qHeight + 20;
 
-    // Answer choices
     for (let i = 0; i < q.choices.length; i++) {
       const choiceY = curY + i * (CHOICE_H + CHOICE_GAP);
       this.createChoiceButton(panelX + PADDING, choiceY, PANEL_W - PADDING * 2, CHOICE_H, i, q);
     }
 
-    // X button
     const xBtn = this.scene.add.text(panelX + PANEL_W - 18, panelY + 10, 'X', {
       fontFamily: 'monospace', fontSize: '16px', color: '#556677', fontStyle: 'bold',
     }).setOrigin(0.5, 0).setInteractive({ useHandCursor: true });
@@ -194,7 +186,6 @@ export class QuizDialog {
     }).setOrigin(0, 0.5);
     this.container.add(btnText);
 
-    // Hit area
     const hitArea = this.scene.add.rectangle(x + w / 2, y + h / 2, w, h)
       .setInteractive({ useHandCursor: true })
       .setAlpha(0.001);
@@ -231,10 +222,7 @@ export class QuizDialog {
     const correct = selectedIndex === question.correctIndex;
     if (correct) this.score++;
 
-    // Play sound
     eventBus.emit(correct ? 'sfx:quiz_correct' : 'sfx:quiz_wrong');
-
-    // Rebuild panel to show result state
     this.showAnswerFeedback(question, selectedIndex);
   }
 
@@ -248,7 +236,6 @@ export class QuizDialog {
     const CHOICE_H = 52;
     const CHOICE_GAP = 8;
 
-    // Measure question + explanation text
     const qMeasure = this.scene.make.text({
       x: 0, y: 0, text: question.question,
       style: { fontFamily: 'monospace', fontSize: '16px', color: '#c0c8d4',
@@ -277,7 +264,6 @@ export class QuizDialog {
     );
     const panelY = Math.max(20, (GAME_HEIGHT - panelH) / 2);
 
-    // Panel background
     const bg = this.scene.add.graphics();
     bg.fillStyle(0x0a0a2a, 0.95);
     bg.fillRoundedRect(panelX, panelY, PANEL_W, panelH, 10);
@@ -287,7 +273,6 @@ export class QuizDialog {
 
     let curY = panelY + PADDING;
 
-    // Result header
     const diffColors: Record<QuizDifficulty, string> = {
       easy: '#44ff88', medium: '#ffdd44', hard: '#ff6644',
     };
@@ -309,7 +294,6 @@ export class QuizDialog {
 
     curY += headerH;
 
-    // Question text
     const qText = this.scene.add.text(panelX + PADDING, curY, question.question, {
       fontFamily: 'monospace', fontSize: '16px', color: '#8899aa',
       wordWrap: { width: PANEL_W - PADDING * 2 }, lineSpacing: 6,
@@ -317,7 +301,6 @@ export class QuizDialog {
     this.container.add(qText);
     curY += qHeight + 20;
 
-    // Answer choices (with correct/wrong indicators)
     for (let i = 0; i < question.choices.length; i++) {
       const choiceY = curY + i * (CHOICE_H + CHOICE_GAP);
       const prefix = String.fromCharCode(65 + i);
@@ -357,14 +340,12 @@ export class QuizDialog {
 
     curY += 4 * CHOICE_H + 3 * CHOICE_GAP + 16;
 
-    // Explanation
     const expText = this.scene.add.text(panelX + PADDING + 6, curY, question.explanation, {
       fontFamily: 'monospace', fontSize: '13px', color: '#8899aa',
       wordWrap: { width: PANEL_W - PADDING * 2 - 12 }, lineSpacing: 4,
     });
     this.container.add(expText);
 
-    // Left border for explanation
     const expBorder = this.scene.add.graphics();
     expBorder.fillStyle(correct ? 0x44ff88 : 0xff4444, 0.6);
     expBorder.fillRect(panelX + PADDING, curY - 2, 3, expHeight + 4);
@@ -372,7 +353,6 @@ export class QuizDialog {
 
     curY += explanationH;
 
-    // Next button
     const isLast = this.currentIndex >= this.questions.length - 1;
     const nextLabel = isLast ? '[  SEE RESULTS  ]' : '[  NEXT QUESTION  ]';
 
@@ -392,7 +372,6 @@ export class QuizDialog {
     });
     this.container.add(nextBtn);
 
-    // X button
     const xBtn = this.scene.add.text(panelX + PANEL_W - 18, panelY + 10, 'X', {
       fontFamily: 'monospace', fontSize: '16px', color: '#556677', fontStyle: 'bold',
     }).setOrigin(0.5, 0).setInteractive({ useHandCursor: true });
@@ -402,8 +381,6 @@ export class QuizDialog {
     this.container.add(xBtn);
   }
 
-  /* ---- results ---- */
-
   private showResults(): void {
     this.clearPanel();
 
@@ -411,10 +388,9 @@ export class QuizDialog {
     const passed = this.score >= 2;
     const perfect = this.score === total;
 
-    // Save result
     saveQuizResult(this.options.infoId, this.score, total);
 
-    // Award AU only if this is the first pass
+    // AU only awarded on first pass
     let auAwarded = 0;
     if (passed && !this.alreadyPassed) {
       auAwarded = perfect ? QUIZ_REWARDS.perfect : QUIZ_REWARDS.pass;
@@ -423,7 +399,6 @@ export class QuizDialog {
       }
     }
 
-    // Play sound
     eventBus.emit(passed ? 'sfx:quiz_success' : 'sfx:quiz_fail');
 
     const PANEL_W = 620;
@@ -432,7 +407,6 @@ export class QuizDialog {
     const panelH = passed ? 340 : 280;
     const panelY = (GAME_HEIGHT - panelH) / 2;
 
-    // Panel background
     const bg = this.scene.add.graphics();
     bg.fillStyle(0x0a0a2a, 0.95);
     bg.fillRoundedRect(panelX, panelY, PANEL_W, panelH, 10);
@@ -442,7 +416,6 @@ export class QuizDialog {
 
     let curY = panelY + PADDING;
 
-    // Result title
     const titleText = passed
       ? (perfect ? 'PERFECT SCORE!' : 'QUIZ PASSED!')
       : 'NOT QUITE...';
@@ -453,7 +426,6 @@ export class QuizDialog {
     }).setOrigin(0.5, 0);
     this.container.add(title);
 
-    // Animate title
     if (passed) {
       this.scene.tweens.add({
         targets: title, scaleX: 1.15, scaleY: 1.15,
@@ -463,7 +435,6 @@ export class QuizDialog {
 
     curY += 50;
 
-    // Score
     const scoreText = this.scene.add.text(
       GAME_WIDTH / 2, curY,
       `Score:  ${this.score} / ${total}`,
@@ -473,7 +444,6 @@ export class QuizDialog {
 
     curY += 40;
 
-    // AU reward
     if (passed && auAwarded > 0) {
       const auText = this.scene.add.text(
         GAME_WIDTH / 2, curY,
@@ -482,7 +452,6 @@ export class QuizDialog {
       ).setOrigin(0.5, 0);
       this.container.add(auText);
 
-      // Gold pulsing glow
       this.scene.tweens.add({
         targets: auText, alpha: { from: 1, to: 0.6 },
         duration: 600, yoyo: true, repeat: 2, ease: 'Sine.easeInOut',
@@ -490,7 +459,6 @@ export class QuizDialog {
 
       curY += 40;
 
-      // Camera flash
       this.scene.cameras.main.flash(200, 255, 215, 0);
     } else if (passed && this.alreadyPassed) {
       const alreadyText = this.scene.add.text(
@@ -510,12 +478,10 @@ export class QuizDialog {
       curY += 40;
     }
 
-    // Particle burst on pass
     if (passed) {
       this.spawnCelebrationParticles();
     }
 
-    // Close button
     const closeBtn = this.scene.add.text(GAME_WIDTH / 2, curY + 10, '[  CLOSE  ]', {
       fontFamily: 'monospace', fontSize: '16px', color: '#00d4ff', fontStyle: 'bold',
     }).setOrigin(0.5, 0).setInteractive({ useHandCursor: true });
@@ -527,7 +493,6 @@ export class QuizDialog {
   }
 
   private spawnCelebrationParticles(): void {
-    // Create a small texture for particles if it doesn't exist
     if (!this.scene.textures.exists('quiz_particle')) {
       const g = this.scene.add.graphics();
       g.fillStyle(0xffffff);
@@ -553,7 +518,6 @@ export class QuizDialog {
 
     emitter.explode(30);
 
-    // Clean up after particles die
     this.scene.time.delayedCall(1500, () => {
       emitter.destroy();
     });

--- a/src/ui/QuizDialog.ts
+++ b/src/ui/QuizDialog.ts
@@ -1,0 +1,590 @@
+import * as Phaser from 'phaser';
+import { GAME_WIDTH, GAME_HEIGHT, FloorId } from '../config/gameConfig';
+import { QuizQuestion, QuizDifficulty, QUIZ_DATA, QUIZ_REWARDS, QUIZ_QUESTION_COUNT } from '../config/quizData';
+import { ProgressionSystem } from '../systems/ProgressionSystem';
+import { saveQuizResult, isQuizPassed } from '../systems/QuizManager';
+import { eventBus } from '../systems/EventBus';
+
+export interface QuizDialogOptions {
+  infoId: string;
+  floorId: FloorId;
+  progression: ProgressionSystem;
+  onClose?: () => void;
+}
+
+/**
+ * Multiple-choice quiz overlay.
+ *
+ * Follows the same Phaser Container + overlay pattern as InfoDialog:
+ * depth 200, scrollFactor 0, fade in/out tweens.
+ */
+export class QuizDialog {
+  private scene: Phaser.Scene;
+  private container: Phaser.GameObjects.Container;
+  private options: QuizDialogOptions;
+  private questions: QuizQuestion[];
+  private currentIndex = 0;
+  private score = 0;
+  private answered = false;
+  private destroyed = false;
+  private escKey: Phaser.Input.Keyboard.Key | null = null;
+  private escHandler: (() => void) | null = null;
+  private alreadyPassed: boolean;
+
+  constructor(scene: Phaser.Scene, options: QuizDialogOptions) {
+    this.scene = scene;
+    this.options = options;
+    this.alreadyPassed = isQuizPassed(options.infoId);
+    this.questions = this.selectQuestions(options.infoId);
+
+    this.container = scene.add.container(0, 0);
+    this.container.setDepth(200);
+    this.container.setScrollFactor(0);
+    this.container.setAlpha(0);
+
+    this.buildOverlay();
+    this.showQuestion();
+    this.registerEscKey();
+
+    scene.tweens.add({ targets: this.container, alpha: 1, duration: 200 });
+  }
+
+  /** Pick 1 easy + 1 medium + 1 hard from the question pool. */
+  private selectQuestions(infoId: string): QuizQuestion[] {
+    const def = QUIZ_DATA[infoId];
+    if (!def) return [];
+
+    const byDiff: Record<QuizDifficulty, QuizQuestion[]> = { easy: [], medium: [], hard: [] };
+    for (const q of def.questions) {
+      byDiff[q.difficulty].push(q);
+    }
+
+    const pick = (arr: QuizQuestion[]): QuizQuestion =>
+      arr[Math.floor(Math.random() * arr.length)];
+
+    const selected: QuizQuestion[] = [];
+    if (byDiff.easy.length) selected.push(pick(byDiff.easy));
+    if (byDiff.medium.length) selected.push(pick(byDiff.medium));
+    if (byDiff.hard.length) selected.push(pick(byDiff.hard));
+    return selected;
+  }
+
+  private buildOverlay(): void {
+    const overlay = this.scene.add.rectangle(
+      GAME_WIDTH / 2, GAME_HEIGHT / 2,
+      GAME_WIDTH, GAME_HEIGHT,
+      0x000000, 0.65,
+    );
+    overlay.setInteractive(); // block clicks through
+    this.container.add(overlay);
+  }
+
+  private clearPanel(): void {
+    // Remove everything except the overlay (index 0)
+    while (this.container.length > 1) {
+      this.container.removeAt(1, true);
+    }
+  }
+
+  /* ---- question rendering ---- */
+
+  private showQuestion(): void {
+    this.clearPanel();
+    this.answered = false;
+
+    const q = this.questions[this.currentIndex];
+    if (!q) { this.showResults(); return; }
+
+    const PANEL_W = 620;
+    const PADDING = 32;
+    const panelX = (GAME_WIDTH - PANEL_W) / 2;
+    const CHOICE_H = 52;
+    const CHOICE_GAP = 8;
+
+    // Measure question text height
+    const qMeasure = this.scene.make.text({
+      x: 0, y: 0,
+      text: q.question,
+      style: { fontFamily: 'monospace', fontSize: '16px', color: '#c0c8d4',
+        wordWrap: { width: PANEL_W - PADDING * 2 }, lineSpacing: 6 },
+      add: false,
+    });
+    const qHeight = qMeasure.height;
+    qMeasure.destroy();
+
+    // Calculate panel height
+    const headerH = 70;
+    const choicesH = 4 * CHOICE_H + 3 * CHOICE_GAP;
+    const closeBarH = 44;
+    const panelH = Math.min(headerH + qHeight + 20 + choicesH + closeBarH + PADDING * 2, GAME_HEIGHT - 40);
+    const panelY = Math.max(20, (GAME_HEIGHT - panelH) / 2);
+
+    // Panel background
+    const bg = this.scene.add.graphics();
+    bg.fillStyle(0x0a0a2a, 0.95);
+    bg.fillRoundedRect(panelX, panelY, PANEL_W, panelH, 10);
+    bg.lineStyle(2, 0x00aaff, 0.7);
+    bg.strokeRoundedRect(panelX, panelY, PANEL_W, panelH, 10);
+    this.container.add(bg);
+
+    let curY = panelY + PADDING;
+
+    // Header: "Question X / N"
+    const header = this.scene.add.text(
+      GAME_WIDTH / 2, curY,
+      `Question ${this.currentIndex + 1} / ${this.questions.length}`,
+      { fontFamily: 'monospace', fontSize: '22px', color: '#00d4ff', fontStyle: 'bold' },
+    ).setOrigin(0.5, 0);
+    this.container.add(header);
+
+    // Difficulty badge
+    const diffColors: Record<QuizDifficulty, string> = {
+      easy: '#44ff88', medium: '#ffdd44', hard: '#ff6644',
+    };
+    const badge = this.scene.add.text(
+      GAME_WIDTH / 2, curY + 30,
+      `[${q.difficulty.toUpperCase()}]`,
+      { fontFamily: 'monospace', fontSize: '13px', color: diffColors[q.difficulty], fontStyle: 'bold' },
+    ).setOrigin(0.5, 0);
+    this.container.add(badge);
+
+    curY += headerH;
+
+    // Question text
+    const qText = this.scene.add.text(panelX + PADDING, curY, q.question, {
+      fontFamily: 'monospace', fontSize: '16px', color: '#c0c8d4',
+      wordWrap: { width: PANEL_W - PADDING * 2 }, lineSpacing: 6,
+    });
+    this.container.add(qText);
+    curY += qHeight + 20;
+
+    // Answer choices
+    for (let i = 0; i < q.choices.length; i++) {
+      const choiceY = curY + i * (CHOICE_H + CHOICE_GAP);
+      this.createChoiceButton(panelX + PADDING, choiceY, PANEL_W - PADDING * 2, CHOICE_H, i, q);
+    }
+
+    // X button
+    const xBtn = this.scene.add.text(panelX + PANEL_W - 18, panelY + 10, 'X', {
+      fontFamily: 'monospace', fontSize: '16px', color: '#556677', fontStyle: 'bold',
+    }).setOrigin(0.5, 0).setInteractive({ useHandCursor: true });
+    xBtn.on('pointerover', () => xBtn.setColor('#ff6666'));
+    xBtn.on('pointerout', () => xBtn.setColor('#556677'));
+    xBtn.on('pointerdown', () => this.close());
+    this.container.add(xBtn);
+  }
+
+  private createChoiceButton(
+    x: number, y: number, w: number, h: number,
+    index: number, question: QuizQuestion,
+  ): void {
+    const prefix = String.fromCharCode(65 + index); // A, B, C, D
+    const label = `${prefix}.  ${question.choices[index]}`;
+
+    const btnBg = this.scene.add.graphics();
+    btnBg.fillStyle(0x1a2a3a, 1);
+    btnBg.fillRoundedRect(x, y, w, h, 6);
+    btnBg.lineStyle(1, 0x2a4a6a, 0.6);
+    btnBg.strokeRoundedRect(x, y, w, h, 6);
+    this.container.add(btnBg);
+
+    const btnText = this.scene.add.text(x + 16, y + h / 2, label, {
+      fontFamily: 'monospace', fontSize: '14px', color: '#c0c8d4',
+      wordWrap: { width: w - 32 },
+    }).setOrigin(0, 0.5);
+    this.container.add(btnText);
+
+    // Hit area
+    const hitArea = this.scene.add.rectangle(x + w / 2, y + h / 2, w, h)
+      .setInteractive({ useHandCursor: true })
+      .setAlpha(0.001);
+    this.container.add(hitArea);
+
+    hitArea.on('pointerover', () => {
+      if (this.answered) return;
+      btnBg.clear();
+      btnBg.fillStyle(0x2a4a6a, 1);
+      btnBg.fillRoundedRect(x, y, w, h, 6);
+      btnBg.lineStyle(1, 0x4a6a8a, 0.8);
+      btnBg.strokeRoundedRect(x, y, w, h, 6);
+      btnText.setColor('#ffffff');
+    });
+
+    hitArea.on('pointerout', () => {
+      if (this.answered) return;
+      btnBg.clear();
+      btnBg.fillStyle(0x1a2a3a, 1);
+      btnBg.fillRoundedRect(x, y, w, h, 6);
+      btnBg.lineStyle(1, 0x2a4a6a, 0.6);
+      btnBg.strokeRoundedRect(x, y, w, h, 6);
+      btnText.setColor('#c0c8d4');
+    });
+
+    hitArea.on('pointerdown', () => {
+      if (this.answered) return;
+      this.onAnswer(index, question);
+    });
+  }
+
+  private onAnswer(selectedIndex: number, question: QuizQuestion): void {
+    this.answered = true;
+    const correct = selectedIndex === question.correctIndex;
+    if (correct) this.score++;
+
+    // Play sound
+    eventBus.emit(correct ? 'sfx:quiz_correct' : 'sfx:quiz_wrong');
+
+    // Rebuild panel to show result state
+    this.showAnswerFeedback(question, selectedIndex);
+  }
+
+  private showAnswerFeedback(question: QuizQuestion, selectedIndex: number): void {
+    this.clearPanel();
+
+    const correct = selectedIndex === question.correctIndex;
+    const PANEL_W = 620;
+    const PADDING = 32;
+    const panelX = (GAME_WIDTH - PANEL_W) / 2;
+    const CHOICE_H = 52;
+    const CHOICE_GAP = 8;
+
+    // Measure question + explanation text
+    const qMeasure = this.scene.make.text({
+      x: 0, y: 0, text: question.question,
+      style: { fontFamily: 'monospace', fontSize: '16px', color: '#c0c8d4',
+        wordWrap: { width: PANEL_W - PADDING * 2 }, lineSpacing: 6 },
+      add: false,
+    });
+    const qHeight = qMeasure.height;
+    qMeasure.destroy();
+
+    const expMeasure = this.scene.make.text({
+      x: 0, y: 0, text: question.explanation,
+      style: { fontFamily: 'monospace', fontSize: '13px', color: '#8899aa',
+        wordWrap: { width: PANEL_W - PADDING * 2 - 12 }, lineSpacing: 4 },
+      add: false,
+    });
+    const expHeight = expMeasure.height;
+    expMeasure.destroy();
+
+    const headerH = 70;
+    const choicesH = 4 * CHOICE_H + 3 * CHOICE_GAP;
+    const explanationH = expHeight + 24;
+    const nextBtnH = 52;
+    const panelH = Math.min(
+      headerH + qHeight + 20 + choicesH + explanationH + nextBtnH + PADDING * 2,
+      GAME_HEIGHT - 40,
+    );
+    const panelY = Math.max(20, (GAME_HEIGHT - panelH) / 2);
+
+    // Panel background
+    const bg = this.scene.add.graphics();
+    bg.fillStyle(0x0a0a2a, 0.95);
+    bg.fillRoundedRect(panelX, panelY, PANEL_W, panelH, 10);
+    bg.lineStyle(2, correct ? 0x44ff88 : 0xff4444, 0.7);
+    bg.strokeRoundedRect(panelX, panelY, PANEL_W, panelH, 10);
+    this.container.add(bg);
+
+    let curY = panelY + PADDING;
+
+    // Result header
+    const diffColors: Record<QuizDifficulty, string> = {
+      easy: '#44ff88', medium: '#ffdd44', hard: '#ff6644',
+    };
+    const resultText = correct ? 'Correct!' : 'Wrong!';
+    const resultColor = correct ? '#44ff88' : '#ff6644';
+
+    const header = this.scene.add.text(
+      GAME_WIDTH / 2, curY, resultText,
+      { fontFamily: 'monospace', fontSize: '22px', color: resultColor, fontStyle: 'bold' },
+    ).setOrigin(0.5, 0);
+    this.container.add(header);
+
+    const badge = this.scene.add.text(
+      GAME_WIDTH / 2, curY + 30,
+      `Question ${this.currentIndex + 1} / ${this.questions.length}  [${question.difficulty.toUpperCase()}]`,
+      { fontFamily: 'monospace', fontSize: '13px', color: diffColors[question.difficulty] },
+    ).setOrigin(0.5, 0);
+    this.container.add(badge);
+
+    curY += headerH;
+
+    // Question text
+    const qText = this.scene.add.text(panelX + PADDING, curY, question.question, {
+      fontFamily: 'monospace', fontSize: '16px', color: '#8899aa',
+      wordWrap: { width: PANEL_W - PADDING * 2 }, lineSpacing: 6,
+    });
+    this.container.add(qText);
+    curY += qHeight + 20;
+
+    // Answer choices (with correct/wrong indicators)
+    for (let i = 0; i < question.choices.length; i++) {
+      const choiceY = curY + i * (CHOICE_H + CHOICE_GAP);
+      const prefix = String.fromCharCode(65 + i);
+      const isCorrect = i === question.correctIndex;
+      const isSelected = i === selectedIndex;
+
+      let fillColor = 0x1a2a3a;
+      let borderColor = 0x2a4a6a;
+      let textColor = '#667788';
+
+      if (isCorrect) {
+        fillColor = 0x1a4a2a;
+        borderColor = 0x44ff88;
+        textColor = '#44ff88';
+      } else if (isSelected && !isCorrect) {
+        fillColor = 0x4a1a1a;
+        borderColor = 0xff4444;
+        textColor = '#ff6644';
+      }
+
+      const btnBg = this.scene.add.graphics();
+      btnBg.fillStyle(fillColor, 1);
+      btnBg.fillRoundedRect(panelX + PADDING, choiceY, PANEL_W - PADDING * 2, CHOICE_H, 6);
+      btnBg.lineStyle(isCorrect || isSelected ? 2 : 1, borderColor, isCorrect || isSelected ? 1 : 0.6);
+      btnBg.strokeRoundedRect(panelX + PADDING, choiceY, PANEL_W - PADDING * 2, CHOICE_H, 6);
+      this.container.add(btnBg);
+
+      const marker = isCorrect ? '\u2713' : (isSelected ? '\u2717' : ' ');
+      const btnText = this.scene.add.text(
+        panelX + PADDING + 16, choiceY + CHOICE_H / 2,
+        `${prefix}. ${marker} ${question.choices[i]}`,
+        { fontFamily: 'monospace', fontSize: '14px', color: textColor,
+          wordWrap: { width: PANEL_W - PADDING * 2 - 32 } },
+      ).setOrigin(0, 0.5);
+      this.container.add(btnText);
+    }
+
+    curY += 4 * CHOICE_H + 3 * CHOICE_GAP + 16;
+
+    // Explanation
+    const expText = this.scene.add.text(panelX + PADDING + 6, curY, question.explanation, {
+      fontFamily: 'monospace', fontSize: '13px', color: '#8899aa',
+      wordWrap: { width: PANEL_W - PADDING * 2 - 12 }, lineSpacing: 4,
+    });
+    this.container.add(expText);
+
+    // Left border for explanation
+    const expBorder = this.scene.add.graphics();
+    expBorder.fillStyle(correct ? 0x44ff88 : 0xff4444, 0.6);
+    expBorder.fillRect(panelX + PADDING, curY - 2, 3, expHeight + 4);
+    this.container.add(expBorder);
+
+    curY += explanationH;
+
+    // Next button
+    const isLast = this.currentIndex >= this.questions.length - 1;
+    const nextLabel = isLast ? '[  SEE RESULTS  ]' : '[  NEXT QUESTION  ]';
+
+    const nextBtn = this.scene.add.text(GAME_WIDTH / 2, curY, nextLabel, {
+      fontFamily: 'monospace', fontSize: '16px', color: '#00d4ff', fontStyle: 'bold',
+    }).setOrigin(0.5, 0).setInteractive({ useHandCursor: true });
+
+    nextBtn.on('pointerover', () => nextBtn.setColor('#88ddff'));
+    nextBtn.on('pointerout', () => nextBtn.setColor('#00d4ff'));
+    nextBtn.on('pointerdown', () => {
+      this.currentIndex++;
+      if (this.currentIndex < this.questions.length) {
+        this.showQuestion();
+      } else {
+        this.showResults();
+      }
+    });
+    this.container.add(nextBtn);
+
+    // X button
+    const xBtn = this.scene.add.text(panelX + PANEL_W - 18, panelY + 10, 'X', {
+      fontFamily: 'monospace', fontSize: '16px', color: '#556677', fontStyle: 'bold',
+    }).setOrigin(0.5, 0).setInteractive({ useHandCursor: true });
+    xBtn.on('pointerover', () => xBtn.setColor('#ff6666'));
+    xBtn.on('pointerout', () => xBtn.setColor('#556677'));
+    xBtn.on('pointerdown', () => this.close());
+    this.container.add(xBtn);
+  }
+
+  /* ---- results ---- */
+
+  private showResults(): void {
+    this.clearPanel();
+
+    const total = this.questions.length;
+    const passed = this.score >= 2;
+    const perfect = this.score === total;
+
+    // Save result
+    saveQuizResult(this.options.infoId, this.score, total);
+
+    // Award AU only if this is the first pass
+    let auAwarded = 0;
+    if (passed && !this.alreadyPassed) {
+      auAwarded = perfect ? QUIZ_REWARDS.perfect : QUIZ_REWARDS.pass;
+      for (let i = 0; i < auAwarded; i++) {
+        this.options.progression.collectAU(this.options.floorId);
+      }
+    }
+
+    // Play sound
+    eventBus.emit(passed ? 'sfx:quiz_success' : 'sfx:quiz_fail');
+
+    const PANEL_W = 620;
+    const PADDING = 32;
+    const panelX = (GAME_WIDTH - PANEL_W) / 2;
+    const panelH = passed ? 340 : 280;
+    const panelY = (GAME_HEIGHT - panelH) / 2;
+
+    // Panel background
+    const bg = this.scene.add.graphics();
+    bg.fillStyle(0x0a0a2a, 0.95);
+    bg.fillRoundedRect(panelX, panelY, PANEL_W, panelH, 10);
+    bg.lineStyle(2, passed ? 0xffd700 : 0xff4444, 0.7);
+    bg.strokeRoundedRect(panelX, panelY, PANEL_W, panelH, 10);
+    this.container.add(bg);
+
+    let curY = panelY + PADDING;
+
+    // Result title
+    const titleText = passed
+      ? (perfect ? 'PERFECT SCORE!' : 'QUIZ PASSED!')
+      : 'NOT QUITE...';
+    const titleColor = passed ? '#ffd700' : '#ff6644';
+
+    const title = this.scene.add.text(GAME_WIDTH / 2, curY, titleText, {
+      fontFamily: 'monospace', fontSize: '28px', color: titleColor, fontStyle: 'bold',
+    }).setOrigin(0.5, 0);
+    this.container.add(title);
+
+    // Animate title
+    if (passed) {
+      this.scene.tweens.add({
+        targets: title, scaleX: 1.15, scaleY: 1.15,
+        duration: 300, yoyo: true, repeat: 1, ease: 'Sine.easeInOut',
+      });
+    }
+
+    curY += 50;
+
+    // Score
+    const scoreText = this.scene.add.text(
+      GAME_WIDTH / 2, curY,
+      `Score:  ${this.score} / ${total}`,
+      { fontFamily: 'monospace', fontSize: '20px', color: '#c0c8d4' },
+    ).setOrigin(0.5, 0);
+    this.container.add(scoreText);
+
+    curY += 40;
+
+    // AU reward
+    if (passed && auAwarded > 0) {
+      const auText = this.scene.add.text(
+        GAME_WIDTH / 2, curY,
+        `+${auAwarded} AU Earned!`,
+        { fontFamily: 'monospace', fontSize: '22px', color: '#ffd700', fontStyle: 'bold' },
+      ).setOrigin(0.5, 0);
+      this.container.add(auText);
+
+      // Gold pulsing glow
+      this.scene.tweens.add({
+        targets: auText, alpha: { from: 1, to: 0.6 },
+        duration: 600, yoyo: true, repeat: 2, ease: 'Sine.easeInOut',
+      });
+
+      curY += 40;
+
+      // Camera flash
+      this.scene.cameras.main.flash(200, 255, 215, 0);
+    } else if (passed && this.alreadyPassed) {
+      const alreadyText = this.scene.add.text(
+        GAME_WIDTH / 2, curY,
+        'Quiz already completed \u2014 no additional AU',
+        { fontFamily: 'monospace', fontSize: '14px', color: '#556677' },
+      ).setOrigin(0.5, 0);
+      this.container.add(alreadyText);
+      curY += 40;
+    } else {
+      const failHint = this.scene.add.text(
+        GAME_WIDTH / 2, curY,
+        'Read the info text and try again!',
+        { fontFamily: 'monospace', fontSize: '15px', color: '#8899aa' },
+      ).setOrigin(0.5, 0);
+      this.container.add(failHint);
+      curY += 40;
+    }
+
+    // Particle burst on pass
+    if (passed) {
+      this.spawnCelebrationParticles();
+    }
+
+    // Close button
+    const closeBtn = this.scene.add.text(GAME_WIDTH / 2, curY + 10, '[  CLOSE  ]', {
+      fontFamily: 'monospace', fontSize: '16px', color: '#00d4ff', fontStyle: 'bold',
+    }).setOrigin(0.5, 0).setInteractive({ useHandCursor: true });
+
+    closeBtn.on('pointerover', () => closeBtn.setColor('#88ddff'));
+    closeBtn.on('pointerout', () => closeBtn.setColor('#00d4ff'));
+    closeBtn.on('pointerdown', () => this.close());
+    this.container.add(closeBtn);
+  }
+
+  private spawnCelebrationParticles(): void {
+    // Create a small texture for particles if it doesn't exist
+    if (!this.scene.textures.exists('quiz_particle')) {
+      const g = this.scene.add.graphics();
+      g.fillStyle(0xffffff);
+      g.fillRect(0, 0, 6, 6);
+      g.generateTexture('quiz_particle', 6, 6);
+      g.destroy();
+    }
+
+    const cx = GAME_WIDTH / 2;
+    const cy = GAME_HEIGHT / 2 - 40;
+
+    const emitter = this.scene.add.particles(cx, cy, 'quiz_particle', {
+      speed: { min: 80, max: 250 },
+      angle: { min: 0, max: 360 },
+      scale: { start: 1.2, end: 0 },
+      lifespan: 1200,
+      quantity: 30,
+      tint: [0xffd700, 0xffed4a, 0x00d4ff, 0x44ff88, 0xff6644],
+      gravityY: 120,
+      emitting: false,
+    });
+    emitter.setDepth(201);
+
+    emitter.explode(30);
+
+    // Clean up after particles die
+    this.scene.time.delayedCall(1500, () => {
+      emitter.destroy();
+    });
+  }
+
+  /* ---- lifecycle ---- */
+
+  private registerEscKey(): void {
+    if (!this.scene.input.keyboard) return;
+    this.escKey = this.scene.input.keyboard.addKey(Phaser.Input.Keyboard.KeyCodes.ESC);
+    this.escHandler = () => {
+      if (this.escKey?.isDown) this.close();
+    };
+    this.scene.events.on('update', this.escHandler);
+  }
+
+  close(): void {
+    if (this.destroyed) return;
+    this.destroyed = true;
+    if (this.escHandler) {
+      this.scene.events.off('update', this.escHandler);
+    }
+    if (this.escKey) {
+      this.escKey.destroy();
+    }
+    this.scene.tweens.add({
+      targets: this.container, alpha: 0, duration: 150,
+      onComplete: () => {
+        this.container.destroy();
+        this.options.onClose?.();
+      },
+    });
+  }
+}

--- a/src/ui/QuizDialog.ts
+++ b/src/ui/QuizDialog.ts
@@ -1,6 +1,6 @@
 import * as Phaser from 'phaser';
 import { GAME_WIDTH, GAME_HEIGHT, FloorId } from '../config/gameConfig';
-import { QuizQuestion, QuizDifficulty, QUIZ_DATA, QUIZ_REWARDS, QUIZ_QUESTION_COUNT } from '../config/quizData';
+import { QuizQuestion, QuizDifficulty, QUIZ_DATA, QUIZ_REWARDS, QUIZ_PASS_THRESHOLD } from '../config/quizData';
 import { ProgressionSystem } from '../systems/ProgressionSystem';
 import { saveQuizResult, isQuizPassed } from '../systems/QuizManager';
 import { eventBus } from '../systems/EventBus';
@@ -385,18 +385,16 @@ export class QuizDialog {
     this.clearPanel();
 
     const total = this.questions.length;
-    const passed = this.score >= 2;
+    const passed = this.score >= QUIZ_PASS_THRESHOLD;
     const perfect = this.score === total;
 
-    saveQuizResult(this.options.infoId, this.score, total);
+    saveQuizResult(this.options.infoId, this.score);
 
     // AU only awarded on first pass
     let auAwarded = 0;
     if (passed && !this.alreadyPassed) {
       auAwarded = perfect ? QUIZ_REWARDS.perfect : QUIZ_REWARDS.pass;
-      for (let i = 0; i < auAwarded; i++) {
-        this.options.progression.collectAU(this.options.floorId);
-      }
+      this.options.progression.addAU(this.options.floorId, auAwarded);
     }
 
     eventBus.emit(passed ? 'sfx:quiz_success' : 'sfx:quiz_fail');


### PR DESCRIPTION
Implement a quiz system where each info point has a set of multiple-choice
questions at three difficulty levels (easy, medium, hard). Players can take
a quiz after reading an info dialog, earn AU on success (3 AU for passing,
5 AU for perfect), and retry after a 30-second cooldown.

New files:
- config/infoContent.ts: Centralized info point content with extended "deep dive" sections
- config/quizData.ts: 9+ questions per info point (3 per difficulty level)
- systems/QuizManager.ts: Quiz state persistence and cooldown tracking via localStorage
- ui/QuizDialog.ts: Multiple-choice quiz overlay with answer feedback and results

Changes:
- InfoDialog: Extended info collapsible section, "Take Quiz" button with cooldown timer
- InfoIcon: Quiz status badge (gold ? for available, green check for passed)
- SoundGenerator: 4 new procedural sounds (correct ding, wrong buzz, success fanfare, fail tone)
- HubScene: Uses centralized info content, wires quiz flow
- LevelScene: Info point support in base class with quiz integration
- Floor1Scene/Floor2Scene: Info point positions for Platform Engineering and Cloud Architecture

https://claude.ai/code/session_01TxRh28CQDvRandVP35ZFKg