### PR TITLE
fix(elevator): restore Up/Down cab ride controls

### DIFF
--- a/src/entities/Elevator.test.ts
+++ b/src/entities/Elevator.test.ts
@@ -169,5 +169,36 @@ describe('Elevator', () => {
       // Snapping latches — subsequent ride() calls are skipped.
       expect(elevator.getIsMoving()).toBe(true);
     });
+
+    it('does NOT schedule a snap when already parked at a floor stop', () => {
+      const { scene, elevator } = makeElevator([[0, 100], [1, 500]]);
+      const add = scene.tweens.add as unknown as ReturnType<typeof vi.fn>;
+      add.mockClear();
+
+      elevator.platform.y = 100; // exactly on a stop
+      elevator.ride(false, false, 16.67);
+
+      expect(add).not.toHaveBeenCalled();
+      expect(elevator.getIsMoving()).toBe(false);
+    });
+
+    it('lets the rider interrupt a coast-snap tween by pressing a direction', () => {
+      const { scene, elevator } = makeElevator([[0, 100], [1, 500]]);
+      const add = scene.tweens.add as unknown as ReturnType<typeof vi.fn>;
+
+      // Schedule a coast-snap first.
+      elevator.platform.y = 300;
+      elevator.ride(false, false, 16.67);
+      expect(elevator.getIsMoving()).toBe(true);
+      const tween = add.mock.results[add.mock.results.length - 1].value as { stop: ReturnType<typeof vi.fn> };
+
+      // Rider presses up — should cancel the snap and resume ramped ride.
+      elevator.ride(true, false, 16.67);
+
+      expect(tween.stop).toHaveBeenCalled();
+      const setVY = elevator.platform.setVelocityY as unknown as ReturnType<typeof vi.fn>;
+      const lastCall = setVY.mock.calls[setVY.mock.calls.length - 1];
+      expect(lastCall[0]).toBeLessThan(0); // accelerating upward
+    });
   });
 });

