### PR TITLE
feat: load MP3 background music; add info-card + link SFX

### DIFF
--- a/public/music/README.md
+++ b/public/music/README.md
@@ -1,6 +1,13 @@
 # Music Assets
 
-Background music is currently generated procedurally at runtime (see `src/systems/MusicGenerator.ts`). To replace with higher-quality tracks, download CC0/royalty-free MP3s from the sources below and update `BootScene.preload()` to load them via `this.load.audio()` instead of `generateMusic()`.
+Background music is loaded from the MP3 files in this directory:
+
+- `retro-synth/retro_synth.mp3` — default game music (MenuScene, Floor1Scene, Floor2Scene)
+- `elevator-jazz/elevator_jazz.mp3` — elevator shaft (HubScene)
+
+These are loaded in `src/scenes/BootScene.ts` via `this.load.audio(...)`. SFX (jumps, footsteps, quiz feedback, info-card and link clicks) remain procedurally generated in `src/systems/SoundGenerator.ts`.
+
+The procedural music generator `src/systems/MusicGenerator.ts` is retained for reference / fallback but is no longer called.
 
 ## 80s Retro Synth (default game music)
 
@@ -28,16 +35,9 @@ Used in: HubScene (elevator shaft)
 | Archive.org — Elevator Music (Kevin MacLeod, CC0) | https://archive.org/details/elevator-musicchosic.com |
 | Archive.org — Elevator Music Bossa Nova | https://archive.org/details/elevator-music-bossa-nova-background-music-version-60s |
 
-## How to replace procedural music with MP3 files
+## Swapping in a different track
 
-1. Download tracks and save them as `public/music/retro_synth.mp3` and `public/music/elevator_jazz.mp3`
-2. In `src/scenes/BootScene.ts`, replace `generateMusic(this)` with:
-   ```typescript
-   this.load.audio('music_retro_synth', 'music/retro_synth.mp3');
-   this.load.audio('music_elevator_jazz', 'music/elevator_jazz.mp3');
-   ```
-3. Remove the `generateMusic` import from BootScene
-4. Everything else (EventBus, MusicPlugin, AudioManager) works unchanged
+To switch to a different MP3, drop it into the appropriate subdirectory and update the path in `src/scenes/BootScene.ts` (the `this.load.audio(...)` calls in `preload()`). The EventBus, MusicPlugin and AudioManager will pick up the new file with no further changes.
 
 ## Licensing
 

--- a/src/config/audioConfig.ts
+++ b/src/config/audioConfig.ts
@@ -24,6 +24,8 @@ export const SFX_EVENTS: Record<string, string> = {
   'sfx:quiz_wrong':   'quiz_wrong',
   'sfx:quiz_success': 'quiz_success',
   'sfx:quiz_fail':    'quiz_fail',
+  'sfx:info_open':    'info_open',
+  'sfx:link_click':   'link_click',
 };
 
 /** Default volume for background music (0–1). */

--- a/src/scenes/BootScene.ts
+++ b/src/scenes/BootScene.ts
@@ -1,7 +1,6 @@
 import * as Phaser from 'phaser';
 import { generateSprites } from '../systems/SpriteGenerator';
 import { generateSounds } from '../systems/SoundGenerator';
-import { generateMusic } from '../systems/MusicGenerator';
 import { AudioManager } from '../systems/AudioManager';
 import { COLORS } from '../config/gameConfig';
 
@@ -47,9 +46,12 @@ export class BootScene extends Phaser.Scene {
       percentText.destroy();
     });
 
-    // Generate procedural audio and queue for Phaser's loader
+    // Generate procedural SFX and queue for Phaser's loader
     generateSounds(this);
