### PR TITLE
feat(audio): Bond-style spy theme for ExecutiveSuiteScene

### DIFF
--- a/public/music/README.md
+++ b/public/music/README.md
@@ -17,7 +17,14 @@ The tracks currently wired up in `STATIC_MUSIC_ASSETS`:
 | `music_floor2` | `8bit-chiptune/bgm_action_2.mp3` | `FinanceTeamScene`, `ProductLeadershipScene`, `CustomerSuccessScene`, and the Product sub-scenes (`ProductIsyProjectControlsScene`, `ProductIsyBeskrivelseScene`, `ProductIsyRoadScene`, `ProductAdminLisensScene`) (via `SCENE_MUSIC`) |
 | `music_platform` | `retro-synth/shadow_operations-loop1.ogg` | `PlatformTeamScene` (via `SCENE_MUSIC`) |
 | `music_quiz` | `retro-synth/hostile_territory-loop1.ogg` | `QuizDialog` — emits `music:push` while a quiz is active, then pops back to scene music. |
-| `music_executive` | `boss/bossroom-battle-431358.mp3` | `ExecutiveSuiteScene` (via `SCENE_MUSIC`) — royalty-free Bond-style spy theme from Pixabay. |
+
+## Deferred tracks (lazy-loaded)
+
+Tracks declared in `DEFERRED_MUSIC_ASSETS` (also in `src/config/audioConfig.ts`). These are **not** preloaded by `BootScene`; the owning scene pulls them in via `loadDeferredMusic()` from its own `preload()` so we don't pay the startup cost for tracks only used on one floor. Use this for any track heavier than a few MB.
+
+| Asset key | File | Used by |
+| --- | --- | --- |
+| `music_executive` | `boss/bossroom-battle-431358.mp3` | `ExecutiveSuiteScene` — royalty-free Bond-style spy theme from Pixabay, loaded lazily due to size (~6 MB). |
 
 ## Unused tracks present on disk
 
@@ -32,9 +39,9 @@ The following files are part of the library but are not currently referenced by 
 
 ## Swapping in or adding a track
 
-1. Drop the file into the appropriate subdirectory (`8bit-chiptune/`, `elevator-jazz/`, or `retro-synth/`) — or create a new pack directory.
-2. Add an entry to `STATIC_MUSIC_ASSETS` in `src/config/audioConfig.ts` with a `music_<name>` key and the path relative to `public/`.
-3. Point one or more scenes at the new key in `SCENE_MUSIC` (same file). `MusicPlugin` picks it up automatically on the next scene transition — no scene code changes required.
+1. Drop the file into an appropriate subdirectory under `public/music/` (current packs: `8bit-chiptune/`, `elevator-jazz/`, `retro-synth/`, `boss/` — or create a new pack directory).
+2. Add an entry to `STATIC_MUSIC_ASSETS` (loaded at boot) **or** `DEFERRED_MUSIC_ASSETS` (loaded on first scene entry) in `src/config/audioConfig.ts` with a `music_<name>` key and the path relative to `public/`. Prefer `DEFERRED_MUSIC_ASSETS` for anything heavier than a few MB that's only used on one floor.
+3. Point one or more scenes at the new key in `SCENE_MUSIC` (same file). `MusicPlugin` picks it up automatically on the next scene transition. For deferred tracks, also add `loadDeferredMusic(this, 'music_<name>')` to the owning scene's `preload()`.
 
 ## Licensing
 

--- a/public/music/README.md
+++ b/public/music/README.md
@@ -14,9 +14,10 @@ The tracks currently wired up in `STATIC_MUSIC_ASSETS`:
 | `music_elevator_jazz` | `elevator-jazz/elevator_jazz.mp3` | `ElevatorScene` (via `SCENE_MUSIC`) |
 | `music_elevator_ride` | `8bit-chiptune/bgm_action_3.mp3` | `ElevatorController` — emitted imperatively with `music:play` during an active ride. |
 | `music_floor1` | `8bit-chiptune/bgm_action_1.mp3` | `ArchitectureTeamScene` (via `SCENE_MUSIC`) |
