### PR TITLE
Redesign PlatformTeamScene: thin catwalks + 4-tier layout with 3 lifts

### DIFF
--- a/src/features/floors/_shared/LevelScene.ts
+++ b/src/features/floors/_shared/LevelScene.ts
@@ -43,6 +43,20 @@ export interface LevelConfig {
   floorId: FloorId;
   platforms: Array<{ x: number; y: number; width: number }>;
   /**
+   * Thin catwalks / walkways.
+   *
+   * Unlike `platforms` (which use the 128×128 floor tile as both visual
+   * and physics body — great for the ground, terrible for mezzanines
+   * because the tile body extends 128 px downward and crushes the
+   * headroom beneath), catwalks are a ~20 px thin rectangle with a
+   * matching graphic on top. Use these for any floating walkway.
+   *
+   * `x`, `y` = top-left of the walking surface (same semantics as
+   * `platforms.y` — the top of the slab, not its centre). `width` is in
+   * pixels. `thickness` defaults to 20.
+   */
+  catwalks?: Array<{ x: number; y: number; width: number; thickness?: number }>;
+  /**
    * Tokens in the room. `index` overrides the default array-position
    * index used to key into the ProgressionSystem's collected-tokens
    * state. Useful when two scenes share the same floorId and need
@@ -385,7 +399,9 @@ export class LevelScene extends Phaser.Scene {
   /* ---- platforms ---- */
   protected createPlatforms(): void {
     this.platformGroup = this.physics.add.staticGroup();
-    this.buildPlatforms(this.getLevelConfig());
+    const config = this.getLevelConfig();
+    this.buildPlatforms(config);
+    this.buildCatwalks(config);
   }
 
   protected buildPlatforms(config: LevelConfig): void {
@@ -405,6 +421,60 @@ export class LevelScene extends Phaser.Scene {
           this.add.image(tx, ty, 'tile_detail_overlay').setDepth(2.5);
         }
       }
+    }
+  }
+
+  /**
+   * Thin floating walkways. A ~20 px rectangle with a static physics body is
+   * added to the same platformGroup the ground tiles use, so every existing
+   * collider (player, enemies, dropped AU, etc.) just works. On top, a small
+   * graphic draws the slab face, a top rim, and subtle rivets so the catwalk
+   * reads as a metal grating rather than a floating block.
+   *
+   * Using a thin body — rather than re-using the 128 px ground tile — keeps
+   * headroom clear under mezzanines, which is the whole point of the primitive.
+   */
+  protected buildCatwalks(config: LevelConfig): void {
+    if (!config.catwalks?.length) return;
+    for (const c of config.catwalks) {
+      const thickness = c.thickness ?? 20;
+      const cx = c.x + c.width / 2;
+      const cy = c.y + thickness / 2;
+
+      // Physics body (invisible rectangle, added to platformGroup).
+      const body = this.add.rectangle(cx, cy, c.width, thickness, 0x000000, 0);
+      this.physics.add.existing(body, true);
+      this.platformGroup.add(body);
+
+      // One-way: only collide from above, so the player can jump up
+      // through a catwalk and land on top of it. Without this, the thin
+      // body blocks a rising head even when there's plenty of room to
+      // land on top (the classic platformer "jump-through" behaviour).
+      const pbody = body.body as Phaser.Physics.Arcade.StaticBody;
+      pbody.checkCollision.down = false;
+      pbody.checkCollision.left = false;
+      pbody.checkCollision.right = false;
+
+      // Decorative face. Depth sits just above ground tiles (2) but below
+      // props (3) so desks/diagrams in front still overlap correctly.
+      const g = this.add.graphics().setDepth(2.2);
+      const x = c.x, y = c.y, w = c.width, h = thickness;
+      // Slab.
+      g.fillStyle(0x4a5560, 1).fillRect(x, y, w, h);
+      // Top rim — lighter stripe to read as a walking surface.
+      g.fillStyle(0x8fa0b3, 1).fillRect(x, y, w, 3);
+      // Bottom shadow edge.
+      g.fillStyle(0x2a323c, 1).fillRect(x, y + h - 2, w, 2);
+      // Rivets every ~32 px.
+      g.fillStyle(0x1a2028, 1);
+      for (let rx = x + 10; rx < x + w - 6; rx += 32) {
+        g.fillRect(rx, y + 6, 2, 2);
+        g.fillRect(rx, y + h - 8, 2, 2);
+      }
+      // Side caps so the end of the walkway reads as a thick edge piece.
+      g.fillStyle(0x2a323c, 1);
+      g.fillRect(x, y, 2, h);
+      g.fillRect(x + w - 2, y, 2, h);
     }
   }
 

