### PR TITLE
docs: correct stale paths and content across all markdown files

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -95,7 +95,7 @@ Short index of where things live. Reach for these instead of re-implementing.
 ## How to extend
 
 ### Add a scene
-Follow `.github/skills/new-scene.md`. Key steps: create `src/scenes/<Name>Scene.ts` extending `Phaser.Scene`, register it in the `scene:` array in `src/main.ts`, and — if it needs music — add a `SCENE_MUSIC` entry in `src/config/audioConfig.ts`.
+Follow `.github/skills/new-scene.md`. Key steps: create the scene in the appropriate folder — `src/scenes/core/<Name>Scene.ts` or `src/scenes/elevator/<Name>Scene.ts` for infrastructure scenes, `src/features/products/rooms/<Name>Scene.ts` for product content scenes (floor scenes go under `src/features/floors/` — see the next section) — extend `Phaser.Scene`, register it in the `scene:` array in `src/main.ts`, and — if it needs music — add a `SCENE_MUSIC` entry in `src/config/audioConfig.ts`.
 
 ### Add a floor / level
 Create `src/features/floors/<floor>/<Name>TeamScene.ts` subclassing `LevelScene` (import from `../_shared/LevelScene`) and provide a `LevelConfig` (platforms, `tokens`, `enemies`, `infoPoints`). Register in `LEVEL_DATA` (`src/config/levelData.ts`) with unlock cost and theme, and in the scene array in `main.ts`.

--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -20,11 +20,12 @@ A TypeScript + Phaser 3 platformer about IT architecture, bundled with Vite. Pro
 │   └── music/                # MP3/OGG music tracks loaded in BootScene
 ├── src/
 │   ├── main.ts               # Phaser.Game config + scene registration
-│   ├── config/               # gameConfig, levelData, audioConfig, infoContent, quizData
+│   ├── config/               # gameConfig, levelData, audioConfig; info/ and quiz/ barrel dirs
 │   ├── entities/             # Player, Enemy (+ enemies/), Token, DroppedAU, Elevator
+│   ├── features/floors/      # _shared/LevelScene + helpers, one dir per floor team scene
 │   ├── input/                # Typed action bindings (actions.ts, bindings.ts, InputService)
 │   ├── plugins/              # MusicPlugin, DebugPlugin (Phaser ScenePlugins)
-│   ├── scenes/               # BootScene, MenuScene, ElevatorScene, …TeamScene, products/
+│   ├── scenes/               # core/ (BootScene, MenuScene), elevator/, NavigationContext
 │   ├── systems/              # ProgressionSystem, EventBus, ZoneManager, AudioManager,
 │   │                         # QuizManager, InfoDialogManager, SaveManager,
 │   │                         # SpriteGenerator, SoundGenerator, MusicGenerator
@@ -32,7 +33,7 @@ A TypeScript + Phaser 3 platformer about IT architecture, bundled with Vite. Pro
 ├── tests/                    # Playwright specs + helpers/ (see testing section)
 └── .github/
     ├── copilot-instructions.md   # This file
