### PR TITLE
claude/fix-info-dialog-links-LS818

### DIFF
--- a/src/ui/InfoDialog.ts
+++ b/src/ui/InfoDialog.ts
@@ -65,7 +65,7 @@ export class InfoDialog {
       GAME_WIDTH, GAME_HEIGHT,
       0x000000, 0.65,
     );
-    overlay.setInteractive();
+    overlay.setScrollFactor(0).setInteractive();
     this.container.add(overlay);
   }
 
@@ -137,7 +137,7 @@ export class InfoDialog {
       for (const link of content.links) {
         const linkText = this.scene.add.text(panelX + PADDING + 10, curY, `\u25b8 ${link.label}`, {
           fontFamily: 'monospace', fontSize: '14px', color: '#44aaff',
-        }).setInteractive({ useHandCursor: true });
+        }).setScrollFactor(0).setInteractive({ useHandCursor: true });
 
         linkText.on('pointerover', () => linkText.setColor('#88ddff'));
         linkText.on('pointerout', () => linkText.setColor('#44aaff'));
@@ -157,7 +157,7 @@ export class InfoDialog {
       const toggleY = curY;
       const toggleText = this.scene.add.text(panelX + PADDING, toggleY, '[+]  Deep Dive', {
         fontFamily: 'monospace', fontSize: '14px', color: '#00aaff', fontStyle: 'bold',
-      }).setInteractive({ useHandCursor: true });
+      }).setScrollFactor(0).setInteractive({ useHandCursor: true });
       this.container.add(toggleText);
 
       toggleText.on('pointerover', () => toggleText.setColor('#88ddff'));
@@ -246,7 +246,7 @@ export class InfoDialog {
 
       const quizBtn = this.scene.add.text(GAME_WIDTH / 2, curY, quizLabel, {
         fontFamily: 'monospace', fontSize: '15px', color: quizColor, fontStyle: 'bold',
-      }).setOrigin(0.5, 0);
+      }).setOrigin(0.5, 0).setScrollFactor(0);
       this.container.add(quizBtn);
 
       if (clickable) {
@@ -294,7 +294,7 @@ export class InfoDialog {
     curY = panelY + panelH - CLOSE_BAR_H - 4;
     const closeText = this.scene.add.text(GAME_WIDTH / 2, curY, '[ESC]  Close', {
       fontFamily: 'monospace', fontSize: '14px', color: '#556677',
-    }).setOrigin(0.5, 0).setInteractive({ useHandCursor: true });
+    }).setOrigin(0.5, 0).setScrollFactor(0).setInteractive({ useHandCursor: true });
 
     closeText.on('pointerover', () => closeText.setColor('#88aacc'));
     closeText.on('pointerout', () => closeText.setColor('#556677'));
@@ -303,7 +303,7 @@ export class InfoDialog {
 
     const xBtn = this.scene.add.text(panelX + panelW - 18, panelY + 10, 'X', {
       fontFamily: 'monospace', fontSize: '16px', color: '#556677', fontStyle: 'bold',
-    }).setOrigin(0.5, 0).setInteractive({ useHandCursor: true });
+    }).setOrigin(0.5, 0).setScrollFactor(0).setInteractive({ useHandCursor: true });
 
     xBtn.on('pointerover', () => xBtn.setColor('#ff6666'));
     xBtn.on('pointerout', () => xBtn.setColor('#556677'));

--- a/src/ui/InfoDialog.ts
+++ b/src/ui/InfoDialog.ts
@@ -150,6 +150,9 @@ export class InfoDialog {
       }
     }
 
