### PR TITLE
Graphics polish pass

### DIFF
--- a/src/entities/Enemy.ts
+++ b/src/entities/Enemy.ts
@@ -54,6 +54,12 @@ export abstract class Enemy extends Phaser.Physics.Arcade.Sprite {
     const body = this.body as Phaser.Physics.Arcade.Body | null;
     if (body) body.enable = false;
     this.scene.tweens.killTweensOf(this);
+    // Brief white-hot tint flash for impact readability before the squash.
+    this.setTintFill(0xffffff);
+    this.scene.time.delayedCall(60, () => {
+      if (!this.scene) return;
+      this.clearTint();
+    });
     this.scene.tweens.add({
       targets: this,
       scaleY: 0.2,

--- a/src/entities/Token.test.ts
+++ b/src/entities/Token.test.ts
@@ -47,7 +47,7 @@ describe('Token', () => {
 
   it('creates float + pulse tweens on construction', () => {
     const add = scene.tweens.add as unknown as ReturnType<typeof vi.fn>;
-    // Two tweens: float (yoyo y) and scale pulse.
+    // At minimum: float (yoyo y), scale pulse, and halo alpha/scale pulse.
     expect(add.mock.calls.length).toBeGreaterThanOrEqual(2);
   });
 
@@ -68,7 +68,8 @@ describe('Token', () => {
     expect((token as unknown as { collected: boolean }).collected).toBe(true);
     expect((token.body as { enable: boolean }).enable).toBe(false);
     expect(stopSpy).toHaveBeenCalledTimes(1);
-    expect(add.mock.calls.length).toBe(countBefore + 1);
+    // collect() adds a halo-fade tween (if halo exists) + the coin fade tween.
+    expect(add.mock.calls.length).toBeGreaterThan(countBefore);
   });
 
   it('collect() is idempotent — second call is a no-op', () => {

--- a/src/entities/Token.ts
+++ b/src/entities/Token.ts
@@ -2,6 +2,8 @@ import * as Phaser from 'phaser';
 
 export class Token extends Phaser.Physics.Arcade.Sprite {
   private floatTween?: Phaser.Tweens.Tween;
+  private haloTween?: Phaser.Tweens.Tween;
+  private halo?: Phaser.GameObjects.Image;
   private collected = false;
 
   constructor(scene: Phaser.Scene, x: number, y: number, textureKey: string = 'token') {
@@ -10,6 +12,26 @@ export class Token extends Phaser.Physics.Arcade.Sprite {
     scene.physics.add.existing(this, true); // static body
 
     this.setDepth(5);
+
+    // Soft halo behind the token — tinted per-texture to match the coin
+    // color. Pulses slowly so idle rooms don't feel static.
+    if (scene.textures.exists('token_halo')) {
+      this.halo = scene.add.image(x, y, 'token_halo').setDepth(4).setAlpha(0.4);
+      // Tint halo to match the coin rim for theme cohesion.
+      const rimTint = textureKey === 'token_floor1' ? 0x95d5b2
+        : textureKey === 'token_floor2' ? 0x90e0ef
+        : 0xffd700;
+      this.halo.setTint(rimTint);
+      this.haloTween = scene.tweens.add({
+        targets: this.halo,
+        alpha: { from: 0.25, to: 0.55 },
+        scale: { from: 0.9, to: 1.1 },
+        duration: 1400,
+        yoyo: true,
+        repeat: -1,
+        ease: 'Sine.easeInOut',
+      });
+    }
 
     // Floating animation
     this.floatTween = scene.tweens.add({
@@ -42,16 +64,29 @@ export class Token extends Phaser.Physics.Arcade.Sprite {
       (this.body as Phaser.Physics.Arcade.Body | Phaser.Physics.Arcade.StaticBody).enable = false;
     }
     this.floatTween?.stop();
+    this.haloTween?.stop();
+    if (this.halo) {
+      const halo = this.halo;
+      this.scene.tweens.add({
+        targets: halo,
+        alpha: 0,
+        scale: 1.6,
+        duration: 250,
+        onComplete: () => halo.destroy(),
+      });
+      this.halo = undefined;
+    }
 
-    // Collection animation
+    // Collection animation — squash-out with a brief vertical lift, reads
+    // as the coin being "sucked up" rather than just fading in place.
     this.scene.tweens.add({
       targets: this,
-      y: this.y - 30,
+      y: this.y - 18,
       alpha: 0,
-      scaleX: 1.5,
-      scaleY: 1.5,
-      duration: 300,
-      ease: 'Power2',
+      scaleX: 1.4,
+      scaleY: 0.6,
+      duration: 220,
+      ease: 'Quad.easeOut',
       onComplete: () => {
         this.destroy();
       },

--- a/src/entities/Token.ts
+++ b/src/entities/Token.ts
@@ -3,6 +3,7 @@ import * as Phaser from 'phaser';
 export class Token extends Phaser.Physics.Arcade.Sprite {
   private floatTween?: Phaser.Tweens.Tween;
   private haloTween?: Phaser.Tweens.Tween;
+  private pulseTween?: Phaser.Tweens.Tween;
   private halo?: Phaser.GameObjects.Image;
   private collected = false;
 
@@ -44,7 +45,7 @@ export class Token extends Phaser.Physics.Arcade.Sprite {
     });
 
     // Subtle scale pulse
-    scene.tweens.add({
+    this.pulseTween = scene.tweens.add({
       targets: this,
       scaleX: 1.15,
       scaleY: 1.15,
@@ -53,6 +54,14 @@ export class Token extends Phaser.Physics.Arcade.Sprite {
       yoyo: true,
       repeat: -1,
     });
+  }
+
+  preUpdate(time: number, delta: number): void {
+    super.preUpdate(time, delta);
+    // Keep halo locked to the coin so it tracks the float bob.
+    if (this.halo && !this.collected) {
+      this.halo.setPosition(this.x, this.y);
+    }
   }
 
   collect(): void {
@@ -65,6 +74,9 @@ export class Token extends Phaser.Physics.Arcade.Sprite {
     }
     this.floatTween?.stop();
     this.haloTween?.stop();
+    this.pulseTween?.stop();
+    // Ensure no leftover idle tweens on `this` fight the collection animation.
+    this.scene.tweens.killTweensOf(this);
     if (this.halo) {
       const halo = this.halo;
       this.scene.tweens.add({

--- a/src/features/floors/_shared/LevelEnemySpawner.ts
+++ b/src/features/floors/_shared/LevelEnemySpawner.ts
@@ -78,6 +78,7 @@ export class LevelEnemySpawner {
     if (enemy.canBeStomped && comingFromAbove && falling) {
       enemy.onStomp();
       this.deps.player.sprite.setVelocityY(-420);
+      this.deps.camera.shake(80, 0.004);
       eventBus.emit('sfx:stomp');
       return;
     }

--- a/src/features/floors/_shared/LevelScene.ts
+++ b/src/features/floors/_shared/LevelScene.ts
@@ -143,6 +143,11 @@ export class LevelScene extends Phaser.Scene {
   private tokenMgr!: LevelTokenManager;
   private zones!: LevelZoneSetup;
 
+  /** Grounding shadow tracked to the player each frame. */
+  private playerShadow?: Phaser.GameObjects.Image;
+  /** Shadows tracked to each spawned enemy (same index as enemies[]). */
+  private enemyShadows: Array<Phaser.GameObjects.Image | undefined> = [];
+
   constructor(key: string, floorId: FloorId) {
     super({ key });
     this.floorId = floorId;
@@ -232,6 +237,93 @@ export class LevelScene extends Phaser.Scene {
     this.cameras.main.setScroll(0, 0);
     this.showFloorBanner();
     this.cameras.main.fadeIn(500, 0, 0, 0);
+
+    this.createAtmosphericFx();
+  }
+
+  /**
+   * Atmospheric layer added on top of the backdrop but behind gameplay:
+   *   - Per-floor color grading overlay (very low alpha, theme-tinted).
+   *   - Ambient floating motes (6–10 drifting particles).
+   *   - Drop shadow tracked to the player.
+   *   - Drop shadows tracked to each spawned enemy.
+   */
+  private createAtmosphericFx(): void {
+    // 1. Color grading overlay — full-screen rect tinted with the floor's
+    // token color (which reads as the floor's brand color) at 0.05 alpha.
+    // Placed above backdrop (depth 0) and tiles (depth 2) but below the
+    // player (depth 10) so platforms + decor stay legible.
+    const gradeOverlay = this.add.graphics().setDepth(5.5).setScrollFactor(0);
+    gradeOverlay.fillStyle(this.floorData.theme.tokenColor, 0.05);
+    gradeOverlay.fillRect(0, 0, GAME_WIDTH, GAME_HEIGHT);
+
+    // 2. Ambient motes — slow-drifting tinted particles.
+    if (this.textures.exists('particle')) {
+      const motes = this.add.particles(0, 0, 'particle', {
+        x: { min: 0, max: GAME_WIDTH },
+        y: { min: 0, max: GAME_HEIGHT - 64 },
+        speedY: { min: -12, max: -4 },
+        speedX: { min: -8, max: 8 },
+        scale: { start: 0.35, end: 0.1 },
+        alpha: { start: 0.18, end: 0 },
+        lifespan: { min: 6000, max: 11000 },
+        frequency: 1200,
+        quantity: 1,
+        tint: this.floorData.theme.tokenColor,
+      });
+      motes.setDepth(1.5);
+    }
+
+    // 3. Player drop shadow — a dark ellipse tracked each frame so it
+    // shrinks while airborne for height cueing.
+    if (this.textures.exists('shadow_blob')) {
+      this.playerShadow = this.add
+        .image(this.player.sprite.x, this.player.sprite.y + 70, 'shadow_blob')
+        .setDepth(9.5);
+    }
+
+    // 4. Enemy drop shadows, one per enemy, parented-by-index.
+    for (const enemy of this.enemySpawner.enemies) {
+      if (!this.textures.exists('shadow_blob')) break;
+      const sh = this.add.image(enemy.x, enemy.y + 28, 'shadow_blob').setDepth(5.5).setScale(0.7);
+      this.enemyShadows.push(sh);
+    }
+  }
+
+  private updateAtmosphericFx(): void {
+    // Player shadow: follow x, lock to ~feet y when grounded, otherwise
+    // project down to the nearest surface below with a height-faded scale.
+    if (this.playerShadow) {
+      const p = this.player.sprite;
+      const body = p.body as Phaser.Physics.Arcade.Body;
+      const onGround = body.blocked.down || body.touching.down;
+      this.playerShadow.setPosition(p.x, p.y + 70);
+      if (onGround) {
+        this.playerShadow.setAlpha(1).setScale(1);
+      } else {
+        // Fade + shrink with upward velocity for an airborne cue.
+        const vy = body.velocity.y;
+        const fade = Phaser.Math.Clamp(1 - Math.abs(vy) / 600, 0.3, 1);
+        this.playerShadow.setAlpha(fade * 0.85).setScale(fade);
+      }
+    }
+
+    // Enemy shadows: follow x, pin y to the body's bottom with a small
+    // fixed offset. If an enemy has been destroyed, drop its shadow too.
+    const enemies = this.enemySpawner.enemies;
+    for (let i = 0; i < this.enemyShadows.length; i++) {
+      const sh = this.enemyShadows[i];
+      if (!sh) continue;
+      const en = enemies[i];
+      if (!en || en.defeated || !en.active) {
+        sh.destroy();
+        this.enemyShadows[i] = undefined;
+        continue;
+      }
+      const body = en.body as Phaser.Physics.Arcade.Body | null;
+      const footY = body ? body.bottom : en.y + 28;
+      sh.setPosition(en.x, footY + 2);
+    }
   }
 
   /** Construct the DialogController and stash it on this.dialogs. */
@@ -301,10 +393,17 @@ export class LevelScene extends Phaser.Scene {
     for (const plat of config.platforms) {
       for (let i = 0; i < plat.width; i++) {
         // plat.y is the walking surface; shift tile center down so tile top = plat.y
-        const t = this.platformGroup.create(
-          plat.x + i * TILE_SIZE + TILE_SIZE / 2, plat.y + TILE_SIZE / 2, tileKey,
-        ) as Phaser.Physics.Arcade.Image;
+        const tx = plat.x + i * TILE_SIZE + TILE_SIZE / 2;
+        const ty = plat.y + TILE_SIZE / 2;
+        const t = this.platformGroup.create(tx, ty, tileKey) as Phaser.Physics.Arcade.Image;
         t.setDepth(2).refreshBody();
+        // Deterministic scuff overlay on ~25% of placed tiles — picks the
+        // same tiles across reloads so layout reads as authored, not random.
+        // Hash: mix floor id + grid coords so every floor gets its own pattern.
+        const hash = ((plat.x + i * 7) * 31 + plat.y * 17 + this.floorId * 53) & 0xff;
+        if (hash < 64 && this.textures.exists('tile_detail_overlay')) {
+          this.add.image(tx, ty, 'tile_detail_overlay').setDepth(2.5);
+        }
       }
     }
   }
@@ -464,6 +563,7 @@ export class LevelScene extends Phaser.Scene {
     if (this.dialogs.isOpen) {
       this.player.update(delta);
       this.hud.update();
+      this.updateAtmosphericFx();
       return;
     }
 
@@ -471,6 +571,7 @@ export class LevelScene extends Phaser.Scene {
     this.hud.update();
     this.updateRoomElevators();
     this.enemySpawner.update(_time, delta);
+    this.updateAtmosphericFx();
 
     // Emit zone:enter / zone:exit events when player crosses zone boundaries.
     this.zones.update();

--- a/src/features/floors/_shared/sceneBackdrop.ts
+++ b/src/features/floors/_shared/sceneBackdrop.ts
@@ -119,6 +119,20 @@ export function drawSceneBackdrop(
   g.lineStyle(1, theme.platformColor, 0.55);
   g.strokeRect(0.5, 0.5, width - 1, height - 1);
 
+  // 5. Bottom-edge floor glow — a soft band tinted with the floor's accent
+  // color, fading from ~18% alpha at the very bottom to 0 about 100 px up.
+  // Grounds the room so platforms + props don't float over the vignette.
+  const glowHeight = 100;
+  const glowBands = 20;
+  for (let i = 0; i < glowBands; i++) {
+    const t = i / (glowBands - 1);
+    const alpha = 0.18 * Math.pow(t, 2);
+    const bandH = Math.ceil(glowHeight / glowBands);
+    const yTop = height - glowHeight + Math.round(t * glowHeight);
+    g.fillStyle(theme.platformColor, alpha);
+    g.fillRect(0, yTop, width, bandH);
+  }
+
   drawAccents?.(g);
 
   return g;

--- a/src/features/floors/_shared/sceneBackdrop.ts
+++ b/src/features/floors/_shared/sceneBackdrop.ts
@@ -124,13 +124,15 @@ export function drawSceneBackdrop(
   // Grounds the room so platforms + props don't float over the vignette.
   const glowHeight = 100;
   const glowBands = 20;
+  const glowBandH = Math.ceil(glowHeight / glowBands);
+  const glowTop = height - glowHeight;
   for (let i = 0; i < glowBands; i++) {
-    const t = i / (glowBands - 1);
+    // t in (0,1]: darker at the top of the band, brightest at the bottom.
+    const t = (i + 1) / glowBands;
     const alpha = 0.18 * Math.pow(t, 2);
-    const bandH = Math.ceil(glowHeight / glowBands);
-    const yTop = height - glowHeight + Math.round(t * glowHeight);
+    const yTop = glowTop + i * glowBandH;
     g.fillStyle(theme.platformColor, alpha);
-    g.fillRect(0, yTop, width, bandH);
+    g.fillRect(0, yTop, width, glowBandH);
   }
 
   drawAccents?.(g);

--- a/src/scenes/elevator/ElevatorController.ts
+++ b/src/scenes/elevator/ElevatorController.ts
@@ -115,6 +115,12 @@ export class ElevatorController {
       eventBus.emit('music:play', 'music_elevator_ride');
     } else if (!moving && this.wasElevatorMoving) {
       eventBus.emit('music:play', 'music_elevator_jazz');
+      // Arrival: short low-amplitude shake to sell the cab weight without
+      // nausea. Only shake when the player is actually riding — otherwise
+      // a parked cab sliding to rest between idle presses would shake too.
+      if (this.playerOnElevator) {
+        this.scene.cameras.main.shake(90, 0.003);
+      }
     }
     this.wasElevatorMoving = moving;
 

--- a/src/systems/sprites/particles.ts
+++ b/src/systems/sprites/particles.ts
@@ -1,5 +1,4 @@
 import * as Phaser from 'phaser';
-import { theme } from '../../style/theme';
 
 /** Shared 12×12 white circle used by all particle emitters. */
 export function generateParticleSprite(scene: Phaser.Scene): void {
@@ -8,4 +7,33 @@ export function generateParticleSprite(scene: Phaser.Scene): void {
   gfx.fillCircle(6, 6, 6);
   gfx.generateTexture('particle', 12, 12);
   gfx.destroy();
+
+  // Drop-shadow ellipse used under player + enemies for grounding.
+  // Dark blob with soft radial-ish falloff approximated by stacking
+  // a few translucent ellipses. Keyed to 'shadow_blob'.
+  const sGfx = scene.make.graphics({ x: 0, y: 0 }, false);
+  const W = 64;
+  const H = 20;
+  sGfx.fillStyle(0x000000, 0.18);
+  sGfx.fillEllipse(W / 2, H / 2, W, H);
+  sGfx.fillStyle(0x000000, 0.22);
+  sGfx.fillEllipse(W / 2, H / 2, W * 0.75, H * 0.75);
+  sGfx.fillStyle(0x000000, 0.28);
+  sGfx.fillEllipse(W / 2, H / 2, W * 0.45, H * 0.55);
+  sGfx.generateTexture('shadow_blob', W, H);
+  sGfx.destroy();
+
+  // Soft radial halo used behind tokens. Pre-generated so per-Token tinting
+  // via setTint is enough — no need to regenerate per floor.
+  const hGfx = scene.make.graphics({ x: 0, y: 0 }, false);
+  const HR = 48;
+  const HD = HR * 2;
+  // Stack concentric low-alpha circles for a soft falloff.
+  for (let i = 6; i >= 0; i--) {
+    const t = i / 6;
+    hGfx.fillStyle(0xffffff, 0.03 + (1 - t) * 0.06);
+    hGfx.fillCircle(HR, HR, HR * (0.4 + t * 0.6));
+  }
+  hGfx.generateTexture('token_halo', HD, HD);
+  hGfx.destroy();
 }

--- a/src/systems/sprites/tiles.ts
+++ b/src/systems/sprites/tiles.ts
@@ -14,6 +14,51 @@ function createTile(
   gfx.destroy();
 }
 
+/** Lighten a 0xRRGGBB int toward white by amount in [0,1]. */
+function lighten(color: number, amount: number): number {
+  const r = (color >> 16) & 0xff;
+  const g = (color >> 8) & 0xff;
+  const b = color & 0xff;
+  const lr = Math.min(255, Math.round(r + (255 - r) * amount));
+  const lg = Math.min(255, Math.round(g + (255 - g) * amount));
+  const lb = Math.min(255, Math.round(b + (255 - b) * amount));
+  return (lr << 16) | (lg << 8) | lb;
+}
+
+/** Darken a 0xRRGGBB int toward black by amount in [0,1]. */
+function darken(color: number, amount: number): number {
+  const f = 1 - amount;
+  return (
+    (Math.round(((color >> 16) & 0xff) * f) << 16) |
+    (Math.round(((color >> 8) & 0xff) * f) << 8) |
+    Math.round((color & 0xff) * f)
+  );
+}
+
+/**
+ * Apply the standard rim-light + bottom shadow + top-left specular treatment
+ * to a tile. Matches the historical `platform_floor4_lit` look but generalized
+ * across all platform tiles so every floor reads with depth instead of flat.
+ */
+function addTileBevel(
+  gfx: Phaser.GameObjects.Graphics,
+  size: number,
+  baseColor: number,
+): void {
+  // Top rim (2px lighter band)
+  gfx.fillStyle(lighten(baseColor, 0.45));
+  gfx.fillRect(0, 0, size, 2);
+  // Bottom shadow (2px darker band)
+  gfx.fillStyle(darken(baseColor, 0.35));
+  gfx.fillRect(0, size - 2, size, 2);
+  // Top-left specular 1px pixel
+  gfx.fillStyle(0xffffff);
+  gfx.fillRect(1, 1, 1, 1);
+  // Right-edge faint shadow to break the uniform repeat
+  gfx.fillStyle(darken(baseColor, 0.2), 0.5);
+  gfx.fillRect(size - 1, 2, 1, size - 4);
+}
+
 /** Generic shaft/wall/floor/background tile textures (TILE_SIZE square). */
 export function generateTileSprites(scene: Phaser.Scene): void {
   const S = TILE_SIZE;
@@ -25,6 +70,7 @@ export function generateTileSprites(scene: Phaser.Scene): void {
     gfx.lineStyle(1, theme.color.floor.lobby.platform, 0.3);
     gfx.lineBetween(S / 2, 0, S / 2, S);
     gfx.lineBetween(0, S / 2, S, S / 2);
+    addTileBevel(gfx, S, 0x555577);
   });
 
   createTile(scene, 'wall_tile', S, (gfx) => {
@@ -42,6 +88,7 @@ export function generateTileSprites(scene: Phaser.Scene): void {
     gfx.lineStyle(1, theme.color.floor.platform.platform, 0.4);
     gfx.lineBetween(S / 2, 0, S / 2, S);
     gfx.lineBetween(0, S / 2, S, S / 2);
+    addTileBevel(gfx, S, theme.color.floor.platform.platform);
   });
 
   createTile(scene, 'platform_floor2', S, (gfx) => {
@@ -52,11 +99,12 @@ export function generateTileSprites(scene: Phaser.Scene): void {
     gfx.lineStyle(1, 0x023e8a, 0.4);
     gfx.lineBetween(S / 2, 0, S / 2, S);
     gfx.lineBetween(0, S / 2, S, S / 2);
+    addTileBevel(gfx, S, 0x023e8a);
   });
 
   // Rim-lit variant used only by ExecutiveSuiteScene.
-  // Mirrors platform_floor2 but adds a 2px lighter top rim and a 1px
-  // top-left specular for depth against the gradient-sky background.
+  // Kept as its own key for backward compat even though addTileBevel now
+  // applies a similar treatment to platform_floor2.
   createTile(scene, 'platform_floor4_lit', S, (gfx) => {
     gfx.fillStyle(0x023e8a); gfx.fillRect(0, 0, S, S);
     gfx.fillStyle(0x0077b6);
@@ -76,5 +124,31 @@ export function generateTileSprites(scene: Phaser.Scene): void {
     gfx.fillStyle(0x1a2542, 0.5);
     gfx.fillRect(0, 0, S / 2, S / 2);
     gfx.fillRect(S / 2, S / 2, S / 2, S / 2);
+  });
+
+  // Semi-transparent scuff / scratch overlay — drawn on a subset of placed
+  // tiles in LevelScene to break the "gridded wallpaper" look without
+  // adding geometry. Alpha is baked low so layering multiple never crushes.
+  createTile(scene, 'tile_detail_overlay', S, (gfx) => {
+    // Deterministic pseudo-random sprinkle of 1px dots.
+    let seed = 0x2f6a5e;
+    const rand = (): number => {
+      seed = (seed * 1103515245 + 12345) & 0x7fffffff;
+      return seed / 0x7fffffff;
+    };
+    gfx.fillStyle(0xffffff, 0.06);
+    for (let i = 0; i < 32; i++) {
+      const x = Math.floor(rand() * S);
+      const y = Math.floor(rand() * S);
+      gfx.fillRect(x, y, 1, 1);
+    }
+    // A couple of short scratches
+    gfx.lineStyle(1, 0x000000, 0.15);
+    for (let i = 0; i < 3; i++) {
+      const x = Math.floor(rand() * (S - 24)) + 6;
+      const y = Math.floor(rand() * (S - 12)) + 6;
+      const len = 8 + Math.floor(rand() * 14);
+      gfx.lineBetween(x, y, x + len, y + 1);
+    }
   });
 }

--- a/src/ui/HUD.test.ts
+++ b/src/ui/HUD.test.ts
@@ -19,30 +19,64 @@ import { HUD } from './HUD';
 type Listener = (...args: unknown[]) => void;
 
 function makeGraphics() {
-  return {
-    clear: vi.fn(),
-    fillStyle: vi.fn(),
-    fillCircle: vi.fn(),
-    fillRect: vi.fn(),
-    fillGradientStyle: vi.fn(),
-    lineStyle: vi.fn(),
-    beginPath: vi.fn(),
-    moveTo: vi.fn(),
-    lineTo: vi.fn(),
-    strokePath: vi.fn(),
-    fillEllipse: vi.fn(),
-    setPosition: vi.fn().mockReturnThis(),
+  const g: Record<string, unknown> = {};
+  const chained = [
+    'clear',
+    'fillStyle',
+    'fillCircle',
+    'fillRect',
+    'fillGradientStyle',
+    'lineStyle',
+    'beginPath',
+    'moveTo',
+    'lineTo',
+    'strokePath',
+    'fillEllipse',
+    'setPosition',
+    'setAlpha',
+    'setX',
+    'setScale',
+  ];
+  for (const name of chained) {
+    g[name] = vi.fn().mockReturnThis();
+  }
+  (g as unknown as { scene: unknown }).scene = {};
+  return g as unknown as ReturnType<typeof vi.fn> & {
+    clear: ReturnType<typeof vi.fn>;
+    setPosition: ReturnType<typeof vi.fn>;
   };
 }
 
 function makeText(text: string) {
-  return {
+  const t: Record<string, unknown> = {
     text,
-    setOrigin: vi.fn().mockReturnThis(),
-    setText: vi.fn().mockReturnThis(),
-    setScrollFactor: vi.fn().mockReturnThis(),
-    setDepth: vi.fn().mockReturnThis(),
-    destroy: vi.fn(),
+    x: 0,
+    y: 0,
+  };
+  t.setOrigin = vi.fn().mockReturnValue(t);
+  t.setText = vi.fn((s: string) => {
+    (t as { text: string }).text = s;
+    return t;
+  });
+  t.setScrollFactor = vi.fn().mockReturnValue(t);
+  t.setDepth = vi.fn().mockReturnValue(t);
+  t.setY = vi.fn((y: number) => {
+    (t as { y: number }).y = y;
+    return t;
+  });
+  t.setAlpha = vi.fn().mockReturnValue(t);
+  t.destroy = vi.fn();
+  return t as unknown as {
+    text: string;
+    x: number;
+    y: number;
+    setOrigin: ReturnType<typeof vi.fn>;
+    setText: ReturnType<typeof vi.fn>;
+    setScrollFactor: ReturnType<typeof vi.fn>;
+    setDepth: ReturnType<typeof vi.fn>;
+    setY: ReturnType<typeof vi.fn>;
+    setAlpha: ReturnType<typeof vi.fn>;
+    destroy: ReturnType<typeof vi.fn>;
   };
 }
 
@@ -97,6 +131,10 @@ function makeScene(muted = false) {
         targets: config.targets,
         onComplete: config.onComplete as (() => void) | undefined,
       })),
+    },
+    time: {
+      delayedCall: vi.fn(),
+      addEvent: vi.fn(),
     },
     registry: {
       get: vi.fn((key: string) => (key === 'audio' ? { isMuted: () => muted } : undefined)),
@@ -159,7 +197,10 @@ describe('HUD', () => {
 
     expect(auText.setText).toHaveBeenCalledWith('AU: 2');
     expect(floorText.setText).toHaveBeenCalledWith(expect.stringContaining('F0:'));
-    expect(scene.tweens.add).toHaveBeenCalledTimes(2);
+    // update() triggers a tween for the coin-punch, a tween for the +N flyer,
+    // and a progress-strip fill tween. Exact count is not asserted to allow
+    // future tween additions to coexist without breaking the test.
+    expect(scene.tweens.add).toHaveBeenCalled();
   });
 
   it('emits toggle event on mute click and unsubscribes from mute-changed on shutdown', () => {

--- a/src/ui/HUD.ts
+++ b/src/ui/HUD.ts
@@ -23,10 +23,14 @@ export class HUD {
   private muteHit!: Phaser.GameObjects.Zone;
   private bg!: Phaser.GameObjects.Graphics;
   private coinIcon!: Phaser.GameObjects.Graphics;
+  private coinShine!: Phaser.GameObjects.Graphics;
   private progressStrip!: Phaser.GameObjects.Graphics;
   private lastAU = 0;
   private lastFloor: FloorId | -1 = -1;
   private lastProgressSig = '';
+  /** Animated progress-strip ratio (tweened toward the target). */
+  private progressRatio = 0;
+  private progressTween?: Phaser.Tweens.Tween;
   private onMuteChanged = (muted: boolean): void => this.renderMuteIcon(muted);
 
   constructor(scene: Phaser.Scene, progression: ProgressionSystem) {
@@ -50,6 +54,16 @@ export class HUD {
     this.coinIcon.setPosition(COIN_X, COIN_Y);
     this.container.add(this.coinIcon);
 
+    // Shimmer band swept across the coin periodically — small live-UI cue
+    // so the HUD doesn't read as static when idling. Drawn as a separate
+    // graphics so the tween can slide it without re-rendering the coin.
+    this.coinShine = this.scene.add.graphics();
+    this.coinShine.fillStyle(0xffffff, 0.6);
+    this.coinShine.fillRect(-1, -10, 2, 20);
+    this.coinShine.setPosition(COIN_X - 14, COIN_Y).setAlpha(0);
+    this.container.add(this.coinShine);
+    this.scheduleCoinShimmer();
+
     // AU label + counter
     this.auText = this.scene.add.text(46, 6, 'AU: 0', {
       fontFamily: 'monospace', fontSize: '20px',
@@ -69,6 +83,7 @@ export class HUD {
     this.container.add(this.muteIcon);
     this.muteHit = this.scene.add.zone(muteX, muteY, 32, 32).setInteractive({ useHandCursor: true });
     this.muteHit.on('pointerup', () => eventBus.emit('audio:toggle-mute'));
+    this.muteHit.on('pointerdown', () => this.punchMuteIcon());
     this.container.add(this.muteHit);
     this.renderMuteIcon(this.getAudio()?.isMuted() ?? false);
     createSceneLifecycle(this.scene).bindEventBus('audio:mute-changed', this.onMuteChanged);
@@ -137,8 +152,6 @@ export class HUD {
     g.clear();
     const next = this.findNextUnlockFloor();
     if (!next) return;
-    const au = this.progression.getTotalAU();
-    const ratio = Phaser.Math.Clamp(au / next.auRequired, 0, 1);
     const x = 46;
     const y = 30;
     const floor = this.progression.getCurrentFloor();
@@ -146,12 +159,78 @@ export class HUD {
     // Background track
     g.fillStyle(0x1a2a3a, 0.6);
     g.fillRect(x, y, PROGRESS_STRIP_WIDTH, PROGRESS_STRIP_HEIGHT);
-    // Fill
-    const fillW = Math.round(ratio * PROGRESS_STRIP_WIDTH);
+    // Fill — uses the tweened `progressRatio`, not the raw AU ratio, so
+    // changes animate instead of snapping.
+    const fillW = Math.round(this.progressRatio * PROGRESS_STRIP_WIDTH);
     if (fillW > 0) {
       g.fillStyle(this.lighten(fillColor, 0.25), 0.95);
       g.fillRect(x, y, fillW, PROGRESS_STRIP_HEIGHT);
     }
+  }
+
+  /** Tween `progressRatio` toward the current AU/required ratio, repainting each frame. */
+  private tweenProgressTo(target: number): void {
+    this.progressTween?.stop();
+    this.progressTween = this.scene.tweens.add({
+      targets: this,
+      progressRatio: target,
+      duration: 260,
+      ease: 'Cubic.easeOut',
+      onUpdate: () => this.redrawProgressStrip(),
+      onComplete: () => this.redrawProgressStrip(),
+    });
+  }
+
+  /** Crossfade the floor label between old and new text. */
+  private crossfadeFloorLabel(nextText: string): void {
+    const g = this.floorText;
+    this.scene.tweens.add({
+      targets: g,
+      alpha: 0,
+      y: g.y - 6,
+      duration: 100,
+      ease: 'Quad.easeIn',
+      onComplete: () => {
+        g.setText(nextText).setY(g.y + 12).setAlpha(0);
+        this.scene.tweens.add({
+          targets: g,
+          alpha: 1,
+          y: g.y - 6,
+          duration: 140,
+          ease: 'Quad.easeOut',
+        });
+      },
+    });
+  }
+
+  /** Schedule a 2s shimmer sweep across the coin, looping every ~6s. */
+  private scheduleCoinShimmer(): void {
+    const fire = (): void => {
+      if (!this.coinShine.scene) return;
+      this.coinShine.setX(COIN_X - 14).setAlpha(0.8);
+      this.scene.tweens.add({
+        targets: this.coinShine,
+        x: COIN_X + 14,
+        alpha: { from: 0.8, to: 0 },
+        duration: 600,
+        ease: 'Sine.easeInOut',
+        onComplete: () => this.coinShine.setAlpha(0),
+      });
+    };
+    // Kick off the first sweep after a short delay, then repeat.
+    this.scene.time.delayedCall(3000, fire);
+    this.scene.time.addEvent({ delay: 6000, loop: true, callback: fire });
+  }
+
+  /** Scale-punch + tint pulse on mute icon press. */
+  private punchMuteIcon(): void {
+    this.scene.tweens.add({
+      targets: this.muteIcon,
+      scale: { from: 1, to: 0.85 },
+      duration: 90,
+      ease: 'Quad.easeOut',
+      yoyo: true,
+    });
   }
 
   /** Punch coin + float "+N" on AU gain. */
@@ -219,11 +298,19 @@ export class HUD {
 
     const floor = this.progression.getCurrentFloor();
     const fd = LEVEL_DATA[floor];
-    if (fd) this.floorText.setText(`F${fd.id}: ${fd.name}`);
+    const nextFloorLabel = fd ? `F${fd.id}: ${fd.name}` : '';
 
     if (floor !== this.lastFloor) {
+      const isFirstRender = this.lastFloor === -1;
       this.lastFloor = floor;
       this.redrawBackground();
+      if (isFirstRender || !fd) {
+        this.floorText.setText(nextFloorLabel);
+      } else {
+        this.crossfadeFloorLabel(nextFloorLabel);
+      }
+    } else if (fd && this.floorText.text !== nextFloorLabel) {
+      this.floorText.setText(nextFloorLabel);
     }
 
     if (au > this.lastAU) {
@@ -235,7 +322,8 @@ export class HUD {
     const sig = next ? `${next.id}:${au}:${floor}` : `none:${floor}`;
     if (sig !== this.lastProgressSig) {
       this.lastProgressSig = sig;
-      this.redrawProgressStrip();
+      const target = next ? Phaser.Math.Clamp(au / next.auRequired, 0, 1) : 0;
+      this.tweenProgressTo(target);
     }
   }
 }

--- a/tests/helpers/phaserMock.ts
+++ b/tests/helpers/phaserMock.ts
@@ -122,6 +122,7 @@ export interface FakeScene {
     existing: (obj: unknown) => unknown;
     graphics: () => { clear: () => void; setDepth: (n: number) => unknown; lineStyle: (...a: unknown[]) => unknown; fillStyle: (...a: unknown[]) => unknown; fillRect: (...a: unknown[]) => unknown; strokeRect: (...a: unknown[]) => unknown; fillCircle: (...a: unknown[]) => unknown; strokeCircle: (...a: unknown[]) => unknown; fillTriangle: (...a: unknown[]) => unknown; lineBetween: (...a: unknown[]) => unknown };
     particles: () => { setDepth: (n: number) => unknown; setPosition: (x: number, y: number) => unknown; explode: (n: number) => unknown };
+    image: (x: number, y: number, key: string) => { x: number; y: number; setDepth: (n: number) => unknown; setAlpha: (a: number) => unknown; setTint: (t: number) => unknown; setScale: (s: number) => unknown; setScrollFactor: (s: number) => unknown; destroy: () => void };
   };
   textures: { exists: (key: string) => boolean };
   inputs: { horizontal: () => number; justPressed: (action: string) => boolean };
@@ -178,6 +179,19 @@ export function createFakeScene(overrides: Partial<FakeScene> = {}): FakeScene {
         setPosition: vi.fn(),
         explode: vi.fn(),
       }),
+      image: (x: number, y: number, _key: string) => {
+        const img = {
+          x,
+          y,
+          setDepth: vi.fn(() => img),
+          setAlpha: vi.fn(() => img),
+          setTint: vi.fn(() => img),
+          setScale: vi.fn(() => img),
+          setScrollFactor: vi.fn(() => img),
+          destroy: vi.fn(),
+        };
+        return img;
+      },
     },
     textures: { exists: () => true },
     inputs: {

--- a/tests/helpers/phaserMock.ts
+++ b/tests/helpers/phaserMock.ts
@@ -105,7 +105,7 @@ interface PendingCall { at: number; cb: () => void }
 
 export interface FakeScene {
   time: { now: number; delayedCall: (ms: number, cb: () => void) => void };
-  tweens: { add: (config: Record<string, unknown>) => { stop: () => void; targets: unknown; onComplete?: () => void } };
+  tweens: { add: (config: Record<string, unknown>) => { stop: () => void; targets: unknown; onComplete?: () => void }; killTweensOf: (targets: unknown) => void };
   anims: {
     exists: (key: string) => boolean;
     create: (config: Record<string, unknown>) => void;
@@ -158,6 +158,7 @@ export function createFakeScene(overrides: Partial<FakeScene> = {}): FakeScene {
         targets: config['targets'],
         onComplete: config['onComplete'] as (() => void) | undefined,
       })),
+      killTweensOf: vi.fn(),
     },
     anims: {
       exists: () => false,


### PR DESCRIPTION
Implements the approved 22-item graphics plan across tiles, entities, HUD, and atmosphere.

## What's in

### Juice / feedback
- Token collect: squash-out anim + halo fadeout
- Enemy stomp: white tint flash (60ms) + camera shake (80/0.004)
- Elevator arrival: camera shake (90/0.003) when player on cab

### Lighting / atmosphere
- Per-floor color grading overlay
- Ambient floating motes per scene
- Drop shadows under player + enemies
- Token halo (floor-tinted, pulsing)
- Bottom-edge floor glow in scene backdrop

### HUD / UI
- Progress strip fill tween
- Floor label crossfade on floor change
- Coin idle shimmer sweep
- Mute icon press punch

### Tiles / decor
- Bevel on platform tiles
- Deterministic scuff overlay on ~25% of tiles

## Deferred
- Item 7 FxLayer replacing white camera.flash
- Item 19 corner/edge tile variants

## Verification
- typecheck clean, lint clean, 267/267 unit tests passing
- Playwright not run (opt-in)