-    └── skills/                   # new-scene, add-game-object, debug-with-playwright, git-worktree
+    └── skills/                   # add-game-object, caveman-mode, debug-with-playwright, git-worktree, new-scene, setup-project
 ```
 
 There is **no** `public/assets/` directory — only `public/music/` exists today. Procedural sprites and SFX are generated at runtime by `SpriteGenerator` and `SoundGenerator`; only music is shipped as static files.
@@ -66,16 +67,16 @@ Scripts from `package.json`:
 
 Short index of where things live. Reach for these instead of re-implementing.
 
-- **`ProgressionSystem`** (`src/systems/ProgressionSystem.ts`) — the only public API for save/load. Tracks `totalAU`, `floorAU`, `unlockedFloors`, `currentFloor`, `collectedTokens`. Persists via `SaveManager` (localStorage key `architect_default_v1`).
+- **`ProgressionSystem`** (`src/systems/ProgressionSystem.ts`) — the only public API for save/load. Tracks `totalAU`, `floorAU`, `unlockedFloors`, `currentFloor`, `collectedTokens`. Persists via `SaveManager` (localStorage key `architect_<slot>_v1`; default slot `default` → `architect_default_v1`).
 - **`SaveManager`** — infrastructure. Scenes must not import it; use `ProgressionSystem`. The one exception is `SaveManager.hasSave()` for UI checks (e.g. a "Continue" button).
 - **`EventBus`** (`src/systems/EventBus.ts`) — typed pub/sub singleton. The `GameEvents` map is the single source of truth for event names and payloads; add new events there and all call sites become type-checked. No Phaser dependency.
 - **`ZoneManager`** (`src/systems/ZoneManager.ts`) — registers named zones with arbitrary `check: () => boolean` predicates, emits `zone:enter` / `zone:exit` on state change only. UI reacts to events; `getActiveZone()` is a synchronous query for keyboard handlers. Default pattern for anything that should appear only in a specific area of a scene.
-- **`AudioManager`** + **`MusicPlugin`** — fully reactive. Scenes don't play audio directly; entities emit `sfx:*` / `music:*` events. Scene music is auto-driven by `SCENE_MUSIC` in `src/config/audioConfig.ts` via `MusicPlugin`.
+- **`AudioManager`** + **`MusicPlugin`** — fully reactive. Scenes don't play audio directly; entities emit `sfx:*` / `music:*` events. Scene music is auto-driven by `SCENE_MUSIC` in `src/config/audioConfig.ts` via `MusicPlugin`. Mute state persists under localStorage key `architect_audio_muted_v1`.
 - **`SoundGenerator`** — procedural SFX generated at runtime and registered as Phaser audio keys. Music is loaded from `public/music/` in `BootScene.preload()` (MP3/OGG). `MusicGenerator` is a retained but unused procedural fallback.
 - **`SpriteGenerator`** — procedural pixel-art textures for player, enemies, tokens, platforms, elevator cab, etc.
-- **`QuizManager`** (localStorage key `architect_quiz_v1`) — quiz completion + cooldowns. Data in `src/config/quizData.ts`.
-- **`InfoDialogManager`** (localStorage key `architect_info_seen_v1`) — tracks which info dialogs the player has opened. Content in `src/config/infoContent.ts`.
-- **`LevelScene`** (`src/scenes/LevelScene.ts`) — shared base for floor scenes. Floor-specific scenes (`PlatformTeamScene`, `FinanceTeamScene`, etc.) provide a `LevelConfig` with platforms, tokens, enemies (`type: 'slime' | 'bot'`), and info points. Enemies are scene-local, no persistence; they respawn on re-entry.
+- **`QuizManager`** (localStorage key `architect_quiz_v1`) — quiz completion + cooldowns. Data under `src/config/quiz/` (barrel `index.ts`).
+- **`InfoDialogManager`** (localStorage key `architect_info_seen_v1`) — tracks which info dialogs the player has opened. Content under `src/config/info/` (barrel `index.ts`).
+- **`LevelScene`** (`src/features/floors/_shared/LevelScene.ts`) — shared base for floor scenes. Sibling helpers (`LevelDialogBindings`, `LevelEnemySpawner`, `LevelTokenManager`, `LevelZoneSetup`) compose the shared concerns. Floor-specific scenes (`PlatformTeamScene`, `FinanceTeamScene`, etc.) live under `src/features/floors/<floor>/` and provide a `LevelConfig` with platforms, tokens, enemies (`type: 'slime' | 'bot'`), and info points. Enemies are scene-local, no persistence; they respawn on re-entry.
 - **Input** (`src/input/`) — `GameAction` enum + `DEFAULT_BINDINGS` table. Never reference raw `KeyCode`s elsewhere. `InputService` is a Phaser ScenePlugin mapped to `scene.inputs`.
 
 ## Conventions
@@ -97,7 +98,7 @@ Short index of where things live. Reach for these instead of re-implementing.
 Follow `.github/skills/new-scene.md`. Key steps: create `src/scenes/<Name>Scene.ts` extending `Phaser.Scene`, register it in the `scene:` array in `src/main.ts`, and — if it needs music — add a `SCENE_MUSIC` entry in `src/config/audioConfig.ts`.
 
 ### Add a floor / level
-Subclass `LevelScene` and provide a `LevelConfig` (platforms, `tokens`, `enemies`, `infoPoints`). Register in `LEVEL_DATA` (`src/config/levelData.ts`) with unlock cost and theme, and in the scene array in `main.ts`.
+Create `src/features/floors/<floor>/<Name>TeamScene.ts` subclassing `LevelScene` (import from `../_shared/LevelScene`) and provide a `LevelConfig` (platforms, `tokens`, `enemies`, `infoPoints`). Register in `LEVEL_DATA` (`src/config/levelData.ts`) with unlock cost and theme, and in the scene array in `main.ts`.
 
 ### Add an enemy
 Declare it in the scene's `LevelConfig.enemies` array: `{ type: 'slime' | 'bot', x, y, minX, maxX, speed }`. Implementations live in `src/entities/enemies/`. To add a new enemy *type*, create the class there and handle it in `Enemy.ts`.
@@ -113,10 +114,10 @@ Declare it in the scene's `LevelConfig.enemies` array: `{ type: 'slime' | 'bot',
 2. Add a `SceneKey → music_<name>` entry in `SCENE_MUSIC`. `MusicPlugin` handles playback — no scene code needed.
 
 ### Add an info card
-Add the entry to `src/config/infoContent.ts`. Place an info point in the relevant scene's `LevelConfig.infoPoints` with matching `id`. Zone IDs default to the content ID, so the same string identifies both the zone and the dialog.
+Add the entry under `src/config/info/` (re-exported from `index.ts`). Place an info point in the relevant scene's `LevelConfig.infoPoints` with matching `id`. Zone IDs default to the content ID, so the same string identifies both the zone and the dialog.
 
 ### Add a quiz
-Add the question set to `src/config/quizData.ts` keyed by ID. Quiz state is tracked automatically by `QuizManager`.
+Add the question set under `src/config/quiz/` (re-exported from `index.ts`) keyed by ID. Quiz state is tracked automatically by `QuizManager`.
 
 ### Add a zone
 Register in the scene's `create()`:

--- a/.github/skills/git-worktree.md
+++ b/.github/skills/git-worktree.md
@@ -9,6 +9,8 @@ The primary checkout at `C:\code\SoYouWantToBeAnArchitect` keeps `main`'s `node_
 - Sibling directory: `C:\code\SoYouWantToBeAnArchitect-<slug>` on Windows, `../architect-elevator-game-<slug>` (or `~/code/architect-elevator-game-<slug>`) on macOS/Linux.
 - Branch name: `<type>/<slug>` with `<type>` ∈ { `fix`, `feat`, `chore`, `docs`, … } and `<slug>` in kebab-case.
 
+> **Note on primary-checkout names.** The examples below hardcode the Windows team's legacy checkout name `SoYouWantToBeAnArchitect` and the macOS/Linux convention `architect-elevator-game` (matching the GitHub repo name). These are the team's primary clone directory names for each OS, **not** the repo name in both places. If your local clone uses a different directory name, substitute it in every `..\…` / `../…` path below — the worktree sibling path is always `<primary-checkout-name>-<slug>`.
+
 ## Create
 
 **Windows (PowerShell):**

--- a/.github/skills/git-worktree.md
+++ b/.github/skills/git-worktree.md
@@ -6,10 +6,12 @@ The primary checkout at `C:\code\SoYouWantToBeAnArchitect` keeps `main`'s `node_
 
 ## Convention
 
-- Sibling directory: `C:\code\SoYouWantToBeAnArchitect-<slug>`.
+- Sibling directory: `C:\code\SoYouWantToBeAnArchitect-<slug>` on Windows, `../architect-elevator-game-<slug>` (or `~/code/architect-elevator-game-<slug>`) on macOS/Linux.
 - Branch name: `<type>/<slug>` with `<type>` ∈ { `fix`, `feat`, `chore`, `docs`, … } and `<slug>` in kebab-case.
 
 ## Create
+
+**Windows (PowerShell):**
 
 ```powershell
 # From the primary checkout, on main
@@ -19,9 +21,21 @@ npm install    # each worktree has its own node_modules
 # …edit, build (npm run build), test (npm run test:all), commit…
 ```
 
+**macOS / Linux (bash / zsh):**
+
+```bash
+# From the primary checkout, on main
+git worktree add ../architect-elevator-game-<slug> -b <type>/<slug>
+cd ../architect-elevator-game-<slug>
+npm install
+# …edit, build (npm run build), test (npm run test:all), commit…
+```
+
 ## Integrate back into main
 
 Ask the user whether to **rebase** or **merge**, then from the primary checkout:
+
+**Windows (PowerShell):**
 
 ```powershell
 cd ..\SoYouWantToBeAnArchitect
@@ -35,10 +49,33 @@ git merge --ff-only <type>/<slug>
 git merge --no-ff <type>/<slug>
 ```
 
+**macOS / Linux:**
+
+```bash
+cd ../architect-elevator-game
+git fetch origin
+
+# Rebase path (linear history):
+git -C ../architect-elevator-game-<slug> rebase origin/main
+git merge --ff-only <type>/<slug>
+
+# Or merge path (preserve branch topology):
+git merge --no-ff <type>/<slug>
+```
+
 ## Clean up
+
+**Windows (PowerShell):**
 
 ```powershell
 git worktree remove ..\SoYouWantToBeAnArchitect-<slug>
+git branch -d <type>/<slug>
+```
+
+**macOS / Linux:**
+
+```bash
+git worktree remove ../architect-elevator-game-<slug>
 git branch -d <type>/<slug>
 ```
 

--- a/.github/skills/new-scene.md
+++ b/.github/skills/new-scene.md
@@ -8,7 +8,9 @@ For a playable **floor** (platforming level with tokens, enemies, info points), 
 
 ## Convention
 
-- Infrastructure scenes live in `src/scenes/`; product content scenes live in `src/features/products/{hall,rooms}/`.
+- Infrastructure scenes live under `src/scenes/` (subdivided into `core/` for Boot/Menu and `elevator/` for the lift).
+- Floor scenes live under `src/features/floors/<floor>/` and extend `LevelScene`.
+- Product content scenes live under `src/features/products/rooms/`.
 - Filename = exported class name in PascalCase, suffixed with `Scene` (e.g. `MenuScene.ts`).
 - The string passed to `super(...)` is the scene **key** and must be unique. By convention it matches the class name.
 
@@ -16,8 +18,9 @@ For a playable **floor** (platforming level with tokens, enemies, info points), 
 
 Create one of:
 
-- `src/scenes/<Name>Scene.ts` for infrastructure scenes.
-- `src/features/products/hall/<Name>Scene.ts` or `src/features/products/rooms/<Name>Scene.ts` for product content scenes.
+- `src/scenes/core/<Name>Scene.ts` or `src/scenes/elevator/<Name>Scene.ts` for infrastructure scenes.
+- `src/features/floors/<floor>/<Name>TeamScene.ts` for a floor (use the "New floor variant" below).
+- `src/features/products/rooms/<Name>Scene.ts` for product content scenes.
 
 ```ts
 import * as Phaser from 'phaser';
@@ -45,11 +48,11 @@ export class NameScene extends Phaser.Scene {
 
 1. Register the scene in `src/main.ts`:
     ```ts
-    import { NameScene } from './scenes/NameScene';
+    import { NameScene } from './scenes/core/NameScene';
     // …
     scene: [BootScene, MenuScene, ElevatorScene, /* …, */ NameScene],
     ```
-   Product content scenes import from `./features/products/hall/...` or `./features/products/rooms/...`.
+   Floor scenes import from `./features/floors/<floor>/...`; product content scenes import from `./features/products/rooms/...`.
 2. If the scene has background music, add it to `SCENE_MUSIC` in `src/config/audioConfig.ts`:
    ```ts
    NameScene: 'music_floor2',
@@ -59,10 +62,10 @@ export class NameScene extends Phaser.Scene {
 
 ## New floor variant
 
-Floors extend `LevelScene` and declare their content as a `LevelConfig`:
+Floors live under `src/features/floors/<floor>/<Name>TeamScene.ts`, extend `LevelScene`, and declare their content as a `LevelConfig`:
 
 ```ts
-import { LevelScene } from './LevelScene';
+import { LevelScene } from '../_shared/LevelScene';
 
 export class MyFloorScene extends LevelScene {
   constructor() {

--- a/.github/skills/setup-project.md
+++ b/.github/skills/setup-project.md
@@ -2,94 +2,82 @@
 
 ## Purpose
 
-Bootstrap the Phaser + Vite project from scratch. Use this skill when the repository has no `package.json` or `src/` directory yet.
+Bring a fresh clone of this repo to a runnable state, verify the toolchain, and confirm the dev server is serving the game. Use this skill when:
 
-## Based On
+- You've just cloned the repo.
+- `node_modules/` is missing or stale (e.g. after switching Node versions).
+- You want to confirm typecheck / lint / unit tests still pass before starting work.
 
-- `README.md` — declares this is a Phaser game project.
-- `.gitignore` — contains Node.js and Vite ignore patterns, confirming the intended toolchain.
+The project is already scaffolded (TypeScript strict, Phaser 3.90, Vite, Vitest, Playwright) — there is no "bootstrap from empty directory" step.
+
+## Prerequisites
+
+- **Node.js** — match what `package.json` / the lockfile were last built against. Any recent LTS (≥ 18) generally works.
+- **npm** — the lockfile is `package-lock.json`. Do not substitute pnpm / yarn.
 
 ## Steps
 
-1. Initialize the project:
+1. Install dependencies:
    ```bash
-   npm init -y
+   npm install
    ```
+   This installs Phaser, Vite, Vitest, Playwright, ESLint, TypeScript, and everything declared in `devDependencies`.
 
-2. Install Phaser and Vite:
+2. (First-time only) Install Playwright browsers if you plan to run E2E tests:
    ```bash
-   npm install phaser
-   npm install --save-dev vite
+   npx playwright install
    ```
 
-3. Create `vite.config.js` at the project root:
-   ```js
-   import { defineConfig } from 'vite';
-
-   export default defineConfig({
-     base: './',
-     build: {
-       outDir: 'dist'
-     }
-   });
-   ```
-
-4. Create `index.html` at the project root:
-   ```html
-   <!DOCTYPE html>
-   <html lang="en">
-   <head>
-     <meta charset="UTF-8" />
-     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-     <title>MyFirstPhaserGame</title>
-   </head>
-   <body>
-     <div id="game-container"></div>
-     <script type="module" src="/src/main.js"></script>
-   </body>
-   </html>
-   ```
-
-5. Create `src/main.js` with the Phaser game config:
-   ```js
-   import Phaser from 'phaser';
-   import { Boot } from './scenes/Boot.js';
-   import { Preloader } from './scenes/Preloader.js';
-   import { MainMenu } from './scenes/MainMenu.js';
-   import { Game } from './scenes/Game.js';
-
-   const config = {
-     type: Phaser.AUTO,
-     width: 800,
-     height: 600,
-     parent: 'game-container',
-     scene: [Boot, Preloader, MainMenu, Game]
-   };
-
-   new Phaser.Game(config);
-   ```
-
-6. Create the starter scenes in `src/scenes/` (see the `new-scene` skill for the pattern).
-
-7. Create the `public/assets/` directory for static game assets.
-
-8. Add scripts to `package.json`:
-   ```json
-   {
-     "scripts": {
-       "dev": "vite",
-       "build": "vite build",
-       "preview": "vite preview"
-     }
-   }
-   ```
-
-9. Verify with:
+3. Run the dev server to confirm the toolchain works end-to-end:
    ```bash
    npm run dev
    ```
+   Vite serves on `http://localhost:3000` (port configured in `vite.config.ts`). The game should boot into `MenuScene`.
+
+4. Run the fast local checks before starting or finishing work:
+   ```bash
+   npm run typecheck
+   npm run lint
+   npm run test:unit
+   ```
+   These three together are the "pre-PR gate" for pure-docs changes; for code changes, consider `npm run test:all` (slow — ask the user first).
+
+## Scripts reference
+
+From `package.json`:
+
+| Script | Purpose |
+| --- | --- |
+| `npm run dev` | Vite dev server (exposes `window.__game` in dev for tests). |
+| `npm run build` | `tsc && vite build` — typecheck is part of the build. |
+| `npm run preview` | Serve the production build locally. |
+| `npm run lint` | ESLint across the repo. |
+| `npm run typecheck` | `tsc --noEmit`. |
+| `npm run test:unit` | Vitest (pure logic; jsdom). |
+| `npm run test:unit:watch` | Vitest in watch mode. |
+| `npm run test:unit:coverage` | Vitest with coverage; 60% floor on `src/systems/**` and `src/input/**`. |
+| `npm run test:e2e` | Playwright integration specs. |
+| `npm run test:headed` / `test:ui` | Playwright with visible browser / interactive UI. |
+| `npm run test:report` | Open the last Playwright HTML report. |
+| `npm run test:visual:update` | Refresh visual snapshot PNGs. |
+| `npm test` | `test:unit && test:e2e`. |
+| `npm run test:all` | `typecheck && lint && test:unit --coverage && test:e2e` — opt-in, slow. |
+
+## Conventions to keep in mind
+
+- **TypeScript strict, ES modules.** Do not add `.js` source files.
+- **No `public/assets/` directory.** Sprites and SFX are generated procedurally at runtime by `SpriteGenerator` and `SoundGenerator`. Only music is shipped as static files (`public/music/`).
+- **Filenames.** Scenes, entities, UI components, and systems use PascalCase filenames matching the exported class. Config / tooling files are lowercase.
+- **Dev-only global.** `src/main.ts` exposes `window.__game` when `import.meta.env.DEV` is true — Playwright depends on it, so don't remove or rename.
+
+## Adding new scenes / floors / content
+
+See the companion skills:
+
+- `.github/skills/new-scene.md` — adding a Phaser scene (infrastructure, floor, or product room).
+- `CLAUDE.md` → "How to extend" — the canonical how-to index for floors, enemies, sound effects, music, info cards, quizzes, and zones.
 
 ## Notes
 
-- The `.gitignore` already covers `node_modules/`, `dist/`, and Vite cache files.
-- All game assets go in `public/assets/` so Vite serves them without processing.
+- `.gitignore` already covers `node_modules/`, `dist/`, Vite cache, Playwright reports, and coverage output.
+- If `npm install` fails with peer-dep errors, check your Node version against the lockfile's build environment rather than forcing `--legacy-peer-deps`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -95,7 +95,7 @@ Short index of where things live. Reach for these instead of re-implementing.
 ## How to extend
 
 ### Add a scene
-Follow `.github/skills/new-scene.md`. Key steps: create `src/scenes/<Name>Scene.ts` extending `Phaser.Scene`, register it in the `scene:` array in `src/main.ts`, and — if it needs music — add a `SCENE_MUSIC` entry in `src/config/audioConfig.ts`.
+Follow `.github/skills/new-scene.md`. Key steps: create the scene in the appropriate folder — `src/scenes/core/<Name>Scene.ts` or `src/scenes/elevator/<Name>Scene.ts` for infrastructure scenes, `src/features/products/rooms/<Name>Scene.ts` for product content scenes (floor scenes go under `src/features/floors/` — see the next section) — extend `Phaser.Scene`, register it in the `scene:` array in `src/main.ts`, and — if it needs music — add a `SCENE_MUSIC` entry in `src/config/audioConfig.ts`.
 
 ### Add a floor / level
 Create `src/features/floors/<floor>/<Name>TeamScene.ts` subclassing `LevelScene` (import from `../_shared/LevelScene`) and provide a `LevelConfig` (platforms, `tokens`, `enemies`, `infoPoints`). Register in `LEVEL_DATA` (`src/config/levelData.ts`) with unlock cost and theme, and in the scene array in `main.ts`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -20,11 +20,12 @@ A TypeScript + Phaser 3 platformer about IT architecture, bundled with Vite. Pro
 │   └── music/                # MP3/OGG music tracks loaded in BootScene
 ├── src/
 │   ├── main.ts               # Phaser.Game config + scene registration
-│   ├── config/               # gameConfig, levelData, audioConfig, infoContent, quizData
+│   ├── config/               # gameConfig, levelData, audioConfig; info/ and quiz/ barrel dirs
 │   ├── entities/             # Player, Enemy (+ enemies/), Token, DroppedAU, Elevator
+│   ├── features/floors/      # _shared/LevelScene + helpers, one dir per floor team scene
 │   ├── input/                # Typed action bindings (actions.ts, bindings.ts, InputService)
 │   ├── plugins/              # MusicPlugin, DebugPlugin (Phaser ScenePlugins)
-│   ├── scenes/               # BootScene, MenuScene, ElevatorScene, …TeamScene, products/
+│   ├── scenes/               # core/ (BootScene, MenuScene), elevator/, NavigationContext
 │   ├── systems/              # ProgressionSystem, EventBus, ZoneManager, AudioManager,
 │   │                         # QuizManager, InfoDialogManager, SaveManager,
 │   │                         # SpriteGenerator, SoundGenerator, MusicGenerator
@@ -32,7 +33,7 @@ A TypeScript + Phaser 3 platformer about IT architecture, bundled with Vite. Pro
 ├── tests/                    # Playwright specs + helpers/ (see testing section)
 └── .github/
     ├── copilot-instructions.md   # Mirror of this file (keep in sync)
-    └── skills/                   # new-scene, add-game-object, debug-with-playwright, git-worktree
+    └── skills/                   # add-game-object, caveman-mode, debug-with-playwright, git-worktree, new-scene, setup-project
 ```
 
 There is **no** `public/assets/` directory — only `public/music/` exists today. Procedural sprites and SFX are generated at runtime by `SpriteGenerator` and `SoundGenerator`; only music is shipped as static files.
@@ -66,16 +67,16 @@ Scripts from `package.json`:
 
 Short index of where things live. Reach for these instead of re-implementing.
 
-- **`ProgressionSystem`** (`src/systems/ProgressionSystem.ts`) — the only public API for save/load. Tracks `totalAU`, `floorAU`, `unlockedFloors`, `currentFloor`, `collectedTokens`. Persists via `SaveManager` (localStorage key `architect_default_v1`).
+- **`ProgressionSystem`** (`src/systems/ProgressionSystem.ts`) — the only public API for save/load. Tracks `totalAU`, `floorAU`, `unlockedFloors`, `currentFloor`, `collectedTokens`. Persists via `SaveManager` (localStorage key `architect_<slot>_v1`; default slot `default` → `architect_default_v1`).
 - **`SaveManager`** — infrastructure. Scenes must not import it; use `ProgressionSystem`. The one exception is `SaveManager.hasSave()` for UI checks (e.g. a "Continue" button).
 - **`EventBus`** (`src/systems/EventBus.ts`) — typed pub/sub singleton. The `GameEvents` map is the single source of truth for event names and payloads; add new events there and all call sites become type-checked. No Phaser dependency.
 - **`ZoneManager`** (`src/systems/ZoneManager.ts`) — registers named zones with arbitrary `check: () => boolean` predicates, emits `zone:enter` / `zone:exit` on state change only. UI reacts to events; `getActiveZone()` is a synchronous query for keyboard handlers. Default pattern for anything that should appear only in a specific area of a scene.
-- **`AudioManager`** + **`MusicPlugin`** — fully reactive. Scenes don't play audio directly; entities emit `sfx:*` / `music:*` events. Scene music is auto-driven by `SCENE_MUSIC` in `src/config/audioConfig.ts` via `MusicPlugin`.
+- **`AudioManager`** + **`MusicPlugin`** — fully reactive. Scenes don't play audio directly; entities emit `sfx:*` / `music:*` events. Scene music is auto-driven by `SCENE_MUSIC` in `src/config/audioConfig.ts` via `MusicPlugin`. Mute state persists under localStorage key `architect_audio_muted_v1`.
 - **`SoundGenerator`** — procedural SFX generated at runtime and registered as Phaser audio keys. Music is loaded from `public/music/` in `BootScene.preload()` (MP3/OGG). `MusicGenerator` is a retained but unused procedural fallback.
 - **`SpriteGenerator`** — procedural pixel-art textures for player, enemies, tokens, platforms, elevator cab, etc.
-- **`QuizManager`** (localStorage key `architect_quiz_v1`) — quiz completion + cooldowns. Data in `src/config/quizData.ts`.
-- **`InfoDialogManager`** (localStorage key `architect_info_seen_v1`) — tracks which info dialogs the player has opened. Content in `src/config/infoContent.ts`.
-- **`LevelScene`** (`src/scenes/LevelScene.ts`) — shared base for floor scenes. Floor-specific scenes (`PlatformTeamScene`, `FinanceTeamScene`, etc.) provide a `LevelConfig` with platforms, tokens, enemies (`type: 'slime' | 'bot'`), and info points. Enemies are scene-local, no persistence; they respawn on re-entry.
+- **`QuizManager`** (localStorage key `architect_quiz_v1`) — quiz completion + cooldowns. Data under `src/config/quiz/` (barrel `index.ts`).
+- **`InfoDialogManager`** (localStorage key `architect_info_seen_v1`) — tracks which info dialogs the player has opened. Content under `src/config/info/` (barrel `index.ts`).
+- **`LevelScene`** (`src/features/floors/_shared/LevelScene.ts`) — shared base for floor scenes. Sibling helpers (`LevelDialogBindings`, `LevelEnemySpawner`, `LevelTokenManager`, `LevelZoneSetup`) compose the shared concerns. Floor-specific scenes (`PlatformTeamScene`, `FinanceTeamScene`, etc.) live under `src/features/floors/<floor>/` and provide a `LevelConfig` with platforms, tokens, enemies (`type: 'slime' | 'bot'`), and info points. Enemies are scene-local, no persistence; they respawn on re-entry.
 - **Input** (`src/input/`) — `GameAction` enum + `DEFAULT_BINDINGS` table. Never reference raw `KeyCode`s elsewhere. `InputService` is a Phaser ScenePlugin mapped to `scene.inputs`.
 
 ## Conventions
@@ -97,7 +98,7 @@ Short index of where things live. Reach for these instead of re-implementing.
 Follow `.github/skills/new-scene.md`. Key steps: create `src/scenes/<Name>Scene.ts` extending `Phaser.Scene`, register it in the `scene:` array in `src/main.ts`, and — if it needs music — add a `SCENE_MUSIC` entry in `src/config/audioConfig.ts`.
 
 ### Add a floor / level
-Subclass `LevelScene` and provide a `LevelConfig` (platforms, `tokens`, `enemies`, `infoPoints`). Register in `LEVEL_DATA` (`src/config/levelData.ts`) with unlock cost and theme, and in the scene array in `main.ts`.
+Create `src/features/floors/<floor>/<Name>TeamScene.ts` subclassing `LevelScene` (import from `../_shared/LevelScene`) and provide a `LevelConfig` (platforms, `tokens`, `enemies`, `infoPoints`). Register in `LEVEL_DATA` (`src/config/levelData.ts`) with unlock cost and theme, and in the scene array in `main.ts`.
 
 ### Add an enemy
 Declare it in the scene's `LevelConfig.enemies` array: `{ type: 'slime' | 'bot', x, y, minX, maxX, speed }`. Implementations live in `src/entities/enemies/`. To add a new enemy *type*, create the class there and handle it in `Enemy.ts`.
@@ -113,10 +114,10 @@ Declare it in the scene's `LevelConfig.enemies` array: `{ type: 'slime' | 'bot',
 2. Add a `SceneKey → music_<name>` entry in `SCENE_MUSIC`. `MusicPlugin` handles playback — no scene code needed.
 
 ### Add an info card
-Add the entry to `src/config/infoContent.ts`. Place an info point in the relevant scene's `LevelConfig.infoPoints` with matching `id`. Zone IDs default to the content ID, so the same string identifies both the zone and the dialog.
+Add the entry under `src/config/info/` (re-exported from `index.ts`). Place an info point in the relevant scene's `LevelConfig.infoPoints` with matching `id`. Zone IDs default to the content ID, so the same string identifies both the zone and the dialog.
 
 ### Add a quiz
-Add the question set to `src/config/quizData.ts` keyed by ID. Quiz state is tracked automatically by `QuizManager`.
+Add the question set under `src/config/quiz/` (re-exported from `index.ts`) keyed by ID. Quiz state is tracked automatically by `QuizManager`.
 
 ### Add a zone
 Register in the scene's `create()`:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ ships with zero image assets and only a handful of music files.
 | Config        | `src/config/` — `gameConfig`, `levelData`, `audioConfig`, plus barrel re-exports for per-floor info + quiz |
 | Floors        | `src/features/floors/<floor>/` — Scene + `info.ts` + `quiz.ts` (+ optional `enemies.ts`) co-located |
 | Scenes        | `src/scenes/` — infrastructure scenes only: `core/` (Boot, Menu), `elevator/` |
-| Product scenes | `src/features/products/` — product content scenes: `hall/`, `rooms/`         |
+| Product scenes | `src/features/products/rooms/` — product content scenes (one per ISY room)   |
 | Entities      | `src/entities/` — gameplay objects (Player, Elevator, Token, Enemy)              |
 | Systems       | `src/systems/` — cross-cutting logic (EventBus, GameStateManager, Audio, Save, Progression) |
 | Input         | `src/input/` — semantic-action layer; import from `input/` only                  |

--- a/README.md
+++ b/README.md
@@ -23,11 +23,15 @@ You are an IT architect navigating the **Architecture Elevator** — a central s
 
 ### Floors
 
-| Floor | Department | Theme |
+Defined in `src/config/gameConfig.ts` (`FLOORS`) and `src/config/levelData.ts` (`LEVEL_DATA`).
+
+| Floor | Department | Notes |
 |-------|-----------|-------|
-| F0 | Lobby | Elevator shaft |
-| F1 | Platform Team | Green — Infrastructure tokens |
-| F2 | Cloud Team | Blue — Cloud certification tokens |
+| 0 | Lobby | Ground floor — elevator shaft, no gameplay tokens. |
+| 1 | Platform Team / Architecture Team | Split floor: Platform on the left, Architecture on the right. Green — Infrastructure AU. |
+| 3 | Business | Split floor: Product Leadership on the left, Customer Success on the right. Amber — Business AU. |
+| 4 | Executive Suite | Penthouse — Strategy AU. |
+| 5 | Products | Rendered directly by `ElevatorScene` / `ProductDoorManager` — one door per ISY product, no standalone scene. |
 
 ## Development
 

--- a/docs/architecture.md
+++ b/docs/architecture.md
@@ -34,9 +34,7 @@ src/
 │       ├── product/          Product Leadership — Business floor, right room.
 │       └── executive/        ExecutiveSuiteScene.ts (penthouse).
 │   └── products/
-│       ├── hall/
-│       │   └── ProductsHallScene.ts  Floor 5 hall — one door per ISY product.
-│       └── rooms/            Individual product rooms reached from the hall.
+│       └── rooms/            Individual product rooms reached from the Products floor doors.
 │           ├── ProductRoomScene.ts            Shared base for product rooms below.
 │           ├── ProductIsyProjectControlsScene.ts
 │           ├── ProductIsyBeskrivelseScene.ts
@@ -122,7 +120,7 @@ Use this to find the right file to edit for a given feature.
 | Architecture Team room              | `features/floors/architecture/{ArchitectureTeamScene,info,quiz}.ts`                    |
 | Finance room                        | `features/floors/finance/{FinanceTeamScene,info,quiz}.ts`                              |
 | Product Leadership                  | `features/floors/product/{ProductLeadershipScene,info,quiz}.ts`                        |
-| Products hall + product rooms       | `features/products/hall/ProductsHallScene.ts`, `features/products/rooms/Product*Scene.ts` |
+| Products floor + product rooms      | `scenes/elevator/ProductDoorManager.ts` (doors on the Products floor), `features/products/rooms/Product*Scene.ts` |
 | Executive Suite                     | `features/floors/executive/{ExecutiveSuiteScene,info,quiz}.ts`                         |
 | Shared floor base / managers        | `features/floors/_shared/*.ts`                                                         |
 | Elevator shaft + transitions        | `scenes/elevator/*.ts`                                                                 |
@@ -146,15 +144,17 @@ Use this to find the right file to edit for a given feature.
 
 ```
 BootScene  →  MenuScene  →  ElevatorScene  ↔  Floor scenes (features/floors/*)
-                                            ↘  ProductsHallScene  →  product rooms
+                                            ↘  product rooms (features/products/rooms/*)
 ```
 
 `BootScene` generates every sprite + sound once, creates the
 `GameStateManager`, and hands off to `MenuScene`. `ElevatorScene` is
 the central shaft; rides transition into the floor scenes in
 `features/floors/<floor>/` (each a thin wrapper around the shared
-`LevelScene`). The Products hall exits into individual product rooms
-under `features/products/rooms/`.
+`LevelScene`). The Products floor is rendered directly by
+`ElevatorScene` / `scenes/elevator/ProductDoorManager.ts` — one door
+per ISY product, each door launching the corresponding
+`features/products/rooms/Product*Scene.ts`.
 
 ### Scene hand-off
 

--- a/docs/issue-audio-phase3.md
+++ b/docs/issue-audio-phase3.md
@@ -1,5 +1,7 @@
 ## Audio — Music & Sound Effects (Phase 3)
 
+> **Status: shipped — preserved as historical spec.** Scene music is driven by `SCENE_MUSIC` in `src/config/audioConfig.ts`; procedural SFX come from `src/systems/SoundGenerator.ts`; playback and mute are handled by `src/systems/AudioManager.ts` + `src/plugins/MusicPlugin.ts`; mute persists under localStorage key `architect_audio_muted_v1`. Keep this file for design context; do not treat the checklist below as an active TODO.
+
 Add background music and sound effects to enhance game feel.
 
 ### Music
@@ -26,12 +28,12 @@ Add background music and sound effects to enhance game feel.
 - Music should loop per scene, crossfade on scene transitions
 - SFX should be short, retro-style (8-bit or chiptune)
 - Consider using free assets from [opengameart.org](https://opengameart.org) or [freesound.org](https://freesound.org)
-- Audio files go in `public/assets/audio/`
-- Add mute/volume toggle to HUD
+- Audio files go in `public/music/` (loaded by `BootScene.preload()` via `STATIC_MUSIC_ASSETS` in `src/config/audioConfig.ts`). No `public/assets/audio/` directory exists.
+- Add mute toggle to HUD (volume slider is not implemented — only mute).
 
 ### Acceptance Criteria
 
-- [ ] Background music for each scene
-- [ ] SFX for core actions (jump, collect, elevator)
-- [ ] Mute toggle in HUD
-- [ ] Audio doesn't play until user interacts (browser autoplay policy)
+- [x] Background music for each scene
+- [x] SFX for core actions (jump, collect, elevator)
+- [x] Mute toggle in HUD
+- [x] Audio doesn't play until user interacts (browser autoplay policy)

--- a/docs/issue-enemies-phase2.md
+++ b/docs/issue-enemies-phase2.md
@@ -1,5 +1,7 @@
 ## Enemies & Obstacles (Phase 2)
 
+> **Status: shipped — preserved as historical spec.** Base `Enemy` class, `Slime` / `BureaucracyBot` subclasses, Arcade-physics patrol AI, AU-loss on contact, and level-config placement all live in `src/entities/Enemy.ts`, `src/entities/enemies/`, and each floor's `LevelConfig.enemies`. Keep this file for design context; do not treat the checklist below as an active TODO.
+
 Add enemies and environmental hazards to floor levels to create gameplay challenge.
 
 ### Proposed Enemy Types
@@ -17,7 +19,7 @@ Add enemies and environmental hazards to floor levels to create gameplay challen
 
 ### Acceptance Criteria
 
-- [ ] At least one enemy type per floor
-- [ ] Enemy contact has a consequence (lose AU / respawn)
-- [ ] Enemies have idle/patrol animations
-- [ ] Enemies are placed via level config (same pattern as platforms/tokens)
+- [x] At least one enemy type per floor
+- [x] Enemy contact has a consequence (lose AU / respawn)
+- [x] Enemies have idle/patrol animations
+- [x] Enemies are placed via level config (same pattern as platforms/tokens)

--- a/public/music/README.md
+++ b/public/music/README.md
@@ -1,44 +1,40 @@
 # Music Assets
 
-Background music is loaded from the MP3 files in this directory:
+Background music for the game lives in this directory as MP3 / OGG files organized by pack. Files are declared in `STATIC_MUSIC_ASSETS` in `src/config/audioConfig.ts` and loaded by `BootScene.preload()` (which iterates that array). Scene-to-track mapping is defined by `SCENE_MUSIC` in the same config file and applied automatically by `src/plugins/MusicPlugin.ts`.
 
-- `retro-synth/retro_synth.mp3` — default game music (MenuScene, PlatformTeamScene, Floor2Scene)
-- `elevator-jazz/elevator_jazz.mp3` — elevator shaft (ElevatorScene)
+SFX (jump, land, token collect, quiz feedback, info-card / link clicks, elevator cues, etc.) are **not** loaded from this directory — they are procedurally generated at runtime by `src/systems/SoundGenerator.ts`. `src/systems/MusicGenerator.ts` produces a procedural lullaby used in the lobby sofa scene, and is otherwise retained as an unused fallback.
 
-These are loaded in `src/scenes/BootScene.ts` via `this.load.audio(...)`. SFX (jumps, footsteps, quiz feedback, info-card and link clicks) remain procedurally generated in `src/systems/SoundGenerator.ts`.
+## Loaded tracks
 
-The procedural music generator `src/systems/MusicGenerator.ts` is retained for reference / fallback but is no longer called.
+The tracks currently wired up in `STATIC_MUSIC_ASSETS`:
 
-## 80s Retro Synth (default game music)
+| Asset key | File | Used by (`SCENE_MUSIC`) |
+| --- | --- | --- |
+| `music_menu` | `8bit-chiptune/bgm_menu.mp3` | `MenuScene` |
+| `music_elevator_jazz` | `elevator-jazz/elevator_jazz.mp3` | `ElevatorScene` |
+| `music_elevator_ride` | `8bit-chiptune/bgm_action_3.mp3` | Emitted imperatively by `ElevatorController` during an active ride. |
+| `music_floor1` | `8bit-chiptune/bgm_action_1.mp3` | `ArchitectureTeamScene` |
+| `music_floor2` | `8bit-chiptune/bgm_action_2.mp3` | `FinanceTeamScene`, `ProductLeadershipScene`, `CustomerSuccessScene`, `ExecutiveSuiteScene`, and the Product sub-scenes (`ProductIsyProjectControlsScene`, `ProductIsyBeskrivelseScene`, `ProductIsyRoadScene`, `ProductAdminLisensScene`) |
+| `music_platform` | `retro-synth/shadow_operations-loop1.ogg` | `PlatformTeamScene` |
+| `music_quiz` | `retro-synth/hostile_territory-loop1.ogg` | `QuizDialog` emits `music:push` while a quiz is active, then pops back to scene music. |
 
-Used in: MenuScene, PlatformTeamScene, Floor2Scene
+## Unused tracks present on disk
 
-| Source | Link |
-|--------|------|
-| OpenGameArt — Retro Synthwave Loops | https://opengameart.org/content/retro-synthwave-loops |
-| OpenGameArt — CC0 Retro Music | https://opengameart.org/content/cc0-retro-music |
-| OpenGameArt — Calm Ambient 2 (Synthwave 15k) | https://opengameart.org/content/calm-ambient-2-synthwave-15k |
-| OpenGameArt — 8-bit Music Pack (Loopable) | https://opengameart.org/content/8-bit-music-pack-loopable |
-| Pixabay — Synthwave Loop | https://pixabay.com/music/search/synthwave%20loop/ |
-| Pixabay — 80s Synth | https://pixabay.com/music/search/80s%20synth/ |
-| Pixabay — Retrogaming | https://pixabay.com/music/search/retrogaming/ |
+The following files are part of the library but are not currently referenced by `STATIC_MUSIC_ASSETS`. They are kept so future floors / UI can pick them up without a round-trip through asset sourcing:
 
-## Jazzy Elevator Music (ElevatorScene)
+- `8bit-chiptune/bgm_action_4.mp3`
+- `8bit-chiptune/bgm_action_5.mp3`
+- `retro-synth/retro_synth.mp3`
+- `retro-synth/deadly_contracts-loop1.ogg`
+- `retro-synth/going_undercover-loop1.ogg`
+- `retro-synth/the_price_of_freedom-loop1.ogg`
 
-Used in: ElevatorScene (elevator shaft)
+## Swapping in or adding a track
 
-| Source | Link |
-|--------|------|
-| Pixabay — Jazz Lounge Elevator Music | https://pixabay.com/music/elevator-music-jazz-lounge-elevator-music-332339/ |
-| Pixabay — Lounge Jazz Elevator Music | https://pixabay.com/music/elevator-music-lounge-jazz-elevator-music-342629/ |
-| Pixabay — Elevator Music Search | https://pixabay.com/music/search/elevator%20music%20jazz/ |
-| Archive.org — Elevator Music (Kevin MacLeod, CC0) | https://archive.org/details/elevator-musicchosic.com |
-| Archive.org — Elevator Music Bossa Nova | https://archive.org/details/elevator-music-bossa-nova-background-music-version-60s |
-
-## Swapping in a different track
-
-To switch to a different MP3, drop it into the appropriate subdirectory and update the path in `src/scenes/BootScene.ts` (the `this.load.audio(...)` calls in `preload()`). The EventBus, MusicPlugin and AudioManager will pick up the new file with no further changes.
+1. Drop the file into the appropriate subdirectory (`8bit-chiptune/`, `elevator-jazz/`, or `retro-synth/`) — or create a new pack directory.
+2. Add an entry to `STATIC_MUSIC_ASSETS` in `src/config/audioConfig.ts` with a `music_<name>` key and the path relative to `public/`.
+3. Point one or more scenes at the new key in `SCENE_MUSIC` (same file). `MusicPlugin` picks it up automatically on the next scene transition — no scene code changes required.
 
 ## Licensing
 
-All sources listed above offer CC0 or royalty-free tracks. Always verify the license on the specific track you download. Even for CC0 content, it's good practice to credit the author here.
+Tracks come from royalty-free / CC0 sources (OpenGameArt, Pixabay, Archive.org, and bundled chiptune and retro-synth packs). Verify the specific licence of any track you add before committing it, and note the author / source here if the licence requires attribution.

--- a/public/music/README.md
+++ b/public/music/README.md
@@ -8,15 +8,15 @@ SFX (jump, land, token collect, quiz feedback, info-card / link clicks, elevator
 
 The tracks currently wired up in `STATIC_MUSIC_ASSETS`:
 
-| Asset key | File | Used by (`SCENE_MUSIC`) |
+| Asset key | File | Used by |
 | --- | --- | --- |
-| `music_menu` | `8bit-chiptune/bgm_menu.mp3` | `MenuScene` |
-| `music_elevator_jazz` | `elevator-jazz/elevator_jazz.mp3` | `ElevatorScene` |
-| `music_elevator_ride` | `8bit-chiptune/bgm_action_3.mp3` | Emitted imperatively by `ElevatorController` during an active ride. |
-| `music_floor1` | `8bit-chiptune/bgm_action_1.mp3` | `ArchitectureTeamScene` |
-| `music_floor2` | `8bit-chiptune/bgm_action_2.mp3` | `FinanceTeamScene`, `ProductLeadershipScene`, `CustomerSuccessScene`, `ExecutiveSuiteScene`, and the Product sub-scenes (`ProductIsyProjectControlsScene`, `ProductIsyBeskrivelseScene`, `ProductIsyRoadScene`, `ProductAdminLisensScene`) |
-| `music_platform` | `retro-synth/shadow_operations-loop1.ogg` | `PlatformTeamScene` |
-| `music_quiz` | `retro-synth/hostile_territory-loop1.ogg` | `QuizDialog` emits `music:push` while a quiz is active, then pops back to scene music. |
+| `music_menu` | `8bit-chiptune/bgm_menu.mp3` | `MenuScene` (via `SCENE_MUSIC`) |
+| `music_elevator_jazz` | `elevator-jazz/elevator_jazz.mp3` | `ElevatorScene` (via `SCENE_MUSIC`) |
+| `music_elevator_ride` | `8bit-chiptune/bgm_action_3.mp3` | `ElevatorController` — emitted imperatively with `music:play` during an active ride. |
+| `music_floor1` | `8bit-chiptune/bgm_action_1.mp3` | `ArchitectureTeamScene` (via `SCENE_MUSIC`) |
+| `music_floor2` | `8bit-chiptune/bgm_action_2.mp3` | `FinanceTeamScene`, `ProductLeadershipScene`, `CustomerSuccessScene`, `ExecutiveSuiteScene`, and the Product sub-scenes (`ProductIsyProjectControlsScene`, `ProductIsyBeskrivelseScene`, `ProductIsyRoadScene`, `ProductAdminLisensScene`) (via `SCENE_MUSIC`) |
+| `music_platform` | `retro-synth/shadow_operations-loop1.ogg` | `PlatformTeamScene` (via `SCENE_MUSIC`) |
+| `music_quiz` | `retro-synth/hostile_territory-loop1.ogg` | `QuizDialog` — emits `music:push` while a quiz is active, then pops back to scene music. |
 
 ## Unused tracks present on disk
 


### PR DESCRIPTION
Sync CLAUDE.md ↔ .github/copilot-instructions.md and bring every
markdown file in line with the current code.

- Fix LevelScene path: src/scenes/LevelScene.ts → src/features/floors/_shared/LevelScene.ts
  (+ its Level* sibling helpers) in CLAUDE.md, copilot-instructions.md,
  and the new-scene skill template/import.
- Update repo-structure trees to show src/features/floors/, src/scenes/core/,
  src/scenes/elevator/, and src/config/{info,quiz}/ barrel dirs.
- Add missing skills (caveman-mode, setup-project) to the .github/skills
  listing; document new AudioManager mute-key architect_audio_muted_v1;
  clarify SaveManager slot key format architect_<slot>_v1.
- Rewrite setup-project skill for an existing clone (TS, not .js bootstrap);
  add POSIX equivalents alongside Windows paths in git-worktree skill;
  drop stale features/products/hall references (only rooms/ exists).
- Mark issue-enemies-phase2.md and issue-audio-phase3.md as shipped;
  fix public/assets/audio/ → public/music/ path error.
- Rewrite public/music/README.md with the actual 7 loaded tracks and
  SCENE_MUSIC assignments (was listing 2); correct music_elevator_ride
  + music_quiz usage notes.
- Expand README floors table to all 5 floors (lobby/platform/business/
  executive/products); fix CONTRIBUTING and docs/architecture.md to
  drop stale ProductsHallScene / hall/ references.

https://claude.ai/code/session_01PJjMWju1YyrqMdvTepLjNu