--- a/src/features/floors/platform/PlatformTeamScene.ts
+++ b/src/features/floors/platform/PlatformTeamScene.ts
@@ -25,7 +25,7 @@ import { enemiesForGroundY } from './enemies';
  * Lifts:
  *   A — left (x=160):   ground → T2 (Scaling Lab approach)
  *   B — centre (x=640): ground → T4 (spine; lands on the central island)
- *   C — right (x=1180): ground → T1 (Edge Security WAF ledge)
+ *   C — right (x=1100): ground → T1 (Edge Security WAF ledge)
  *
  * A sibling scene `ArchitectureTeamScene` hosts the architecture content
  * on the other side of the elevator; both scenes share FloorId
@@ -69,7 +69,7 @@ export class PlatformTeamScene extends LevelScene {
 
     // --- Floor zone carpets (thin tinted stripes at the walking surface). ---
     // Drawn BEFORE props so props sit on top. Ranges stay clear of the
-    // three lift shafts (A ~x=120..200, B ~x=600..680, C ~x=1140..1220).
+    // three lift shafts (A ~x=120..200, B ~x=600..680, C ~x=1060..1140).
     this.addFloorCarpet(80,   340,  0x4a8fbf, 0.35); // Zone A — Platform Onboarding (cyan)
     this.addFloorCarpet(420,  580,  0x707878, 0.30); // Workstations lane-left
     this.addFloorCarpet(700,  880,  0x707878, 0.30); // Workstations lane-right
@@ -539,7 +539,7 @@ export class PlatformTeamScene extends LevelScene {
 
       platforms: [
         // Ground only — mezzanines use the thin `catwalks` primitive so
-        // their 20 px physics bodies don't eat the headroom below.
+        // their 16 px physics bodies don't eat the headroom below.
         { x: 0, y: G, width: 10 },
       ],
 

--- a/src/features/floors/platform/PlatformTeamScene.ts
+++ b/src/features/floors/platform/PlatformTeamScene.ts
@@ -9,20 +9,23 @@ import { enemiesForGroundY } from './enemies';
  * Floor 1 — Platform room (left side of the Platform Team floor).
  *
  * Reached by stepping OFF the elevator to the LEFT at floor 1.
- * Laid out as a ground floor, a left-side stepping-stone up to a left
- * mezzanine (Scaling Lab), a right mezzanine (Observability), and a
- * single CENTRAL vertical lift that bridges the middle of the ground up
- * to catwalk level — so there is no "dead zone" if the player falls into
- * the middle of the room:
  *
- *            [SCALING LAB]                          [OBSERVABILITY]
- *     ╔═══════════════════╗       │lift│        ╔═══════════════════╗   (catwalk y=C)
- *         │ low step              │    │
- *                                 │    │
- *                                 │    │
- *  [PLATFORM TEAM]          desk router rack           [EDGE SECURITY]
- *  signpost                                            (WAF panel)
- *  ═══════════════════════════════════════════════════════════════════ (ground y=G)
+ * Layout is a four-tier single-screen room built on thin catwalks (NOT
+ * 128×128 floor tiles), so mezzanines don't crush the headroom
+ * underneath. Three in-room lifts stitch the tiers together:
+ *
+ *              [T4 central island]   ← lift B tops here
+ *     [T3 SCALING LAB]            [T3 OBSERVABILITY]
+ *                                                            ┌T1 WAF┐
+ *   [T2 wall] [T2 main] [west bridge] [east bridge] [T2 right]│ledge│
+ *     │A│                  │B│                               │C│
+ *   ════════════════════════════════════════════════════════════════ ground
+ *   signpost   desk / router / rack                        ←WAF panel→
+ *
+ * Lifts:
+ *   A — left (x=160):   ground → T2 (Scaling Lab approach)
+ *   B — centre (x=640): ground → T4 (spine; lands on the central island)
+ *   C — right (x=1180): ground → T1 (Edge Security WAF ledge)
  *
  * A sibling scene `ArchitectureTeamScene` hosts the architecture content
  * on the other side of the elevator; both scenes share FloorId
@@ -34,8 +37,16 @@ import { enemiesForGroundY } from './enemies';
  * rack-buzz / fan-hum / disk-seek ambience underneath the music.
  */
 export class PlatformTeamScene extends LevelScene {
-  /** Catwalk walking-surface y (mezzanine). Kept in sync with enemies.ts. */
-  private static readonly CATWALK_Y = GAME_HEIGHT - TILE_SIZE - 220;
+  /** Tier walking-surface Ys. Kept in sync with enemies.ts.
+   *  Pitch = 140 px; catwalk thickness = 16 → ~124 px clear headroom
+   *  under a catwalk body (140 - 16), which fits the 116 px player
+   *  hitbox with a small safety margin everywhere one tier stacks
+   *  above another. */
+  private static readonly T1_Y = 692; // low ledges (WAF right)
+  private static readonly T2_Y = 552; // mid catwalks spanning the room
+  private static readonly T3_Y = 412; // upper station catwalks (scaling / ops)
+  private static readonly T4_Y = 272; // top central island (split around lift B)
+  private static readonly CATWALK_THICKNESS = 16;
 
   constructor() {
     super('PlatformTeamScene', FLOORS.PLATFORM_TEAM);
@@ -53,59 +64,51 @@ export class PlatformTeamScene extends LevelScene {
 
   protected override createDecorations(): void {
     const G = GAME_HEIGHT - TILE_SIZE;
-    const C = PlatformTeamScene.CATWALK_Y;
+    const T3 = PlatformTeamScene.T3_Y;
+    const T4 = PlatformTeamScene.T4_Y;
 
     // --- Floor zone carpets (thin tinted stripes at the walking surface). ---
-    // Drawn BEFORE props so props sit on top. Ranges keep clear of the
-    // central lift shaft (roughly x=600..680) so the carpet doesn't ghost
-    // through the lift graphics.
+    // Drawn BEFORE props so props sit on top. Ranges stay clear of the
+    // three lift shafts (A ~x=120..200, B ~x=600..680, C ~x=1140..1220).
     this.addFloorCarpet(80,   340,  0x4a8fbf, 0.35); // Zone A — Platform Onboarding (cyan)
-    this.addFloorCarpet(440,  600,  0x707878, 0.30); // Workstations lane-left (neutral grey)
-    this.addFloorCarpet(680,  820,  0x707878, 0.30); // Workstations lane-right (neutral grey)
-    this.addFloorCarpet(1060, 1260, 0xc27099, 0.35); // Zone C — Edge Security (rose)
+    this.addFloorCarpet(420,  580,  0x707878, 0.30); // Workstations lane-left
+    this.addFloorCarpet(700,  880,  0x707878, 0.30); // Workstations lane-right
 
-    // --- Ambient greenery (kept sparse; back accents already carry density). ---
+    // --- Ambient greenery. Kept clear of catwalk shadows above. ---
     this.addAmbientPlants([
-      { x: 60,   kind: 'tall' },
-      { x: 140,  kind: 'small' },
-      { x: 1260, kind: 'tall' },
+      { x: 220,  kind: 'small' },
+      { x: 460,  kind: 'tall' },
+      { x: 820,  kind: 'small' },
     ]);
 
-    // --- Zone A: Platform Team signpost (labels itself; no duplicate nameplate). ---
+    // --- Zone A: Platform Team signpost. ---
     this.addSignpost({ x: 260, label: 'PLATFORM\n   TEAM', color: '#b8e6ff' });
 
-    // --- Workstations cluster, laid out to leave clearance around the
-    //     central lift shaft at x=640. Desk + router on the left of the
-    //     shaft, rack + cables on the right. ---
+    // --- Workstations (ground). Placed between the three lift shafts so
+    //     the player can walk the full width without props blocking lift
+    //     boarding. Desk + router left of lift B, rack + cables right. ---
     this.add.image(500, G - 36, 'desk_monitor').setDepth(3);
     this.add.image(580, G - 10, 'router').setDepth(3);
     this.add.image(740, G - 50, 'server_rack').setDepth(3);
     this.add.image(740, G - 10, 'cables').setDepth(1);
 
-    // --- Mezzanine content panels. Centred on their respective catwalk
-    //     tile span so mounting feet rest on the catwalk. ---
-    //     Left catwalk tile range: x=256..512 → panel centre 384.
-    //     Right catwalk tile range: x=768..1024 → panel centre 896.
-    this.createScalingDiagram(384, C);
-    this.createMonitoringWall(896, C);
+    // --- Mezzanine content panels, anchored to their T3 catwalk tops. ---
+    //     Left T3 catwalk:  x=160..520  → Scaling Lab centred at x=340.
+    //     Right T3 catwalk: x=760..1120 → Observability centred at x=940.
+    this.createScalingDiagram(340, T3);
+    this.createMonitoringWall(940, T3);
 
-    // --- Zone C: Web Application Firewall panel sits on the ground far
-    //     right, well clear of the right catwalk (ends at x=1024) and the
-    //     central lift. Panel width 200, centred at 1180 → spans 1080..1280. ---
-    this.createWafDiagram(1180, G - 40);
+    // --- Edge Security WAF panel on the T1 right ledge (x=1140..1280). ---
+    this.createWafDiagram(1200, PlatformTeamScene.T1_Y);
 
-    // --- Overhead station nameplates. One per station, placed above its
-    //     panel so it doesn't overlap the panel body. Platform Team is
-    //     already labelled by the signpost; the central lift is labelled
-    //     inline on the shaft graphics (see createDecorations' lift hint). ---
-    this.addStationNameplate(384,  C - 180, '[ SCALING LAB ]',   '#b8e6ff');
-    this.addStationNameplate(896,  C - 180, '[ OBSERVABILITY ]', '#b8e6ff');
-    this.addStationNameplate(1180, G - 220, '[ EDGE SECURITY ]', '#ff8fa8');
+    // --- Overhead station nameplates. ---
+    this.addStationNameplate(340,  T3 - 180, '[ SCALING LAB ]',   '#b8e6ff');
+    this.addStationNameplate(940,  T3 - 180, '[ OBSERVABILITY ]', '#b8e6ff');
+    this.addStationNameplate(1200, PlatformTeamScene.T1_Y - 220, '[ EDGE SECURITY ]', '#ff8fa8');
 
-    // --- Central lift hint — a tiny label above the lift shaft so the
-    //     player notices the vertical lift that bridges ground → catwalks.
-    //     The shaft graphics themselves are drawn by LevelScene.createRoomElevators. ---
-    this.add.text(640, C - 40, '↑↓ LIFT', {
+    // --- Central lift hint — above the T4 island so the player notices
+    //     that lift B goes all the way to the top.
+    this.add.text(640, T4 - 40, '↑↓ LIFT', {
       fontFamily: 'monospace', fontSize: '11px',
       color: '#d4f0ff', fontStyle: 'bold',
       backgroundColor: '#1a1a22',
@@ -523,70 +526,96 @@ export class PlatformTeamScene extends LevelScene {
 
   protected getLevelConfig(): LevelConfig {
     const G = GAME_HEIGHT - TILE_SIZE;
-    const C = PlatformTeamScene.CATWALK_Y;
+    const T1 = PlatformTeamScene.T1_Y;
+    const T2 = PlatformTeamScene.T2_Y;
+    const T3 = PlatformTeamScene.T3_Y;
+    const T4 = PlatformTeamScene.T4_Y;
+    const T = PlatformTeamScene.CATWALK_THICKNESS;
 
     return {
       floorId: FLOORS.PLATFORM_TEAM,
-      playerStart: { x: 150, y: G - 100 },
+      playerStart: { x: 240, y: G - 100 },
       exitPosition: { x: 80, y: G - 56 },
 
       platforms: [
-        // Ground (full room width, 10 tiles).
-        { x: 0,    y: G,   width: 10 },
-        // Left side: low stepping stone between ground and the left catwalk.
-        // Placed JUST OUTSIDE the catwalk's x-range so the step tile doesn't
-        // overlap the catwalk tile physics body (catwalk bottom y = C + TILE_SIZE).
-        { x: 128,  y: 720, width: 1 },
-        // Left catwalk — Scaling Lab mezzanine.
-        { x: 256,  y: C,   width: 2 },
-        // Right catwalk — Observability mezzanine.
-        { x: 768,  y: C,   width: 2 },
-        // NOTE: no right-side low step. Right catwalk is reached from the
-        // central lift (short jump left or right off the lift's top position).
-        // A right low step at x=1024..1152 would overlap the WAF panel
-        // visually; dropping it keeps Zone C (Edge Security) visually clean.
+        // Ground only — mezzanines use the thin `catwalks` primitive so
+        // their 20 px physics bodies don't eat the headroom below.
+        { x: 0, y: G, width: 10 },
       ],
 
-      // --- Central vertical lift — the primary fix for the "fell into the
-      //     middle and can't get out" dead zone. Reaches from the ground
-      //     (bottom parked position) up to the catwalk level. ---
+      catwalks: [
+        // Shaft x-ranges to remember:
+        //   Lift A: x=120..200  Lift B: x=600..680  Lift C: x=1060..1140
+        // Each catwalk is split around any lift shaft it would otherwise span.
+
+        // T1 — WAF right ledge. Starts just past lift C's shaft.
+        { x: 1140, y: T1, width: 140, thickness: T },
+
+        // T2 — mid catwalks. Split at each lift shaft.
+        { x: 0,   y: T2, width: 120, thickness: T }, // left-wall pad (step off lift A going left)
+        { x: 200, y: T2, width: 200, thickness: T }, // T2 left main (step off lift A going right)
+        { x: 400, y: T2, width: 180, thickness: T }, // west bridge (butts T2 left main at x=400)
+        { x: 700, y: T2, width: 180, thickness: T }, // east bridge (180 px runway to clear the 80 px lift B shaft)
+        { x: 880, y: T2, width: 180, thickness: T }, // T2 right ledge (butts east bridge at x=880)
+
+        // T3 — upper station catwalks.
+        { x: 160, y: T3, width: 360, thickness: T }, // Scaling Lab (left)
+        { x: 760, y: T3, width: 360, thickness: T }, // Observability (right)
+
+        // T4 — central island split around lift B. Player rides lift B
+        // to the top and can step off either direction onto a small pad.
+        { x: 500, y: T4, width: 100, thickness: T },
+        { x: 680, y: T4, width: 100, thickness: T },
+      ],
+
       roomElevators: [
-        { x: 640, minY: C + 6, maxY: G + 6, startY: G + 6 },
+        // Lift A — left: ground → T2. Lands between T2 left-wall pad
+        // (x=0..120) and T2 left main (x=200..400).
+        { x: 160,  minY: T2 + 6, maxY: G + 6, startY: G + 6 },
+        // Lift B — centre: ground → T4. Lands between the two T4
+        // island halves (x=500..600 and x=680..780).
+        { x: 640,  minY: T4 + 6, maxY: G + 6, startY: G + 6 },
+        // Lift C — right: ground → T1 WAF ledge. Shaft sits just LEFT
+        // of the WAF ledge (x=1140..1280), so ground boarding at
+        // x=1100 is clear of any overhead catwalk body.
+        { x: 1100, minY: T1 + 6, maxY: G + 6, startY: G + 6 },
       ],
 
       // Token indices 0..6 — disjoint from ArchitectureTeamScene (7..).
       tokens: [
-        // Ground trail.
-        { x: 192,  y: G - 40, index: 0 }, // near the signpost (entry reward)
-        { x: 660,  y: G - 40, index: 1 }, // between router (x≈580) and rack (x≈740)
-        { x: 1000, y: G - 40, index: 2 }, // clear ground between rack and WAF panel
-        // Stepping-stone reward.
-        { x: 192,  y: 680,    index: 3 }, // on top of the left low step
-        // Mezzanine trail.
-        { x: 384,  y: C - 40, index: 4 }, // left catwalk (Scaling)
-        { x: 896,  y: C - 40, index: 5 }, // right catwalk (Observability)
-        // Mid-air reward — collectable while riding the central lift up.
-        { x: 640,  y: 500,    index: 6 },
+        { x: 300,  y: G - 40, index: 0 },  // ground near signpost
+        { x: 770,  y: G - 40, index: 1 },  // ground between workstations and lift C
+        { x: 250,  y: T2 - 40, index: 2 }, // T2 left main
+        { x: 1200, y: T1 - 40, index: 3 }, // T1 WAF ledge
+        { x: 340,  y: T3 - 40, index: 4 }, // T3 Scaling Lab
+        { x: 940,  y: T3 - 40, index: 5 }, // T3 Observability
+        { x: 540,  y: T4 - 40, index: 6 }, // T4 island-left (ride lift B, step left)
       ],
 
       infoPoints: [
-        // Ground — onboarding signpost and the WAF edge station.
+        // Ground signpost. Default offsetY = -h/2 places the rect
+        // directly above the anchor (y ≈ 632..832). No catwalk body sits
+        // in that x-range/y-range.
         {
           x: 260, y: G, contentId: 'platform-engineering',
-          zone: { shape: 'rect', width: 160, height: 220 },
+          zone: { shape: 'rect', width: 160, height: 200 },
         },
+        // T3 Scaling Lab — zone above the catwalk. offsetY=-88 places
+        // rect bottom 4 px above the T3 body top (412).
         {
-          x: 1180, y: G, contentId: 'web-application-firewall',
-          zone: { shape: 'rect', width: 200, height: 220 },
+          x: 340, y: T3, contentId: 'scaling',
+          zone: { shape: 'rect', width: 260, height: 160, offsetY: -88 },
         },
-        // Mezzanine — zones centred on the catwalk walking surface.
+        // T3 Observability — mirror of Scaling Lab.
         {
-          x: 384, y: C + 10, contentId: 'scaling',
-          zone: { shape: 'rect', width: 240, height: 200 },
+          x: 940, y: T3, contentId: 'you-build-you-run',
+          zone: { shape: 'rect', width: 260, height: 160, offsetY: -88 },
         },
+        // T1 WAF ledge — zone above the ledge. Left edge at x=1100 stays
+        // east of the T2 right ledge (ends x=1060), so no T2 body clip.
         {
-          x: 896, y: C + 10, contentId: 'you-build-you-run',
-          zone: { shape: 'rect', width: 240, height: 200 },
+          x: 1200, y: T1, contentId: 'web-application-firewall',
+          zone: { shape: 'rect', width: 200, height: 140, offsetY: -78 },
         },
       ],
 

--- a/src/features/floors/platform/enemies.ts
+++ b/src/features/floors/platform/enemies.ts
@@ -4,11 +4,11 @@ type EnemyList = NonNullable<LevelConfig['enemies']>;
 
 /**
  * Platform floor enemies. `G` is the ground walking-surface y. The
- * mezzanines sit on thin catwalks at y=720 / 600 / 480 / 360 — see
- * `PlatformTeamScene.getLevelConfig` for the full geometry.
+ * mezzanines sit on thin catwalks at y=692 / 552 / 412 / 272 (T1..T4) —
+ * see `PlatformTeamScene.getLevelConfig` for the full geometry.
  *
  * Patrol ranges avoid the three lift shafts (A ≈ x=120..200,
- * B ≈ x=600..680, C ≈ x=1140..1220) so enemies never block boarding.
+ * B ≈ x=600..680, C ≈ x=1060..1140) so enemies never block boarding.
  *
  *   - Ground slime patrols the workstation lane between lift A and lift B.
  *   - A rogue deploy bot patrols the T3 Observability catwalk (y=480).

--- a/src/features/floors/platform/enemies.ts
+++ b/src/features/floors/platform/enemies.ts
@@ -3,32 +3,29 @@ import type { LevelConfig } from '../_shared/LevelScene';
 type EnemyList = NonNullable<LevelConfig['enemies']>;
 
 /**
- * Platform floor enemies. `G` is the ground walking-surface y, `C` is the
- * mezzanine (catwalk) walking-surface — `G - 220` — so enemies share the
- * same reference as platforms, tokens, and props.
+ * Platform floor enemies. `G` is the ground walking-surface y. The
+ * mezzanines sit on thin catwalks at y=720 / 600 / 480 / 360 — see
+ * `PlatformTeamScene.getLevelConfig` for the full geometry.
  *
- * Patrol ranges are chosen so none of them straddle an info-zone centre
- * (forcing the player to kite an enemy out of an info prompt) and so no
- * two enemies' ranges overlap.
+ * Patrol ranges avoid the three lift shafts (A ≈ x=120..200,
+ * B ≈ x=600..680, C ≈ x=1140..1220) so enemies never block boarding.
  *
- *   - Slime patrols the workstations row on the ground floor, clear of
- *     both the signpost (x≈260) and the central lift shaft (x=640).
- *   - A rogue deploy bot patrols the RIGHT mezzanine near the monitoring
- *     wall (Observability catwalk, x=768..1024).
- *   - A second bot patrols the Edge Security ground zone near the WAF
- *     panel (x≈1080..1260), thematically "traffic arriving from the
- *     internet".
+ *   - Ground slime patrols the workstation lane between lift A and lift B.
+ *   - A rogue deploy bot patrols the T3 Observability catwalk (y=480).
+ *   - A security bot patrols the T2 right ledge (y=600) — thematically
+ *     "traffic arriving from the internet" just below Edge Security.
  */
 export function enemiesForGroundY(G: number): EnemyList {
-  // Catwalk walking-surface — must match `C` in PlatformTeamScene.getLevelConfig().
-  const C = G - 220;
+  // Tier Ys — must match PlatformTeamScene.getLevelConfig().
+  const T3 = 412;
+  const T2 = 552;
   return [
-    // Ground workstations lane slime — kept to the left of the central lift
-    // (x=640) so it doesn't block the lift boarding zone.
-    { type: 'slime', x: 520, y: G - 20, minX: 380, maxX: 600, speed: 55 },
-    // Rogue deploy bot patrols the RIGHT mezzanine (Observability catwalk).
-    { type: 'bot', x: 896, y: C - 30, minX: 790, maxX: 1000, speed: 75 },
-    // Ground bot guards the WAF zone — traffic "at the edge" thematically.
-    { type: 'bot', x: 1180, y: G - 30, minX: 1080, maxX: 1260, speed: 85 },
+    // Ground workstations lane slime — between lift A (x≈160) and lift B
+    // (x≈640), clear of the signpost (x≈260).
+    { type: 'slime', x: 480, y: G - 20, minX: 340, maxX: 580, speed: 55 },
+    // Rogue deploy bot on T3 Observability (x=760..1120).
+    { type: 'bot', x: 940, y: T3 - 30, minX: 790, maxX: 1090, speed: 75 },
+    // Security bot on T2 right ledge (x=880..1060) — below the WAF panel.
+    { type: 'bot', x: 970, y: T2 - 30, minX: 900, maxX: 1040, speed: 70 },
   ];
 }


### PR DESCRIPTION
## Problem

Debug overlay on floor 1 showed green physics boxes overlapping blue info-zone boxes, and the player could not fit under the mezzanines.

**Root cause:** catwalks were built from the 128x128 `platform_floor1` tile, so each mezzanine's physics body extended 128 px below its walking surface. With catwalks at `y=612` and ground at `y=832`, only 92 px of headroom remained — less than the 116 px player hitbox. Info-zone rects (240x200 centred at `catwalk_y + 10`) then overlapped those tile bodies by ~110 px vertically, which is the exact green-on-blue artefact the user saw.

## Fix

- New `catwalks` primitive on `LevelConfig` / `LevelScene`: a thin (16 px) rectangular static body added to `platformGroup` with a small decorative slab + rail + rivet graphic.
- **One-way collision** (`checkCollision.down/left/right = false`) so the player can jump up through a catwalk and land on top — classic platformer jump-through behaviour; no head-bumps between tiers.
- Redesign `PlatformTeamScene` as a four-tier room:
  - T1 = 692 (WAF / Edge Security ledge)
  - T2 = 552 (mid catwalks, split around each lift shaft)
  - T3 = 412 (Scaling Lab + Observability stations)
  - T4 = 272 (central island, split around lift B)
- Three in-room lifts: **A** (`x=160`, G↔T2), **B** (`x=640`, G↔T4), **C** (`x=1100`, G↔T1). All shafts clear of catwalk bodies.
- Info zones placed **above** their catwalks via negative `offsetY` so no zone rect crosses a physics body.
- All 7 tokens (indices 0..6) preserved for save compatibility; token 6 on T4 now requires riding lift B to the top.
- `enemies.ts`: bot patrols the new T3 Observability catwalk; second bot on T2 right ledge.

## Geometry math

- Tier pitch = 140, catwalk thickness = 16 → clearance = 124 px (> 116 hitbox). ✓
- Max jump height ≈ 520² / (2·900) ≈ 150 px > 140 pitch → every tier-to-tier jump reachable.
- Lift shafts (80 px wide) are not covered by any catwalk body.

## Scope

Platform scene only. `ExecutiveSuiteScene` shares the thick-tile pattern but is out of scope per user direction.

## Checks run

- `npm run typecheck` ✅
- `npm run lint` ✅ (only pre-existing warnings)
- `npm run test:unit` ✅ 269/269

E2E/visual not run (opt-in per repo convention).