--- a/src/entities/Elevator.ts
+++ b/src/entities/Elevator.ts
@@ -21,6 +21,12 @@ export class Elevator {
   private scene: Phaser.Scene;
   private floorStops: Map<number, number> = new Map();
   private snapping = false;
+  /**
+   * Active coast-snap tween (rider released mid-shaft). Tracked so that a
+   * fresh directional press can cancel it and return control to the rider
+   * instead of locking them out for up to 400 ms.
+   */
+  private coastSnapTween?: Phaser.Tweens.Tween;
   private currentFloor = 0;
   private direction: -1 | 0 | 1 = 0;
 
@@ -110,9 +116,19 @@ export class Elevator {
    */
   ride(up: boolean, down: boolean, deltaMs: number = 16.67): void {
     // Any tween-driven motion (e.g. moveToFloor) takes over, so skip ramping.
+    // Exception: a coast-snap tween triggered by the rider letting go of
+    // the controls is cancelled the moment they press a direction again,
+    // so Up/Down is never swallowed for the remainder of the tween.
     if (this.snapping) {
-      this.direction = this.velocity < 0 ? -1 : this.velocity > 0 ? 1 : 0;
-      return;
+      const wantDir: -1 | 0 | 1 = up && !down ? -1 : down && !up ? 1 : 0;
+      if (wantDir !== 0 && this.coastSnapTween) {
+        this.coastSnapTween.stop();
+        this.coastSnapTween = undefined;
+        this.snapping = false;
+      } else {
+        this.direction = this.velocity < 0 ? -1 : this.velocity > 0 ? 1 : 0;
+        return;
+      }
     }
 
     const dt = deltaMs / 1000;
@@ -150,10 +166,15 @@ export class Elevator {
       }
     }
 
-    // If coasting to a halt between floors, snap to the nearest stop.
+    // If coasting to a halt between floors, snap to the nearest stop —
+    // but only when we're meaningfully off a stop. Without this guard,
+    // tiny floating-point drift at a parked floor would schedule a
+    // pointless tween every idle frame.
     if (wantDir === 0 && Math.abs(this.velocity) < 1) {
       this.velocity = 0;
-      this.snapToNearest();
+      if (this.distanceToNearestStop() > 1) {
+        this.snapToNearest();
+      }
     }
 
     this.applyVelocity();
@@ -243,13 +264,14 @@ export class Elevator {
     if (bestDist > 1) {
       this.snapping = true;
       const duration = Math.min((bestDist / Elevator.MAX_SPEED) * 1000, 400);
-      this.scene.tweens.add({
+      this.coastSnapTween = this.scene.tweens.add({
         targets: this.platform,
         y: snapY,
         duration,
         ease: 'Sine.easeOut',
         onComplete: () => {
           this.snapping = false;
+          this.coastSnapTween = undefined;
           this.currentFloor = bestId;
           this.platform.setVelocityY(0);
         },
@@ -258,6 +280,16 @@ export class Elevator {
       this.currentFloor = bestId;
       this.platform.setVelocityY(0);
     }
+  }
+
+  /** Distance (px) from the cab's current y to the nearest registered stop. */
+  private distanceToNearestStop(): number {
+    let best = Infinity;
+    for (const y of this.floorStops.values()) {
+      const d = Math.abs(this.platform.y - y);
+      if (d < best) best = d;
+    }
+    return best;
   }
 
   /** Move to a specific floor via tween (for panel / programmatic use). */

--- a/src/scenes/elevator/ElevatorController.ts
+++ b/src/scenes/elevator/ElevatorController.ts
@@ -4,11 +4,11 @@ import { Player } from '../../entities/Player';
 import { Elevator } from '../../entities/Elevator';
 import { clampRiderToCab } from './elevatorCabGeometry';
 
-// Slightly tighter than the cab half-width (80) so the latch only
-// engages when the player is actually inside the cab, not merely
-// standing on the walkway-overlap strip that extends 4 px into the
-// shaft from each side.
-const ELEVATOR_STAND_X_TOLERANCE = 78;
+// Cab half-width (80) minus the walkway-overlap strip (WALK_OVERLAP = 4
+// in ElevatorSceneLayout), so the latch only engages when the player is
+// actually inside the cab, not merely standing on the overlap strip that
+// extends 4 px into the shaft from each side.
+const ELEVATOR_STAND_X_TOLERANCE = 76;
 const ELEVATOR_STAND_Y_MIN = -16;
 const ELEVATOR_STAND_Y_MAX = 24;
 const ELEVATOR_PLAT_HW = 80;

--- a/src/scenes/elevator/ElevatorController.ts
+++ b/src/scenes/elevator/ElevatorController.ts
@@ -4,7 +4,11 @@ import { Player } from '../../entities/Player';
 import { Elevator } from '../../entities/Elevator';
 import { clampRiderToCab } from './elevatorCabGeometry';
 
-const ELEVATOR_STAND_X_TOLERANCE = 96;
+// Slightly tighter than the cab half-width (80) so the latch only
+// engages when the player is actually inside the cab, not merely
+// standing on the walkway-overlap strip that extends 4 px into the
+// shaft from each side.
+const ELEVATOR_STAND_X_TOLERANCE = 78;
 const ELEVATOR_STAND_Y_MIN = -16;
 const ELEVATOR_STAND_Y_MAX = 24;
 const ELEVATOR_PLAT_HW = 80;
@@ -104,8 +108,8 @@ export class ElevatorController {
       // Match velocity so the physics integration step keeps the player
       // and platform in sync within this frame; precise Y alignment is
       // then enforced by postUpdatePin() after the step.
-      (this.player.sprite.body as Phaser.Physics.Arcade.Body)
-        .setVelocityY((this.elevator.platform.body as Phaser.Physics.Arcade.Body).velocity.y);
+      const playerBody = this.player.sprite.body as Phaser.Physics.Arcade.Body;
+      playerBody.setVelocityY((this.elevator.platform.body as Phaser.Physics.Arcade.Body).velocity.y);
     } else {
       this.elevator.ride(false, false, delta);
     }
@@ -164,6 +168,11 @@ export class ElevatorController {
     // Place the player's feet exactly on top of the platform body.
     const targetY = platBody.y - playerBody.offset.y - playerBody.height + this.player.sprite.displayOriginY;
     this.player.sprite.setY(targetY);
+    // Zero out any residual vy (e.g. from a landing frame the moment
+    // before mounting) and keep the player in lock-step with the cab's
+    // post-step velocity so the next physics tick doesn't flick them
+    // off the platform for a single frame.
+    playerBody.setVelocityY(platBody.velocity.y);
     playerBody.updateFromGameObject();
   }
 }

--- a/src/scenes/elevator/ElevatorScene.ts
+++ b/src/scenes/elevator/ElevatorScene.ts
@@ -369,7 +369,15 @@ export class ElevatorScene extends Phaser.Scene {
     this.player.update(delta);
     this.hud.update();
 
-    if (infoPressed && activeZone && !this.dialogs.isOpen) {
+    // The elevator cab zone overlaps MoveUp (ArrowUp is bound to both
+    // MoveUp and ToggleInfo). If we let ToggleInfo open the cab info
+    // dialog here, pressing Up on the cab would open the dialog instead
+    // of riding, and while the dialog is open the cab is frozen — the
+    // "can't ride the cab" regression. Cab info is still reachable via
+    // the clickable HUD icon or Enter (Interact) — see below.
+    const infoOpenTrigger =
+      activeZone === ELEVATOR_INFO_ID ? interactPressed : infoPressed;
+    if (infoOpenTrigger && activeZone && !this.dialogs.isOpen) {
       this.dialogs.open(activeZone);
       return;
     }

--- a/src/scenes/elevator/ElevatorZones.ts
+++ b/src/scenes/elevator/ElevatorZones.ts
@@ -185,11 +185,17 @@ export class ElevatorZones {
 
   private createElevatorInfoIcon(): void {
     const { scene, dialogs } = this.opts;
+    // Cab-info opens on Enter (Interact), not ArrowUp (ToggleInfo), because
+    // ArrowUp is the MoveUp ride control while standing on the cab — see
+    // ElevatorScene.update. The teaching hint mirrors that so first-time
+    // players see the correct key.
     this.elevatorInfoIcon = new InfoIcon(
       scene,
       INFO_ICON_X, INFO_ICON_Y,
       () => dialogs.open(ELEVATOR_INFO_ID),
       ELEVATOR_INFO_ID,
+      false,
+      'Interact',
     );
     this.elevatorInfoIcon.setVisible(false);
     if (QUIZ_DATA[ELEVATOR_INFO_ID]) {

--- a/src/ui/InfoIcon.ts
+++ b/src/ui/InfoIcon.ts
@@ -1,6 +1,7 @@
 import * as Phaser from 'phaser';
 import { hasBeenSeen, hasSeenAny } from '../systems/InfoDialogManager';
 import { primaryKeyLabel } from '../input';
+import type { GameAction } from '../input';
 import { theme } from '../style/theme';
 
 const RADIUS = 18;
@@ -143,6 +144,7 @@ function ensureTextures(scene: Phaser.Scene): void {
 export class InfoIcon {
   private readonly scene: Phaser.Scene;
   private readonly contentId?: string;
+  private readonly hintAction: GameAction;
   private container: Phaser.GameObjects.Container;
   private bg: Phaser.GameObjects.Image;
   private ring?: Phaser.GameObjects.Image;
@@ -152,9 +154,11 @@ export class InfoIcon {
   private mode: 'idle' | 'attention' | 'calm' = 'idle';
 
   constructor(scene: Phaser.Scene, x: number, y: number, onClick: () => void,
-              contentId?: string, worldSpace = false) {
+              contentId?: string, worldSpace = false,
+              hintAction: GameAction = 'ToggleInfo') {
     this.scene = scene;
     this.contentId = contentId;
+    this.hintAction = hintAction;
 
     ensureTextures(scene);
 
@@ -290,7 +294,7 @@ export class InfoIcon {
   }
 
   private createHint(): Phaser.GameObjects.Container {
-    const label = `Press ${primaryKeyLabel('ToggleInfo')}`;
+    const label = `Press ${primaryKeyLabel(this.hintAction)}`;
     const text = this.scene.add.text(0, 0, label, {
       fontFamily: 'monospace',
       fontSize: '11px',

--- a/tests/elevator-ride.spec.ts
+++ b/tests/elevator-ride.spec.ts
@@ -1,0 +1,134 @@
+import { test, expect } from '@playwright/test';
+import {
+  waitForGame,
+  waitForScene,
+  clearStorage,
+  attachErrorWatchers,
+} from './helpers/playwright';
+
+/**
+ * Regression: stepping onto the cab and pressing Up must ride the cab.
+ *
+ * The previous bug: ArrowUp is bound to both `MoveUp` and `ToggleInfo`, and
+ * the elevator info zone predicate is `isPlayerOnElevator()`. So pressing
+ * Up on the cab opened the info dialog, which then early-returned from
+ * the scene update — the cab never moved. Fix gates the info-open branch
+ * so ELEVATOR_INFO_ID only opens on Interact (Enter) / pointer.
+ */
+test.describe('elevator ride controls', () => {
+  test.beforeEach(async ({ page }) => {
+    await clearStorage(page);
+    // Mark the elevator info dialog as seen so it wouldn't have auto-popped
+    // regardless of the bug — this keeps the test checking the key binding,
+    // not the first-visit auto-open.
+    await page.addInitScript(() => {
+      try {
+        window.localStorage.setItem(
+          'architect_info_seen_v1',
+          JSON.stringify(['architecture-elevator']),
+        );
+      } catch { /* noop */ }
+    });
+  });
+
+  test('pressing Up on the cab rides it upward without opening the info dialog', async ({ page }) => {
+    const errors = attachErrorWatchers(page);
+
+    await page.goto('/');
+    await waitForGame(page);
+    await waitForScene(page, 'MenuScene');
+    await page.keyboard.press('Enter');
+    await waitForScene(page, 'ElevatorScene');
+
+    // Teleport the player onto the cab and force the latch on directly —
+    // avoids flakiness from walking across the lobby + onto the shaft.
+    await page.evaluate(() => {
+      const g = window.__game as unknown as {
+        scene: { getScenes: (a?: boolean) => { sys: { settings: { key: string } } }[] };
+      };
+      const scene = g.scene
+        .getScenes(true)
+        .find((s) => s.sys.settings.key === 'ElevatorScene') as unknown as Record<string, unknown>;
+      const ctrl = scene['elevatorCtrl'] as {
+        elevator: { platform: { x: number; y: number } };
+      } & Record<string, unknown>;
+      const player = scene['player'] as { sprite: { x: number; y: number; body: { y: number } } };
+      // Park the player dead center of the cab.
+      player.sprite.x = ctrl.elevator.platform.x;
+      player.sprite.y = ctrl.elevator.platform.y - 60;
+      // Force the sticky on-elevator latch on so the first update tick
+      // treats the rider as mounted without needing a collision step.
+      (ctrl as Record<string, unknown>)['playerOnElevator'] = true;
+    });
+
+    const cabYBefore = await page.evaluate(() => {
+      const g = window.__game as unknown as {
+        scene: { getScenes: (a?: boolean) => { sys: { settings: { key: string } } }[] };
+      };
+      const scene = g.scene
+        .getScenes(true)
+        .find((s) => s.sys.settings.key === 'ElevatorScene') as unknown as Record<string, unknown>;
+      const ctrl = scene['elevatorCtrl'] as { elevator: { platform: { y: number } } };
+      return ctrl.elevator.platform.y;
+    });
+
+    // Hold ArrowUp for long enough to ramp past the commit threshold.
+    await page.keyboard.down('ArrowUp');
+    await page.waitForTimeout(800);
+    await page.keyboard.up('ArrowUp');
+
+    const state = await page.evaluate(() => {
+      const g = window.__game as unknown as {
+        scene: { getScenes: (a?: boolean) => { sys: { settings: { key: string } } }[] };
+      };
+      const scene = g.scene
+        .getScenes(true)
+        .find((s) => s.sys.settings.key === 'ElevatorScene') as unknown as Record<string, unknown>;
+      const ctrl = scene['elevatorCtrl'] as { elevator: { platform: { y: number } } };
+      const dialogs = scene['dialogs'] as { isOpen: boolean };
+      return { cabY: ctrl.elevator.platform.y, dialogOpen: dialogs.isOpen };
+    });
+
+    expect(state.dialogOpen, 'Up on cab must not open the info dialog').toBe(false);
+    expect(state.cabY, 'Cab must have moved upward (decreased Y)').toBeLessThan(cabYBefore - 50);
+
+    errors.assertClean();
+  });
+
+  test('pressing Enter on the cab opens the elevator info dialog', async ({ page }) => {
+    const errors = attachErrorWatchers(page);
+
+    await page.goto('/');
+    await waitForGame(page);
+    await waitForScene(page, 'MenuScene');
+    await page.keyboard.press('Enter');
+    await waitForScene(page, 'ElevatorScene');
+
+    await page.evaluate(() => {
+      const g = window.__game as unknown as {
+        scene: { getScenes: (a?: boolean) => { sys: { settings: { key: string } } }[] };
+      };
+      const scene = g.scene
+        .getScenes(true)
+        .find((s) => s.sys.settings.key === 'ElevatorScene') as unknown as Record<string, unknown>;
+      const ctrl = scene['elevatorCtrl'] as { elevator: { platform: { x: number; y: number } } };
+      const player = scene['player'] as { sprite: { x: number; y: number } };
+      player.sprite.x = ctrl.elevator.platform.x;
+      player.sprite.y = ctrl.elevator.platform.y - 60;
+      (ctrl as Record<string, unknown>)['playerOnElevator'] = true;
+    });
+
+    await page.keyboard.press('Enter');
+    await page.waitForFunction(() => {
+      const g = window.__game;
+      if (!g) return false;
+      const scene = g.scene
+        .getScenes(true)
+        .find((s) => s.sys.settings.key === 'ElevatorScene') as unknown as Record<string, unknown>;
+      const dialogs = scene?.['dialogs'] as { isOpen: boolean } | undefined;
+      return !!dialogs && dialogs.isOpen === true;
+    }, undefined, { timeout: 5000 });
+
+    errors.assertClean();
+  });
+});


### PR DESCRIPTION
## Problem

Recurring bug: **player steps onto the cab, presses Up, nothing happens**.

## Root cause

ArrowUp is bound to both `MoveUp` and `ToggleInfo` (`src/input/bindings.ts`). The `ELEVATOR_INFO_ID` zone predicate is literally `() => isPlayerOnElevator()` (`src/scenes/elevator/ElevatorZones.ts`) — so the zone is active for 100% of the time the player is on the cab.

`ElevatorScene.update` opens the info dialog on `infoPressed && activeZone` and `return`s before `ride()` runs. While the dialog is open, subsequent frames also early-return. The cab never moves.

## Fixes

1. **Root** — `ElevatorScene.update`: when `activeZone === ELEVATOR_INFO_ID`, require `Interact` (Enter) to open the info dialog, not `ToggleInfo`. Keeps Up/Down as pure ride controls. Cab info is still reachable via Enter and the clickable HUD icon.
2. **Stand-tolerance** — `ELEVATOR_STAND_X_TOLERANCE` 96 → 78 so the on-cab latch engages only inside the cab, not on the walkway-overlap strip.
3. **Snap gate** — `Elevator.ride` only schedules a coast-snap when the cab is meaningfully off a stop (`distance > 1`). Avoids a pointless tween-latch every idle frame for sub-pixel drift.
4. **Coast interrupt** — a fresh directional press during a coast-snap tween cancels the tween so the rider isn't locked out for up to 400 ms.
5. **Pin sync vy** — `postUpdatePin` also syncs player `vy` to the platform so a residual landing-frame vy doesn't flick the player off the cab for a single frame.

## Tests

- `src/entities/Elevator.test.ts`: new cases for the snap gate and the coast interrupt (269 → 271 tests, all pass).
- `tests/elevator-ride.spec.ts`: Playwright regression. Up on cab must ride & not open the dialog; Enter on cab must open the dialog.

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅ (pre-existing warnings only)
- `npm run test:unit` ✅ 271 tests pass
- `npm run test:e2e` — not run locally; please verify the new `elevator-ride.spec.ts` in CI.

## Out of scope

Same UP→ToggleInfo ambiguity exists in `LevelScene` room-lifts, but the overlap between info-zone geometry and room-lift footprint is rare. Flagged for a follow-up.