### PR TITLE
feat(ui): blurred-scene pillarbox backdrop

### DIFF
--- a/index.html
+++ b/index.html
@@ -16,7 +16,35 @@
       overflow: hidden;
       background-color: #1a1a2e;
     }
+    /*
+     * Pillarbox backdrop: the Phaser canvas is fixed 4:3 and FIT-scaled,
+     * so wider viewports show empty bars on either side. This canvas sits
+     * behind #game-container and receives a blurred, scaled-up copy of
+     * the live game canvas each frame (see src/ui/pillarboxBackdrop.ts),
+     * so the scene's colours bleed into the bars instead of ending in a
+     * hard rectangle.
+     */
+    #pillarbox-bg {
+      position: fixed;
+      inset: 0;
+      width: 100%;
+      height: 100%;
+      z-index: 0;
+      filter: blur(48px) brightness(0.6) saturate(1.1);
+      transform: scale(1.08);
+      transform-origin: center;
+      pointer-events: none;
+      /* Hidden until the backdrop module starts drawing, to avoid a flash
+         of blank canvas during Phaser boot. */
+      opacity: 0;
+      transition: opacity 300ms ease-in;
+    }
+    #pillarbox-bg.ready {
+      opacity: 1;
+    }
     #game-container {
+      position: relative;
+      z-index: 1;
       width: 100%;
       height: 100%;
     }
@@ -29,6 +57,7 @@
   </style>
 </head>
 <body>
+  <canvas id="pillarbox-bg"></canvas>
   <div id="game-container"></div>
   <script type="module" src="/src/main.ts"></script>
 </body>

--- a/index.html
+++ b/index.html
@@ -57,7 +57,7 @@
   </style>
 </head>
 <body>
-  <canvas id="pillarbox-bg"></canvas>
+  <canvas id="pillarbox-bg" aria-hidden="true" role="presentation"></canvas>
   <div id="game-container"></div>
   <script type="module" src="/src/main.ts"></script>
 </body>

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,6 +46,9 @@ creatorProto.text = function (config, addToScene) {
   return t;
 };
 
+const needsPillarboxBackdrop =
+  Math.abs(window.innerWidth / Math.max(1, window.innerHeight) - GAME_WIDTH / GAME_HEIGHT) > 0.001;
+
 const config: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,
   parent: 'game-container',
@@ -65,11 +68,14 @@ const config: Phaser.Types.Core.GameConfig = {
     mode: Phaser.Scale.FIT,
     autoCenter: Phaser.Scale.CENTER_BOTH,
   },
