### PR TITLE
refactor: extract ambient plant and signpost helpers to LevelScene

### DIFF
--- a/src/features/floors/_shared/LevelScene.ts
+++ b/src/features/floors/_shared/LevelScene.ts
@@ -290,6 +290,40 @@ export class LevelScene extends Phaser.Scene {
   /* ---- decorations (override in subclass to add floor-specific props) ---- */
   protected createDecorations(): void { /* no-op by default */ }
 
+  /**
+   * Shared decoration helpers used by most floor scenes. Ambient plants and
+   * the entry-signpost follow the same visual contract across rooms, so
+   * they're centralized here and called from subclasses' `createDecorations`.
+   */
+  protected addAmbientPlants(
+    plants: Array<{ x: number; kind: 'tall' | 'small'; depth?: number }>,
+  ): void {
+    const G = GAME_HEIGHT - TILE_SIZE;
+    for (const p of plants) {
+      const yOff = p.kind === 'tall' ? 40 : 32;
+      const depth = p.depth ?? (p.kind === 'tall' ? 3 : 11);
+      this.add.image(p.x, G - yOff, `plant_${p.kind}`).setDepth(depth);
+    }
+  }
+
+  protected addSignpost(opts: {
+    x: number;
+    label: string;
+    color: string;
+    fontSize?: number;
+  }): void {
+    const G = GAME_HEIGHT - TILE_SIZE;
+    const fontSize = opts.fontSize ?? 13;
+    this.add.image(opts.x, G - 60, 'info_board').setDepth(3);
+    this.add.text(opts.x, G - 130, opts.label, {
+      fontFamily: 'monospace',
+      fontSize: `${fontSize}px`,
+      color: opts.color,
+      fontStyle: 'bold',
+      align: 'center',
+    }).setOrigin(0.5).setDepth(4);
+  }
+
   /* ---- exit ---- */
   protected createExit(): void {
     const c = this.getLevelConfig();

--- a/src/features/floors/architecture/ArchitectureTeamScene.ts
+++ b/src/features/floors/architecture/ArchitectureTeamScene.ts
@@ -37,17 +37,19 @@ export class ArchitectureTeamScene extends LevelScene {
   protected override createDecorations(): void {
     const G = GAME_HEIGHT - TILE_SIZE;
 
-    // Ambient plants
-    this.add.image(90, G - 40, 'plant_tall').setDepth(3);
-    this.add.image(160, G - 32, 'plant_small').setDepth(11);
+    this.addAmbientPlants([
+      { x: 90, kind: 'tall' },
+      { x: 160, kind: 'small' },
+    ]);
 
     // ---- Anchor 1: Architecture-team signpost ----
     // The room's "help desk" — establishes the team's role.
-    this.add.image(230, G - 60, 'info_board').setDepth(3);
-    this.add.text(230, G - 130, 'ARCHITECTURE\n    TEAM', {
-      fontFamily: 'monospace', fontSize: '12px', color: '#ffe6b8',
-      fontStyle: 'bold', align: 'center',
-    }).setOrigin(0.5).setDepth(4);
+    this.addSignpost({
+      x: 230,
+      label: 'ARCHITECTURE\n    TEAM',
+      color: '#ffe6b8',
+      fontSize: 12,
+    });
 
     // ---- Anchor 2: C4 diagram whiteboard ----
     this.createC4Whiteboard(490, G - 50);

--- a/src/features/floors/executive/ExecutiveSuiteScene.ts
+++ b/src/features/floors/executive/ExecutiveSuiteScene.ts
@@ -59,18 +59,14 @@ export class ExecutiveSuiteScene extends LevelScene {
   protected override createDecorations(): void {
     const G = GAME_HEIGHT - TILE_SIZE;
 
-    // Penthouse plants flanking the executive lounge.
-    this.add.image(110, G - 40, 'plant_tall').setDepth(3);
-    this.add.image(220, G - 32, 'plant_small').setDepth(11);
-    this.add.image(1180, G - 40, 'plant_tall').setDepth(3);
-    this.add.image(1060, G - 32, 'plant_small').setDepth(11);
+    this.addAmbientPlants([
+      { x: 110, kind: 'tall' },
+      { x: 220, kind: 'small' },
+      { x: 1180, kind: 'tall' },
+      { x: 1060, kind: 'small' },
+    ]);
 
-    // Executive signpost — greets the player on entry.
-    this.add.image(380, G - 60, 'info_board').setDepth(3);
-    this.add.text(380, G - 130, 'EXECUTIVE\n   SUITE', {
-      fontFamily: 'monospace', fontSize: '13px', color: '#ffd700',
-      fontStyle: 'bold', align: 'center',
-    }).setOrigin(0.5).setDepth(4);
+    this.addSignpost({ x: 380, label: 'EXECUTIVE\n   SUITE', color: '#ffd700' });
 
     // Strategy desk in the centre.
     this.add.image(720, G - 36, 'desk_monitor').setDepth(3);

--- a/src/features/floors/finance/FinanceTeamScene.ts
+++ b/src/features/floors/finance/FinanceTeamScene.ts
@@ -20,16 +20,12 @@ export class FinanceTeamScene extends LevelScene {
   protected override createDecorations(): void {
     const G = GAME_HEIGHT - TILE_SIZE;
 
-    // Plants flanking the room
-    this.add.image(90, G - 40, 'plant_tall').setDepth(3);
-    this.add.image(160, G - 32, 'plant_small').setDepth(11);
+    this.addAmbientPlants([
+      { x: 90, kind: 'tall' },
+      { x: 160, kind: 'small' },
+    ]);
 
-    // Finance signpost — greets the player on entry.
-    this.add.image(260, G - 60, 'info_board').setDepth(3);
-    this.add.text(260, G - 130, '  FINANCE\n   TEAM', {
-      fontFamily: 'monospace', fontSize: '13px', color: '#b8ffd1',
-      fontStyle: 'bold', align: 'center',
-    }).setOrigin(0.5).setDepth(4);
+    this.addSignpost({ x: 260, label: '  FINANCE\n   TEAM', color: '#b8ffd1' });
 
     // Trading-desk style monitors — proxy for FP&A dashboards.
     this.add.image(560, G - 36, 'desk_monitor').setDepth(3);

--- a/src/features/floors/platform/PlatformTeamScene.ts
+++ b/src/features/floors/platform/PlatformTeamScene.ts
@@ -23,18 +23,14 @@ export class PlatformTeamScene extends LevelScene {
   protected override createDecorations(): void {
     const G = GAME_HEIGHT - TILE_SIZE;
 
-    // Ambient plants
-    this.add.image(90, G - 40, 'plant_tall').setDepth(3);
-    this.add.image(440, G - 32, 'plant_small').setDepth(3);
-    this.add.image(160, G - 32, 'plant_small').setDepth(11);
-    this.add.image(1200, G - 40, 'plant_tall').setDepth(3);
+    this.addAmbientPlants([
+      { x: 90, kind: 'tall' },
+      { x: 440, kind: 'small', depth: 3 },
+      { x: 160, kind: 'small' },
+      { x: 1200, kind: 'tall' },
+    ]);
 
-    // Platform-Team signpost — greets the player on entry.
-    this.add.image(260, G - 60, 'info_board').setDepth(3);
-    this.add.text(260, G - 130, 'PLATFORM\n   TEAM', {
-      fontFamily: 'monospace', fontSize: '13px', color: '#b8e6ff',
-      fontStyle: 'bold', align: 'center',
-    }).setOrigin(0.5).setDepth(4);
+    this.addSignpost({ x: 260, label: 'PLATFORM\n   TEAM', color: '#b8e6ff' });
 
     // Workstations flanking the center.
     this.add.image(560, G - 36, 'desk_monitor').setDepth(3);

--- a/src/features/floors/product/ProductLeadershipScene.ts
+++ b/src/features/floors/product/ProductLeadershipScene.ts
@@ -23,16 +23,17 @@ export class ProductLeadershipScene extends LevelScene {
   protected override createDecorations(): void {
     const G = GAME_HEIGHT - TILE_SIZE;
 
-    // Plants flanking the room
-    this.add.image(90, G - 40, 'plant_tall').setDepth(3);
-    this.add.image(160, G - 32, 'plant_small').setDepth(11);
+    this.addAmbientPlants([
+      { x: 90, kind: 'tall' },
+      { x: 160, kind: 'small' },
+    ]);
 
-    // Product Leadership signpost — greets the player on entry.
-    this.add.image(230, G - 60, 'info_board').setDepth(3);
-    this.add.text(230, G - 130, '  PRODUCT\nLEADERSHIP', {
-      fontFamily: 'monospace', fontSize: '12px', color: '#ffd6f0',
-      fontStyle: 'bold', align: 'center',
-    }).setOrigin(0.5).setDepth(4);
+    this.addSignpost({
+      x: 230,
+      label: '  PRODUCT\nLEADERSHIP',
+      color: '#ffd6f0',
+      fontSize: 12,
+    });
 
     // Roadmap wall + workstations.
     this.add.image(560, G - 36, 'desk_monitor').setDepth(3);


### PR DESCRIPTION
Six floor scenes opened createDecorations() with the same 2-4 ambient
plants followed by an info_board signpost with identical monospace-bold
text styling. Lifting these into addAmbientPlants() and addSignpost()
on LevelScene trims each subclass and locks the visual contract so new
floors don't drift from the pattern.

Visual output is unchanged: coordinates, depths, fonts, and labels match
the previous per-scene implementations.