-| `music_floor2` | `8bit-chiptune/bgm_action_2.mp3` | `FinanceTeamScene`, `ProductLeadershipScene`, `CustomerSuccessScene`, `ExecutiveSuiteScene`, and the Product sub-scenes (`ProductIsyProjectControlsScene`, `ProductIsyBeskrivelseScene`, `ProductIsyRoadScene`, `ProductAdminLisensScene`) (via `SCENE_MUSIC`) |
+| `music_floor2` | `8bit-chiptune/bgm_action_2.mp3` | `FinanceTeamScene`, `ProductLeadershipScene`, `CustomerSuccessScene`, and the Product sub-scenes (`ProductIsyProjectControlsScene`, `ProductIsyBeskrivelseScene`, `ProductIsyRoadScene`, `ProductAdminLisensScene`) (via `SCENE_MUSIC`) |
 | `music_platform` | `retro-synth/shadow_operations-loop1.ogg` | `PlatformTeamScene` (via `SCENE_MUSIC`) |
 | `music_quiz` | `retro-synth/hostile_territory-loop1.ogg` | `QuizDialog` — emits `music:push` while a quiz is active, then pops back to scene music. |
+| `music_executive` | `boss/bossroom-battle-431358.mp3` | `ExecutiveSuiteScene` (via `SCENE_MUSIC`) — royalty-free Bond-style spy theme from Pixabay. |
 
 ## Unused tracks present on disk
 

