### PR TITLE
fix(elevator): Up arrow now rides cab when walked onto it with momentum

### DIFF
--- a/src/scenes/elevator/ElevatorController.ts
+++ b/src/scenes/elevator/ElevatorController.ts
@@ -87,6 +87,20 @@ export class ElevatorController {
     if (this.playerOnElevator) {
       const up = input.up || (buttonState?.up ?? false);
       const down = input.down || (buttonState?.down ?? false);
+
+      // When the rider requests to move the cab, commit them to the ride:
+      // kill residual walk momentum and clamp them onto the cab. Without
+      // this, walking onto the cab at PLAYER_SPEED carries the player
+      // past the docked-floor unmount threshold (dx > PLAT_HW + 10)
+      // before the cab leaves the floor, so Up/Down appear to do nothing.
+      if (up || down) {
+        const body = this.player.sprite.body as Phaser.Physics.Arcade.Body;
+        body.setVelocityX(0);
+        const left = this.elevator.platform.x - ELEVATOR_CAB_HALF_WIDTH + ELEVATOR_STEP_OUT_X_MARGIN;
+        const right = this.elevator.platform.x + ELEVATOR_CAB_HALF_WIDTH - ELEVATOR_STEP_OUT_X_MARGIN;
+        this.player.sprite.setX(Phaser.Math.Clamp(this.player.sprite.x, left, right));
+      }
+
       this.elevator.ride(up, down, delta);
       this.constrainPlayerToCab();
       // Match velocity so the physics integration step keeps the player

--- a/tests/elevator-up-arrow.spec.ts
+++ b/tests/elevator-up-arrow.spec.ts
@@ -1,0 +1,40 @@
+import { test, expect } from '@playwright/test';
+import { waitForGame, waitForScene, seedFullProgressSave } from './helpers/playwright';
+
+test('pressing Up after walking onto cab rides up', async ({ page }) => {
+  await seedFullProgressSave(page);
+  await page.goto('/');
+  await waitForGame(page);
+  await page.keyboard.press('Enter');
+  await waitForScene(page, 'ElevatorScene');
+  await page.waitForTimeout(400);
+
+  // Walk right until we mount the cab
+  await page.keyboard.down('ArrowRight');
+  for (let i = 0; i < 60; i++) {
+    await page.waitForTimeout(50);
+    const onElev = await page.evaluate(() => {
+      const g: any = (window as any).__game;
+      const s = g.scene.getScene('ElevatorScene') as any;
+      return !!s?.elevatorCtrl?.isOnElevator;
+    });
+    if (onElev) break;
+  }
+  await page.keyboard.up('ArrowRight');
+
+  const y0 = await page.evaluate(() => {
+    const g: any = (window as any).__game;
+    return (g.scene.getScene('ElevatorScene') as any).elevatorCtrl.elevator.getY();
+  });
+
+  await page.keyboard.down('ArrowUp');
+  await page.waitForTimeout(1500);
+  await page.keyboard.up('ArrowUp');
+
+  const y1 = await page.evaluate(() => {
+    const g: any = (window as any).__game;
+    return (g.scene.getScene('ElevatorScene') as any).elevatorCtrl.elevator.getY();
+  });
+
+  expect(y1).toBeLessThan(y0 - 50);
+});


### PR DESCRIPTION
## Problem

When the player walks onto the docked elevator cab from the lobby floor and immediately presses Up, the cab doesn't go up — the arrow appears to do nothing.

## Root cause

Walking onto the cab at `PLAYER_SPEED` (360 px/s) carries residual horizontal velocity. In `ElevatorController.update()` the unmount check is:

\\\	s
if (atFloor) {
  const dx = Math.abs(this.player.sprite.x - this.elevator.platform.x);
  if (dx > ELEVATOR_PLAT_HW + 10) this.playerOnElevator = false;
}
\\\`n
Ground deceleration (`vx *= 0.8` per frame) lets the player drift ~30–40 px after ArrowRight is released. That's enough to cross the 90 px threshold while the cab is still docked, so `playerOnElevator` flips back to `false` before the cab has a chance to leave the floor. `elevator.ride(up=true)` is never called.

## Fix

While the player is on the cab and holds Up or Down, zero their horizontal velocity and clamp `x` into the cab's walkable span (`[platform.x - 70 + 12, platform.x + 70 - 12]`). This commits the rider to the ride regardless of walk-in momentum.

Walking across a docked cab with no vertical input is still unchanged — free horizontal movement only gets locked when the player actually asks the cab to move.

## Verification

- New Playwright spec `tests/elevator-up-arrow.spec.ts` walks right from spawn until mounted, then presses Up and asserts `cab.y` decreases by >50 px. Fails on main, passes here.
- Existing `tests/elevator.spec.ts` (3 tests) still pass.
- `npm run typecheck` + `npm run lint` clean.

## Notes

- Pre-existing unit failures in `src/input/InputService.test.ts` and `src/input/bindings.test.ts` (5 failures re: `K.W`/`K.UP` bound to `Jump`) are unrelated and exist on `main`.