+    let quizBtnRef: Phaser.GameObjects.Text | null = null;
+    let closeTextRef: Phaser.GameObjects.Text | null = null;
+
     if (hasExtended && content.extendedInfo) {
       const extInfo = content.extendedInfo;
       curY += 4;
@@ -178,6 +181,7 @@ export class InfoDialog {
 
       toggleText.on('pointerdown', () => {
         this.extendedExpanded = !this.extendedExpanded;
+        const shift = extBodyH + 36;
 
         if (this.extendedExpanded) {
           toggleText.setText('[-]  Deep Dive');
@@ -203,6 +207,9 @@ export class InfoDialog {
 
           extContainer.setVisible(true);
 
+          if (quizBtnRef) quizBtnRef.y += shift;
+          if (closeTextRef) closeTextRef.y += shift;
+
           const newPanelH = Math.min(panelH + extBodyH + 36, MAX_PANEL_H);
           bg.clear();
           bg.fillStyle(0x0a0a2a, 0.95);
@@ -213,6 +220,9 @@ export class InfoDialog {
           toggleText.setText('[+]  Deep Dive');
           extContainer.removeAll(true);
           extContainer.setVisible(false);
+
+          if (quizBtnRef) quizBtnRef.y -= shift;
+          if (closeTextRef) closeTextRef.y -= shift;
 
           bg.clear();
           bg.fillStyle(0x0a0a2a, 0.95);
@@ -247,6 +257,7 @@ export class InfoDialog {
       const quizBtn = this.scene.add.text(GAME_WIDTH / 2, curY, quizLabel, {
         fontFamily: 'monospace', fontSize: '15px', color: quizColor, fontStyle: 'bold',
       }).setOrigin(0.5, 0).setScrollFactor(0);
+      quizBtnRef = quizBtn;
       this.container.add(quizBtn);
 
       if (clickable) {
@@ -295,6 +306,7 @@ export class InfoDialog {
     const closeText = this.scene.add.text(GAME_WIDTH / 2, curY, '[ESC]  Close', {
       fontFamily: 'monospace', fontSize: '14px', color: '#556677',
     }).setOrigin(0.5, 0).setScrollFactor(0).setInteractive({ useHandCursor: true });
+    closeTextRef = closeText;
 
     closeText.on('pointerover', () => closeText.setColor('#88aacc'));
     closeText.on('pointerout', () => closeText.setColor('#556677'));

--- a/src/ui/InfoDialog.ts
+++ b/src/ui/InfoDialog.ts
@@ -181,7 +181,7 @@ export class InfoDialog {
 
       toggleText.on('pointerdown', () => {
         this.extendedExpanded = !this.extendedExpanded;
-        const shift = extBodyH + 36;
+        const shift = Math.min(extBodyH + 36, MAX_PANEL_H - panelH);
 
         if (this.extendedExpanded) {
           toggleText.setText('[-]  Deep Dive');

--- a/src/ui/QuizDialog.ts
+++ b/src/ui/QuizDialog.ts
@@ -75,7 +75,7 @@ export class QuizDialog {
       GAME_WIDTH, GAME_HEIGHT,
       0x000000, 0.65,
     );
-    overlay.setInteractive(); // block clicks through
+    overlay.setScrollFactor(0).setInteractive(); // block clicks through
     this.container.add(overlay);
   }
 
@@ -159,7 +159,7 @@ export class QuizDialog {
 
     const xBtn = this.scene.add.text(panelX + PANEL_W - 18, panelY + 10, 'X', {
       fontFamily: 'monospace', fontSize: '16px', color: '#556677', fontStyle: 'bold',
-    }).setOrigin(0.5, 0).setInteractive({ useHandCursor: true });
+    }).setOrigin(0.5, 0).setScrollFactor(0).setInteractive({ useHandCursor: true });
     xBtn.on('pointerover', () => xBtn.setColor('#ff6666'));
     xBtn.on('pointerout', () => xBtn.setColor('#556677'));
     xBtn.on('pointerdown', () => this.close());
@@ -187,6 +187,7 @@ export class QuizDialog {
     this.container.add(btnText);
 
     const hitArea = this.scene.add.rectangle(x + w / 2, y + h / 2, w, h)
+      .setScrollFactor(0)
       .setInteractive({ useHandCursor: true })
       .setAlpha(0.001);
     this.container.add(hitArea);
@@ -358,7 +359,7 @@ export class QuizDialog {
 
     const nextBtn = this.scene.add.text(GAME_WIDTH / 2, curY, nextLabel, {
       fontFamily: 'monospace', fontSize: '16px', color: '#00d4ff', fontStyle: 'bold',
-    }).setOrigin(0.5, 0).setInteractive({ useHandCursor: true });
+    }).setOrigin(0.5, 0).setScrollFactor(0).setInteractive({ useHandCursor: true });
 
     nextBtn.on('pointerover', () => nextBtn.setColor('#88ddff'));
     nextBtn.on('pointerout', () => nextBtn.setColor('#00d4ff'));
@@ -374,7 +375,7 @@ export class QuizDialog {
 
     const xBtn = this.scene.add.text(panelX + PANEL_W - 18, panelY + 10, 'X', {
       fontFamily: 'monospace', fontSize: '16px', color: '#556677', fontStyle: 'bold',
-    }).setOrigin(0.5, 0).setInteractive({ useHandCursor: true });
+    }).setOrigin(0.5, 0).setScrollFactor(0).setInteractive({ useHandCursor: true });
     xBtn.on('pointerover', () => xBtn.setColor('#ff6666'));
     xBtn.on('pointerout', () => xBtn.setColor('#556677'));
     xBtn.on('pointerdown', () => this.close());
@@ -482,7 +483,7 @@ export class QuizDialog {
 
     const closeBtn = this.scene.add.text(GAME_WIDTH / 2, curY + 10, '[  CLOSE  ]', {
       fontFamily: 'monospace', fontSize: '16px', color: '#00d4ff', fontStyle: 'bold',
-    }).setOrigin(0.5, 0).setInteractive({ useHandCursor: true });
+    }).setOrigin(0.5, 0).setScrollFactor(0).setInteractive({ useHandCursor: true });
 
     closeBtn.on('pointerover', () => closeBtn.setColor('#88ddff'));
     closeBtn.on('pointerout', () => closeBtn.setColor('#00d4ff'));

--- a/src/ui/QuizDialog.ts
+++ b/src/ui/QuizDialog.ts
@@ -514,7 +514,7 @@ export class QuizDialog {
       emitting: false,
     });
     emitter.setDepth(201);
-
+    emitter.setScrollFactor(0);
     emitter.explode(30);
 
     this.scene.time.delayedCall(1500, () => {


### PR DESCRIPTION
In Phaser 3, objects inside a Container inherit the container's
scrollFactor for rendering but NOT for input hit-testing. Child objects
default to scrollFactor(1), so their hit areas are calculated in world
coordinates. When the game camera has scrolled (following the player),
the hit areas were offset from the visible screen positions, making
links, the close button, the X button, and the quiz/deep-dive buttons
unresponsive to clicks.

Fix by calling setScrollFactor(0) on all interactive children (overlay,
link texts, toggleText, quizBtn, closeText, xBtn) so that Phaser uses
screen-space coordinates for hit testing, matching the visual positions.

https://claude.ai/code/session_01QQ3Q8HHVtxMpA3Tue3AHXm