-    generateMusic(this);
+
+    // Background music loads from MP3 files in public/music/
+    this.load.audio('music_retro_synth', 'music/retro-synth/retro_synth.mp3');
+    this.load.audio('music_elevator_jazz', 'music/elevator-jazz/elevator_jazz.mp3');
   }
 
   create(): void {

--- a/src/systems/SoundGenerator.ts
+++ b/src/systems/SoundGenerator.ts
@@ -17,6 +17,8 @@ export function generateSounds(scene: Phaser.Scene): void {
   loadWav(scene, 'quiz_wrong', generateQuizWrongSound());
   loadWav(scene, 'quiz_success', generateQuizSuccessSound());
   loadWav(scene, 'quiz_fail', generateQuizFailSound());
+  loadWav(scene, 'info_open', generateInfoOpenSound());
+  loadWav(scene, 'link_click', generateLinkClickSound());
 }
 
 export function loadWav(scene: Phaser.Scene, key: string, wav: ArrayBuffer): void {
@@ -185,6 +187,46 @@ function generateQuizFailSound(): ArrayBuffer {
     const attack = Math.min(noteProgress * 15, 1);
     const envelope = attack * Math.exp(-noteProgress * 3);
     samples[i] = wave * envelope * 0.2;
+  }
+
+  return encodeWAV(samples, SAMPLE_RATE);
+}
+
+/** Short ascending UI blip — triangle wave for opening an info card. */
+function generateInfoOpenSound(): ArrayBuffer {
+  const duration = 0.1;
+  const numSamples = Math.floor(SAMPLE_RATE * duration);
+  const samples = new Float32Array(numSamples);
+
+  let phase = 0;
+  for (let i = 0; i < numSamples; i++) {
+    const progress = numSamples > 1 ? i / (numSamples - 1) : 1;
+    // Ascending sweep 500 → 800 Hz (triangle wave)
+    const freq = 500 + 300 * progress;
+    phase += (2 * Math.PI * freq) / SAMPLE_RATE;
+    const wave = (2 / Math.PI) * Math.asin(Math.sin(phase));
+    // Linear decay envelope
+    const envelope = 1 - progress;
+    samples[i] = wave * envelope * 0.2;
+  }
+
+  return encodeWAV(samples, SAMPLE_RATE);
+}
+
+/** Short damped click — square wave for link activation. */
+function generateLinkClickSound(): ArrayBuffer {
+  const duration = 0.05;
+  const numSamples = Math.floor(SAMPLE_RATE * duration);
+  const samples = new Float32Array(numSamples);
+
+  let phase = 0;
+  for (let i = 0; i < numSamples; i++) {
+    const progress = numSamples > 1 ? i / (numSamples - 1) : 1;
+    phase += (2 * Math.PI * 1000) / SAMPLE_RATE;
+    const wave = Math.sign(Math.sin(phase));
+    // Exponential decay for a sharp click
+    const envelope = Math.exp(-progress * 12);
+    samples[i] = wave * envelope * 0.15;
   }
 
   return encodeWAV(samples, SAMPLE_RATE);

--- a/src/ui/InfoDialog.ts
+++ b/src/ui/InfoDialog.ts
@@ -1,5 +1,6 @@
 import * as Phaser from 'phaser';
 import { GAME_WIDTH, GAME_HEIGHT } from '../config/gameConfig';
+import { eventBus } from '../systems/EventBus';
 
 export interface InfoDialogLink {
   label: string;
@@ -56,6 +57,7 @@ export class InfoDialog {
     this.buildPanel(content, options);
     this.registerEscKey();
 
+    eventBus.emit('sfx:info_open');
     scene.tweens.add({ targets: this.container, alpha: 1, duration: 200 });
   }
 
@@ -142,6 +144,7 @@ export class InfoDialog {
         linkText.on('pointerover', () => linkText.setColor('#88ddff'));
         linkText.on('pointerout', () => linkText.setColor('#44aaff'));
         linkText.on('pointerdown', () => {
+          eventBus.emit('sfx:link_click');
           window.open(link.url, '_blank', 'noopener,noreferrer');
         });
 


### PR DESCRIPTION
- BootScene now loads retro_synth.mp3 and elevator_jazz.mp3 from
  public/music/ instead of generating music procedurally, so the
  retro synth plays as the default and the elevator jazz plays in
  the HubScene elevator.
- Added two new procedural UI sounds (info_open, link_click) in
  SoundGenerator and wired them to EventBus events via audioConfig.
- InfoDialog now emits sfx:info_open when the card opens and
  sfx:link_click when a link is clicked, keeping sound triggers
  centralized in the dialog itself.