### PR TITLE
fix: room elevators stuck when startY equals boundary

### DIFF
--- a/src/features/floors/_shared/LevelScene.ts
+++ b/src/features/floors/_shared/LevelScene.ts
@@ -535,11 +535,15 @@ export class LevelScene extends Phaser.Scene {
       lift.platform.setVelocityY(0);
     }
 
-    if (lift.platform.y <= lift.minY) {
+    // Only clamp when moving out of bounds — otherwise starting at a
+    // boundary (startY === maxY) would zero velocity every frame and
+    // block motion back into range. Same tripwire as src/entities/Elevator.ts.
+    const vy = (lift.platform.body as Phaser.Physics.Arcade.Body).velocity.y;
+    if (lift.platform.y <= lift.minY && vy < 0) {
       lift.platform.y = lift.minY;
       lift.platform.setVelocityY(0);
     }
-    if (lift.platform.y >= lift.maxY) {
+    if (lift.platform.y >= lift.maxY && vy > 0) {
       lift.platform.y = lift.maxY;
       lift.platform.setVelocityY(0);
     }


### PR DESCRIPTION
## Problem
Platform scene's central lift (and executive suite's lift) wouldn't move on the first upward press. Both configs use `startY === maxY` (parked at ground).

## Cause
`LevelScene.updateRoomElevators` clamped the lift unconditionally whenever `platform.y >= maxY` or `platform.y <= minY`. Starting at the boundary, the clamp fires every frame: the input handler sets `velocityY = -ELEVATOR_SPEED`, then the clamp immediately zeros it before the physics step runs. Same tripwire as `src/entities/Elevator.ts`.

## Fix
Only clamp when moving *out* of bounds (check velocity sign before zeroing).

## Verification
- `npm run typecheck` ✅
- `npm run lint` ✅ (pre-existing warnings only)
- `npm run test:unit` ✅ 267 passed