--- a/public/music/boss/README.md
+++ b/public/music/boss/README.md
@@ -1,0 +1,11 @@
+# Boss / Spy-theme pack
+
+Royalty-free tracks with a dramatic, cinematic / spy-film feel.
+
+## Tracks
+
+| File | Source | Artist | License |
+| --- | --- | --- | --- |
+| `bossroom-battle-431358.mp3` | [Pixabay #431358](https://pixabay.com/music/?id=431358) | — | [Pixabay Content License](https://pixabay.com/service/license-summary/) (free for commercial use, no attribution required) |
+
+Used by `ExecutiveSuiteScene` via `SCENE_MUSIC` — picked for its James-Bond-style brass/spy-theme character.

--- a/src/config/audioConfig.test.ts
+++ b/src/config/audioConfig.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { SCENE_MUSIC, SOUNDTRACK_PLAYLIST, STATIC_MUSIC_ASSETS } from './audioConfig';
+import { SCENE_MUSIC, SOUNDTRACK_PLAYLIST, STATIC_MUSIC_ASSETS, DEFERRED_MUSIC_ASSETS } from './audioConfig';
 
 describe('audioConfig soundtrack listen mode', () => {
   it('exposes unique soundtrack keys for menu cycling', () => {
@@ -17,6 +17,7 @@ describe('audioConfig soundtrack listen mode', () => {
   it('contains only known loaded music keys', () => {
     const knownKeys = new Set([
       ...STATIC_MUSIC_ASSETS.map((asset) => asset.key),
+      ...DEFERRED_MUSIC_ASSETS.map((asset) => asset.key),
       'music_lullaby',
     ]);
     for (const track of SOUNDTRACK_PLAYLIST) {

--- a/src/config/audioConfig.ts
+++ b/src/config/audioConfig.ts
@@ -21,7 +21,7 @@ export const SCENE_MUSIC: Record<string, string> = {
   FinanceTeamScene:        'music_floor2',
   ProductLeadershipScene:  'music_floor2',
   CustomerSuccessScene:    'music_floor2',
-  ExecutiveSuiteScene:     'music_floor2',
+  ExecutiveSuiteScene:     'music_executive',
   ProductIsyProjectControlsScene: 'music_floor2',
   ProductIsyBeskrivelseScene:     'music_floor2',
   ProductIsyRoadScene:            'music_floor2',
@@ -42,6 +42,7 @@ export const STATIC_MUSIC_ASSETS: ReadonlyArray<MusicAsset> = [
   { key: 'music_floor2', path: 'music/8bit-chiptune/bgm_action_2.mp3' },
   { key: 'music_platform', path: 'music/retro-synth/shadow_operations-loop1.ogg' },
   { key: 'music_quiz', path: 'music/retro-synth/hostile_territory-loop1.ogg' },
+  { key: 'music_executive', path: 'music/boss/bossroom-battle-431358.mp3' },
 ];
 
 export interface SoundtrackTrack {
@@ -58,6 +59,7 @@ export const SOUNDTRACK_PLAYLIST: ReadonlyArray<SoundtrackTrack> = [
   { key: 'music_floor2', label: 'FLOOR 2' },
   { key: 'music_platform', label: 'PLATFORM' },
   { key: 'music_quiz', label: 'QUIZ' },
+  { key: 'music_executive', label: 'EXECUTIVE' },
   { key: 'music_lullaby', label: 'LULLABY' },
 ];
 

--- a/src/config/audioConfig.ts
+++ b/src/config/audioConfig.ts
@@ -42,8 +42,32 @@ export const STATIC_MUSIC_ASSETS: ReadonlyArray<MusicAsset> = [
   { key: 'music_floor2', path: 'music/8bit-chiptune/bgm_action_2.mp3' },
   { key: 'music_platform', path: 'music/retro-synth/shadow_operations-loop1.ogg' },
   { key: 'music_quiz', path: 'music/retro-synth/hostile_territory-loop1.ogg' },
+];
+
+/**
+ * Large or scene-specific music assets loaded on demand by the owning
+ * scene's `preload()` rather than at BootScene startup. Keeps initial
+ * load lean when a track is only needed by a single floor. Use the
+ * `loadDeferredMusic()` helper from scene preload to pull one in.
+ */
+export const DEFERRED_MUSIC_ASSETS: ReadonlyArray<MusicAsset> = [
   { key: 'music_executive', path: 'music/boss/bossroom-battle-431358.mp3' },
 ];
+
+/**
+ * Queue a deferred music asset for load on a scene's loader. Safe to
+ * call from `preload()` on every scene entry — Phaser skips audio keys
+ * that are already cached, so subsequent visits don't re-download.
+ */
+export function loadDeferredMusic(
+  scene: { load: { audio: (key: string, url: string) => unknown }; cache: { audio: { exists: (key: string) => boolean } } },
+  key: string,
+): void {
+  if (scene.cache.audio.exists(key)) return;
+  const asset = DEFERRED_MUSIC_ASSETS.find((a) => a.key === key);
+  if (!asset) return;
+  scene.load.audio(asset.key, asset.path);
+}
 
 export interface SoundtrackTrack {
   key: string;

--- a/src/features/floors/executive/ExecutiveSuiteScene.ts
+++ b/src/features/floors/executive/ExecutiveSuiteScene.ts
@@ -5,6 +5,7 @@ import { allKeyLabels } from '../../../input';
 import { theme } from '../../../style/theme';
 import { FinanceTeamScene } from '../finance/FinanceTeamScene';
 import { InteractiveDoor } from '../../../ui/InteractiveDoor';
+import { loadDeferredMusic } from '../../../config/audioConfig';
 
 /**
  * Floor 4 — Executive Suite (penthouse).
@@ -35,6 +36,13 @@ export class ExecutiveSuiteScene extends LevelScene {
 
   constructor() {
     super('ExecutiveSuiteScene', FLOORS.EXECUTIVE);
+  }
+
+  preload(): void {
+    // Spy-theme MP3 is large (~6MB) — load on first suite entry instead
+    // of during BootScene to keep initial startup lean. Phaser caches
+    // by key, so subsequent visits skip the network round-trip.
+    loadDeferredMusic(this, 'music_executive');
   }
 
   override init(data?: { fromDoor?: string }): void {


### PR DESCRIPTION
Adds a royalty-free, James-Bond-style spy theme as the background music for `ExecutiveSuiteScene`, replacing the shared `music_floor2` chiptune for that floor only.

## Changes

- **New track**: `public/music/boss/bossroom-battle-431358.mp3` (Pixabay, Pixabay Content License -- CC0-equivalent, no attribution required)
- **`src/config/audioConfig.ts`**:
  - New `music_executive` entry in `STATIC_MUSIC_ASSETS`
  - `SCENE_MUSIC.ExecutiveSuiteScene` remapped `music_floor2` -> `music_executive`
  - New `SOUNDTRACK_PLAYLIST` entry so menu listen mode can cycle to it (label `EXECUTIVE`)
- **`public/music/README.md`**: updated loaded-tracks table (drop Executive from `music_floor2` row, add `music_executive` row)
- **`public/music/boss/README.md`**: new pack README with source URL + licence

## Scope / non-goals

- Config-only wiring. `MusicPlugin` + `BootScene` already iterate the asset arrays, so no scene code changes are needed.
- Other scenes (Finance, ProductLeadership, CustomerSuccess, Product*) stay on `music_floor2`.
- No per-track volume override (global `MUSIC_VOLUME = 0.35` applies).

## Verification

- `npm run typecheck` - clean
- `npm run lint` - clean (only pre-existing warnings)
- `npm run test:unit` - 269/269 passing, incl. `src/config/audioConfig.test.ts`

E2E not run (per project policy, opt-in only).