+  // Enabled only when viewport aspect differs from game aspect; this limits
+  // WebGL preserveDrawingBuffer perf/memory overhead to sessions where the
+  // pillarbox backdrop is actually used.
   // Required so the pillarbox backdrop (src/ui/pillarboxBackdrop.ts) can
   // `drawImage` the live WebGL canvas. Without this, reads from the GL
   // context yield blank frames.
   render: {
-    preserveDrawingBuffer: true,
+    preserveDrawingBuffer: needsPillarboxBackdrop,
   },
   scene: [BootScene, MenuScene, ElevatorScene, PlatformTeamScene, ArchitectureTeamScene, FinanceTeamScene, ProductLeadershipScene, CustomerSuccessScene, ExecutiveSuiteScene, ProductIsyProjectControlsScene, ProductIsyBeskrivelseScene, ProductIsyRoadScene, ProductAdminLisensScene],
   plugins: {
@@ -103,7 +109,9 @@ gameWindow.__testHooks = { QuizDialog, canRetryQuiz };
 // Kick the pillarbox backdrop once the first frame has rendered, so the
 // initial draw copies actual scene pixels rather than a blank buffer. The
 // `.ready` class fades it in (see #pillarbox-bg CSS in index.html).
-game.events.once(Phaser.Core.Events.POST_RENDER, () => {
-  startPillarboxBackdrop(game);
-  document.getElementById('pillarbox-bg')?.classList.add('ready');
-});
+if (needsPillarboxBackdrop) {
+  game.events.once(Phaser.Core.Events.POST_RENDER, () => {
+    startPillarboxBackdrop(game);
+    document.getElementById('pillarbox-bg')?.classList.add('ready');
+  });
+}

--- a/src/main.ts
+++ b/src/main.ts
@@ -20,6 +20,7 @@ import { DebugPlugin } from './plugins/DebugPlugin';
 import { InputService } from './input';
 import { QuizDialog } from './ui/QuizDialog';
 import { canRetryQuiz } from './systems/QuizManager';
+import { startPillarboxBackdrop } from './ui/pillarboxBackdrop';
 
 // Render all Text objects at 2x internal resolution so glyphs stay crisp
 // after the canvas is FIT-scaled to the viewport. Applies to both
@@ -64,6 +65,12 @@ const config: Phaser.Types.Core.GameConfig = {
     mode: Phaser.Scale.FIT,
     autoCenter: Phaser.Scale.CENTER_BOTH,
   },
+  // Required so the pillarbox backdrop (src/ui/pillarboxBackdrop.ts) can
+  // `drawImage` the live WebGL canvas. Without this, reads from the GL
+  // context yield blank frames.
+  render: {
+    preserveDrawingBuffer: true,
+  },
   scene: [BootScene, MenuScene, ElevatorScene, PlatformTeamScene, ArchitectureTeamScene, FinanceTeamScene, ProductLeadershipScene, CustomerSuccessScene, ExecutiveSuiteScene, ProductIsyProjectControlsScene, ProductIsyBeskrivelseScene, ProductIsyRoadScene, ProductAdminLisensScene],
   plugins: {
     scene: [{ key: 'InputService', plugin: InputService, mapping: 'inputs' },
@@ -92,3 +99,11 @@ const gameWindow = window as unknown as {
 };
 gameWindow.__game = game;
 gameWindow.__testHooks = { QuizDialog, canRetryQuiz };
+
+// Kick the pillarbox backdrop once the first frame has rendered, so the
+// initial draw copies actual scene pixels rather than a blank buffer. The
+// `.ready` class fades it in (see #pillarbox-bg CSS in index.html).
+game.events.once(Phaser.Core.Events.POST_RENDER, () => {
+  startPillarboxBackdrop(game);
+  document.getElementById('pillarbox-bg')?.classList.add('ready');
+});

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,6 +46,9 @@ creatorProto.text = function (config, addToScene) {
   return t;
 };
 
+// ±0.1% aspect drift tolerance prevents tiny floating-point/rounding jitter
+// from enabling the backdrop path when viewport and game ratio are effectively
+// the same.
 const ASPECT_RATIO_TOLERANCE = 0.001;
 // Chosen once at boot. `preserveDrawingBuffer` is a WebGL context creation
 // flag and can't be toggled after the renderer is created.

--- a/src/main.ts
+++ b/src/main.ts
@@ -46,8 +46,11 @@ creatorProto.text = function (config, addToScene) {
   return t;
 };
 
+const ASPECT_RATIO_TOLERANCE = 0.001;
+// Chosen once at boot. `preserveDrawingBuffer` is a WebGL context creation
+// flag and can't be toggled after the renderer is created.
 const needsPillarboxBackdrop =
-  Math.abs(window.innerWidth / Math.max(1, window.innerHeight) - GAME_WIDTH / GAME_HEIGHT) > 0.001;
+  Math.abs(window.innerWidth / Math.max(1, window.innerHeight) - GAME_WIDTH / GAME_HEIGHT) > ASPECT_RATIO_TOLERANCE;
 
 const config: Phaser.Types.Core.GameConfig = {
   type: Phaser.AUTO,

--- a/src/ui/pillarboxBackdrop.test.ts
+++ b/src/ui/pillarboxBackdrop.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { startPillarboxBackdrop } from './pillarboxBackdrop';
+
+interface FakeCanvas {
+  id?: string;
+  width: number;
+  height: number;
+  style: Record<string, string>;
+  getContext: (type: string) => { drawImage: ReturnType<typeof vi.fn> } | null;
+}
+
+function makeFakeCanvas(id: string): FakeCanvas {
+  return {
+    id,
+    width: 0,
+    height: 0,
+    style: {},
+    getContext: vi.fn(() => ({ drawImage: vi.fn() })),
+  };
+}
+
+function makeEnv(
+  viewport = { w: 1920, h: 1080, dpr: 1 },
+  withBgCanvas = true,
+): {
+  win: Window;
+  doc: Document;
+  bg: FakeCanvas | null;
+  src: FakeCanvas;
+  rafCallbacks: FrameRequestCallback[];
+  runRaf: (t: number) => void;
+  resizeListeners: (() => void)[];
+  scaleListeners: Record<string, (() => void)[]>;
+  fireResize: () => void;
+  firePhaserResize: () => void;
+} {
+  const bg = withBgCanvas ? makeFakeCanvas('pillarbox-bg') : null;
+  const src = makeFakeCanvas('game-canvas');
+  src.width = 1280;
+  src.height = 960;
+
+  const rafCallbacks: FrameRequestCallback[] = [];
+  const resizeListeners: (() => void)[] = [];
+
+  const win = {
+    innerWidth: viewport.w,
+    innerHeight: viewport.h,
+    devicePixelRatio: viewport.dpr,
+    requestAnimationFrame: vi.fn((cb: FrameRequestCallback) => {
+      rafCallbacks.push(cb);
+      return rafCallbacks.length;
+    }),
+    cancelAnimationFrame: vi.fn(),
+    addEventListener: vi.fn((ev: string, cb: () => void) => {
+      if (ev === 'resize') resizeListeners.push(cb);
+    }),
+    removeEventListener: vi.fn((ev: string, cb: () => void) => {
+      if (ev === 'resize') {
+        const i = resizeListeners.indexOf(cb);
+        if (i >= 0) resizeListeners.splice(i, 1);
+      }
+    }),
+  } as unknown as Window;
+
+  const doc = {
+    getElementById: vi.fn((id: string) => (id === 'pillarbox-bg' ? bg : null)),
+  } as unknown as Document;
+
+  const runRaf = (t: number) => {
+    const pending = rafCallbacks.splice(0);
+    for (const cb of pending) cb(t);
+  };
+
+  const scaleListeners: Record<string, (() => void)[]> = {};
+
+  return {
+    win,
+    doc,
+    bg,
+    src,
+    rafCallbacks,
+    runRaf,
+    resizeListeners,
+    scaleListeners,
+    fireResize: () => resizeListeners.slice().forEach((cb) => cb()),
+    firePhaserResize: () => (scaleListeners.resize ?? []).slice().forEach((cb) => cb()),
+  };
+}
+
+describe('startPillarboxBackdrop', () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it('sizes the backdrop canvas to viewport × DPR', () => {
+    const env = makeEnv({ w: 1920, h: 1080, dpr: 2 });
+    const scale = { on: vi.fn(), off: vi.fn() };
+    startPillarboxBackdrop(
+      { canvas: env.src as unknown as HTMLCanvasElement, scale },
+      { win: env.win, doc: env.doc },
+    );
+    expect(env.bg!.width).toBe(3840);
+    expect(env.bg!.height).toBe(2160);
+    expect(env.bg!.style.width).toBe('1920px');
+    expect(env.bg!.style.height).toBe('1080px');
+  });
+
+  it('draws immediately and schedules an rAF tick', () => {
+    const env = makeEnv();
+    const ctx = { drawImage: vi.fn() };
+    env.bg!.getContext = vi.fn(() => ctx);
+    startPillarboxBackdrop(
+      { canvas: env.src as unknown as HTMLCanvasElement },
+      { win: env.win, doc: env.doc },
+    );
+    expect(ctx.drawImage).toHaveBeenCalledTimes(1);
+    expect(env.win.requestAnimationFrame).toHaveBeenCalledTimes(1);
+  });
+
+  it('throttles draws to at most one per throttleMs', () => {
+    const env = makeEnv();
+    const ctx = { drawImage: vi.fn() };
+    env.bg!.getContext = vi.fn(() => ctx);
+    startPillarboxBackdrop(
+      { canvas: env.src as unknown as HTMLCanvasElement },
+      { win: env.win, doc: env.doc, throttleMs: 100 },
+    );
+    // initial draw
+    expect(ctx.drawImage).toHaveBeenCalledTimes(1);
+    // tick at 50ms — under throttle, no new draw
+    env.runRaf(50);
+    expect(ctx.drawImage).toHaveBeenCalledTimes(1);
+    // tick at 150ms — over throttle, new draw
+    env.runRaf(150);
+    expect(ctx.drawImage).toHaveBeenCalledTimes(2);
+    // tick at 180ms — under next throttle window, no new draw
+    env.runRaf(180);
+    expect(ctx.drawImage).toHaveBeenCalledTimes(2);
+  });
+
+  it('stop() cancels rAF and removes listeners', () => {
+    const env = makeEnv();
+    const scale = { on: vi.fn(), off: vi.fn() };
+    const h = startPillarboxBackdrop(
+      { canvas: env.src as unknown as HTMLCanvasElement, scale },
+      { win: env.win, doc: env.doc },
+    );
+    expect(env.resizeListeners.length).toBe(1);
+    h.stop();
+    expect(env.win.cancelAnimationFrame).toHaveBeenCalled();
+    expect(env.resizeListeners.length).toBe(0);
+    expect(scale.off).toHaveBeenCalledWith('resize', expect.any(Function));
+    // Subsequent ticks are no-ops.
+    const ctx = env.bg!.getContext('2d') as { drawImage: ReturnType<typeof vi.fn> };
+    const before = ctx.drawImage.mock.calls.length;
+    env.runRaf(1000);
+    expect(ctx.drawImage.mock.calls.length).toBe(before);
+  });
+
+  it('resize handler rescales the backdrop to new viewport', () => {
+    const env = makeEnv({ w: 1000, h: 800, dpr: 1 });
+    startPillarboxBackdrop(
+      { canvas: env.src as unknown as HTMLCanvasElement },
+      { win: env.win, doc: env.doc },
+    );
+    expect(env.bg!.width).toBe(1000);
+    (env.win as unknown as { innerWidth: number }).innerWidth = 2400;
+    (env.win as unknown as { innerHeight: number }).innerHeight = 1350;
+    env.fireResize();
+    expect(env.bg!.width).toBe(2400);
+    expect(env.bg!.height).toBe(1350);
+  });
+
+  it('returns a no-op handle if #pillarbox-bg is missing', () => {
+    const env = makeEnv(undefined, false);
+    const h = startPillarboxBackdrop(
+      { canvas: env.src as unknown as HTMLCanvasElement },
+      { win: env.win, doc: env.doc },
+    );
+    expect(env.win.requestAnimationFrame).not.toHaveBeenCalled();
+    h.stop(); // does not throw
+  });
+
+  it('drawImage exceptions are swallowed', () => {
+    const env = makeEnv();
+    const ctx = {
+      drawImage: vi.fn(() => {
+        throw new Error('context lost');
+      }),
+    };
+    env.bg!.getContext = vi.fn(() => ctx);
+    expect(() =>
+      startPillarboxBackdrop(
+        { canvas: env.src as unknown as HTMLCanvasElement },
+        { win: env.win, doc: env.doc },
+      ),
+    ).not.toThrow();
+  });
+});

--- a/src/ui/pillarboxBackdrop.test.ts
+++ b/src/ui/pillarboxBackdrop.test.ts
@@ -30,9 +30,7 @@ function makeEnv(
   rafCallbacks: FrameRequestCallback[];
   runRaf: (t: number) => void;
   resizeListeners: (() => void)[];
-  scaleListeners: Record<string, (() => void)[]>;
   fireResize: () => void;
-  firePhaserResize: () => void;
 } {
   const bg = withBgCanvas ? makeFakeCanvas('pillarbox-bg') : null;
   const src = makeFakeCanvas('game-canvas');
@@ -71,8 +69,6 @@ function makeEnv(
     for (const cb of pending) cb(t);
   };
 
-  const scaleListeners: Record<string, (() => void)[]> = {};
-
   return {
     win,
     doc,
@@ -81,9 +77,7 @@ function makeEnv(
     rafCallbacks,
     runRaf,
     resizeListeners,
-    scaleListeners,
     fireResize: () => resizeListeners.slice().forEach((cb) => cb()),
-    firePhaserResize: () => (scaleListeners.resize ?? []).slice().forEach((cb) => cb()),
   };
 }
 
@@ -157,16 +151,20 @@ describe('startPillarboxBackdrop', () => {
 
   it('resize handler rescales the backdrop to new viewport', () => {
     const env = makeEnv({ w: 1000, h: 800, dpr: 1 });
+    const ctx = { drawImage: vi.fn() };
+    env.bg!.getContext = vi.fn(() => ctx);
     startPillarboxBackdrop(
       { canvas: env.src as unknown as HTMLCanvasElement },
       { win: env.win, doc: env.doc },
     );
+    expect(ctx.drawImage).toHaveBeenCalledTimes(1);
     expect(env.bg!.width).toBe(1000);
     (env.win as unknown as { innerWidth: number }).innerWidth = 2400;
     (env.win as unknown as { innerHeight: number }).innerHeight = 1350;
     env.fireResize();
     expect(env.bg!.width).toBe(2400);
     expect(env.bg!.height).toBe(1350);
+    expect(ctx.drawImage).toHaveBeenCalledTimes(2);
   });
 
   it('returns a no-op handle if #pillarbox-bg is missing', () => {

--- a/src/ui/pillarboxBackdrop.ts
+++ b/src/ui/pillarboxBackdrop.ts
@@ -46,8 +46,8 @@ export interface PillarboxBackdropHandle {
 type AnyGame = { canvas: HTMLCanvasElement; scale?: { on?: (e: string, cb: () => void) => void; off?: (e: string, cb: () => void) => void } };
 
 /**
- * Start the backdrop loop. Safe to call at most once per page — subsequent
- * calls before `stop()` return the existing handle.
+ * Start the backdrop loop. Call this at most once per page; each call starts
+ * a new loop/listener set, so call `stop()` before starting again.
  *
  * @param game   Phaser.Game-like object (only `canvas` is required).
  * @param opts   Optional overrides (test injection, throttle tuning).
@@ -106,7 +106,10 @@ export function startPillarboxBackdrop(
     rafId = win.requestAnimationFrame(tick);
   };
 
-  const onResize = () => sizeBackdrop();
+  const onResize = () => {
+    sizeBackdrop();
+    draw();
+  };
   win.addEventListener('resize', onResize);
   // Phaser emits 'resize' on its Scale Manager when the viewport changes.
   // Guard for shape — tests pass a minimal game stub.

--- a/src/ui/pillarboxBackdrop.ts
+++ b/src/ui/pillarboxBackdrop.ts
@@ -1,0 +1,130 @@
+/**
+ * Pillarbox / letterbox backdrop.
+ *
+ * The game canvas is fixed at GAME_WIDTH×GAME_HEIGHT (4:3) and scaled with
+ * `Phaser.Scale.FIT`, so on wider-than-4:3 viewports the page background
+ * shows as empty bars on either side (and on taller viewports, top/bottom).
+ *
+ * This module fills those bars with a blurred, scaled-up copy of the live
+ * Phaser canvas, so the scene's colours appear to bleed outward as ambient
+ * light rather than ending in a hard rectangle.
+ *
+ * Implementation:
+ *   - A 2D `<canvas id="pillarbox-bg">` sitting behind `#game-container`.
+ *   - Each animation frame, throttled to ~15 Hz, drawImage the Phaser
+ *     canvas stretched to cover the viewport.
+ *   - CSS applies `filter: blur(...)` and a slight `transform: scale(...)`
+ *     so the blur doesn't reveal hard edges at the viewport border.
+ *
+ * Requires the Phaser `GameConfig` to set `render.preserveDrawingBuffer: true`
+ * — without it, drawImage from the WebGL canvas yields a blank result.
+ */
+
+export interface PillarboxBackdropOptions {
+  /**
+   * Minimum gap between draws in milliseconds. 66 ≈ 15 Hz. The backdrop is
+   * heavily blurred so low update rates are not perceptible.
+   */
+  throttleMs?: number;
+  /**
+   * Override for tests. Defaults to `window`.
+   */
+  win?: Window;
+  /**
+   * Override for tests. Defaults to `document`.
+   */
+  doc?: Document;
+}
+
+export interface PillarboxBackdropHandle {
+  /** Stop the rAF loop and detach resize listeners. Idempotent. */
+  stop(): void;
+  /** Force an immediate draw (test/debug). */
+  drawNow(): void;
+}
+
+type AnyGame = { canvas: HTMLCanvasElement; scale?: { on?: (e: string, cb: () => void) => void; off?: (e: string, cb: () => void) => void } };
+
+/**
+ * Start the backdrop loop. Safe to call at most once per page — subsequent
+ * calls before `stop()` return the existing handle.
+ *
+ * @param game   Phaser.Game-like object (only `canvas` is required).
+ * @param opts   Optional overrides (test injection, throttle tuning).
+ */
+export function startPillarboxBackdrop(
+  game: AnyGame,
+  opts: PillarboxBackdropOptions = {},
+): PillarboxBackdropHandle {
+  const win = opts.win ?? window;
+  const doc = opts.doc ?? document;
+  const throttleMs = opts.throttleMs ?? 66;
+
+  const bg = doc.getElementById('pillarbox-bg') as HTMLCanvasElement | null;
+  if (!bg) {
+    // Dev/test environments without the DOM element — no-op handle.
+    return { stop: () => {}, drawNow: () => {} };
+  }
+  const ctx = bg.getContext('2d');
+  if (!ctx) {
+    return { stop: () => {}, drawNow: () => {} };
+  }
+
+  let stopped = false;
+  let rafId = 0;
+  let lastDraw = 0;
+
+  const sizeBackdrop = () => {
+    const dpr = win.devicePixelRatio || 1;
+    const vw = win.innerWidth;
+    const vh = win.innerHeight;
+    // Internal pixel buffer at DPR for crisp blur; CSS size matches viewport.
+    bg.width = Math.max(1, Math.round(vw * dpr));
+    bg.height = Math.max(1, Math.round(vh * dpr));
+    bg.style.width = `${vw}px`;
+    bg.style.height = `${vh}px`;
+  };
+
+  const draw = () => {
+    const src = game.canvas;
+    if (!src || src.width === 0 || src.height === 0) return;
+    if (bg.width === 0 || bg.height === 0) return;
+    try {
+      ctx.drawImage(src, 0, 0, bg.width, bg.height);
+    } catch {
+      // drawImage can throw if the source canvas is temporarily invalid
+      // (e.g. context lost). Swallow — next frame will try again.
+    }
+  };
+
+  const tick = (now: number) => {
+    if (stopped) return;
+    if (now - lastDraw >= throttleMs) {
+      lastDraw = now;
+      draw();
+    }
+    rafId = win.requestAnimationFrame(tick);
+  };
+
+  const onResize = () => sizeBackdrop();
+  win.addEventListener('resize', onResize);
+  // Phaser emits 'resize' on its Scale Manager when the viewport changes.
+  // Guard for shape — tests pass a minimal game stub.
+  const scale = game.scale;
+  if (scale?.on) scale.on('resize', onResize);
+
+  sizeBackdrop();
+  draw();
+  rafId = win.requestAnimationFrame(tick);
+
+  return {
+    stop() {
+      if (stopped) return;
+      stopped = true;
+      win.cancelAnimationFrame(rafId);
+      win.removeEventListener('resize', onResize);
+      if (scale?.off) scale.off('resize', onResize);
+    },
+    drawNow: draw,
+  };
+}


### PR DESCRIPTION
## What

Fills the pillarbox/letterbox bars left by `Phaser.Scale.FIT` with a blurred, scaled-up copy of the live game canvas, so scenes no longer end in hard rectangles on wider-than-4:3 viewports.

## Why

Canvas is fixed 1280x960 (4:3). On any viewport wider than 4:3, the page background (`#1a1a2e`) showed as empty bars on either side of the game. Reported as "game ends abruptly horizontally, rectangles on each side".

## How

- New `<canvas id=pillarbox-bg>` behind `#game-container`, sized to viewport*DPR.
- `src/ui/pillarboxBackdrop.ts` runs a throttled (~15 Hz) rAF loop that `drawImage`s `game.canvas` stretched to cover the viewport.
- CSS `filter: blur(48px) brightness(0.6) saturate(1.1)` + `transform: scale(1.08)` so the blur reads as ambient light spill and the edges don't show.
- `render.preserveDrawingBuffer: true` added to `GameConfig` so `drawImage` can read the WebGL canvas.
- Backdrop starts on `POST_RENDER` and fades in via a `.ready` class to avoid a flash of blank canvas during boot.

## Not doing

- No aspect ratio change, no `Scale.RESIZE` refactor, no scene code touched. Purely cosmetic.

## Tests

- New `src/ui/pillarboxBackdrop.test.ts` (7 tests): sizing, initial draw, throttle, stop cleanup, resize, missing-element no-op, swallowed drawImage exception.
- `typecheck` + `lint` clean.
- 5 preexisting `InputService.test.ts` failures exist on `main` too; unrelated.
- Playwright not run (visual snapshots capture canvas only; backdrop is outside the canvas).