### PR TITLE
feat: coffee power-up pickup with temporary speed/jump buff

### DIFF
--- a/src/config/audioConfig.ts
+++ b/src/config/audioConfig.ts
@@ -102,6 +102,7 @@ export const SFX_EVENTS: Record<SfxEventName, string> = {
   'sfx:stomp':        'stomp',
   'sfx:drop_au':      'drop_au',
   'sfx:recover_au':   'recover_au',
+  'sfx:coffee_sip':   'coffee_sip',
 };
 
 /** Default volume for background music (0–1). */

--- a/src/entities/Coffee.ts
+++ b/src/entities/Coffee.ts
@@ -1,0 +1,109 @@
+import * as Phaser from 'phaser';
+
+/**
+ * Collectible coffee mug. Consumable — not persisted, respawns every
+ * time the scene is re-entered. Visual contract mirrors {@link Token}:
+ * idle float + pulse, soft halo behind, squash-out on collect.
+ */
+export class Coffee extends Phaser.Physics.Arcade.Sprite {
+  private floatTween?: Phaser.Tweens.Tween;
+  private haloTween?: Phaser.Tweens.Tween;
+  private pulseTween?: Phaser.Tweens.Tween;
+  private steam?: Phaser.GameObjects.Image;
+  private collected = false;
+
+  constructor(scene: Phaser.Scene, x: number, y: number) {
+    super(scene, x, y, 'coffee_mug');
+    scene.add.existing(this);
+    scene.physics.add.existing(this, true); // static body
+
+    this.setDepth(5);
+
+    // Steam halo — positioned above the mug so it reads as rising vapor
+    // rather than a glow around the cup itself.
+    if (scene.textures.exists('coffee_steam')) {
+      this.steam = scene.add
+        .image(x, y - 22, 'coffee_steam')
+        .setDepth(4)
+        .setAlpha(0.55)
+        .setTint(0xe8d8c0);
+      this.haloTween = scene.tweens.add({
+        targets: this.steam,
+        alpha: { from: 0.35, to: 0.65 },
+        y: { from: y - 22, to: y - 30 },
+        scale: { from: 0.9, to: 1.15 },
+        duration: 1100,
+        yoyo: true,
+        repeat: -1,
+        ease: 'Sine.easeInOut',
+      });
+    }
+
+    this.floatTween = scene.tweens.add({
+      targets: this,
+      y: y - 6,
+      duration: 1000,
+      ease: 'Sine.easeInOut',
+      yoyo: true,
+      repeat: -1,
+    });
+
+    this.pulseTween = scene.tweens.add({
+      targets: this,
+      scaleX: 1.08,
+      scaleY: 1.08,
+      duration: 700,
+      ease: 'Sine.easeInOut',
+      yoyo: true,
+      repeat: -1,
+    });
+  }
+
+  preUpdate(time: number, delta: number): void {
+    super.preUpdate(time, delta);
+    // Steam floats above the bobbing mug — keep horizontal x tracking but
+    // let the halo y-tween drive vertical motion so it doesn't jitter.
+    if (this.steam && !this.collected) {
+      this.steam.setX(this.x);
+    }
+  }
+
+  collect(): void {
+    if (this.collected) return;
+    this.collected = true;
+
+    if (this.body) {
+      (this.body as Phaser.Physics.Arcade.Body | Phaser.Physics.Arcade.StaticBody).enable = false;
+    }
+    this.floatTween?.stop();
+    this.haloTween?.stop();
+    this.pulseTween?.stop();
+    this.scene.tweens.killTweensOf(this);
+
+    if (this.steam) {
+      const steam = this.steam;
+      this.scene.tweens.add({
+        targets: steam,
+        alpha: 0,
+        y: steam.y - 16,
+        scale: 1.6,
+        duration: 280,
+        onComplete: () => steam.destroy(),
+      });
+      this.steam = undefined;
+    }
+
+    this.scene.tweens.add({
+      targets: this,
+      y: this.y - 22,
+      alpha: 0,
+      scaleX: 1.3,
+      scaleY: 0.7,
+      duration: 220,
+      ease: 'Quad.easeOut',
+      onComplete: () => {
+        this.destroy();
+      },
+    });
+  }
+}

--- a/src/entities/Coffee.ts
+++ b/src/entities/Coffee.ts
@@ -1,10 +1,6 @@
 import * as Phaser from 'phaser';
 
-/**
- * Collectible coffee mug. Consumable — not persisted, respawns every
- * time the scene is re-entered. Visual contract mirrors {@link Token}:
- * idle float + pulse, soft halo behind, squash-out on collect.
- */
+/** Consumable pickup — not persisted; respawns on scene entry. */
 export class Coffee extends Phaser.Physics.Arcade.Sprite {
   private floatTween?: Phaser.Tweens.Tween;
   private haloTween?: Phaser.Tweens.Tween;
@@ -19,8 +15,6 @@ export class Coffee extends Phaser.Physics.Arcade.Sprite {
 
     this.setDepth(5);
 
-    // Steam halo — positioned above the mug so it reads as rising vapor
-    // rather than a glow around the cup itself.
     if (scene.textures.exists('coffee_steam')) {
       this.steam = scene.add
         .image(x, y - 22, 'coffee_steam')
@@ -61,8 +55,7 @@ export class Coffee extends Phaser.Physics.Arcade.Sprite {
 
   preUpdate(time: number, delta: number): void {
     super.preUpdate(time, delta);
-    // Steam floats above the bobbing mug — keep horizontal x tracking but
-    // let the halo y-tween drive vertical motion so it doesn't jitter.
+    // x-only follow so the halo's own y-tween isn't fought by the mug's bob.
     if (this.steam && !this.collected) {
       this.steam.setX(this.x);
     }

--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -4,8 +4,7 @@ import { eventBus } from '../systems/EventBus';
 import { activeContext } from '../input';
 import { CaffeineBuff } from '../systems/CaffeineBuff';
 
-/** Coffee buff tuning. Air speed is deliberately NOT buffed — see
- *  AIR_HORIZONTAL_SPEED note above for the shaft-width invariant. */
+// Air speed is NOT buffed — see AIR_HORIZONTAL_SPEED shaft-width invariant below.
 export const CAFFEINE_DURATION_MS = 6000;
 export const CAFFEINE_SPEED_MULT = 1.4;
 export const CAFFEINE_JUMP_MULT = 1.15;
@@ -82,7 +81,6 @@ export class Player {
   /** Last applied walk fps, rounded — avoids restarting the tween every frame. */
   private currentWalkFps = 10;
 
-  /** Caffeine buff timer + steam particle trail. */
   private caffeine = new CaffeineBuff();
   private caffeineSteam?: Phaser.GameObjects.Particles.ParticleEmitter;
 
@@ -243,8 +241,7 @@ export class Player {
 
     // Horizontal movement. Air control is capped below ground speed so the
     // player can't clear wide gaps (in particular the elevator shaft) by
-    // jumping off the edge. Coffee buff multiplies ground speed only —
-    // air speed stays at the base cap to preserve the shaft invariant.
+    // jumping off the edge.
     const groundSpeed = this.isCaffeinated()
       ? PLAYER_SPEED * CAFFEINE_SPEED_MULT
       : PLAYER_SPEED;
@@ -405,10 +402,6 @@ export class Player {
     this.caffeineSteam.setDepth(9);
   }
 
-  /**
-   * Called every tick from {@link update}. Follows the steam emitter to
-   * the sprite while active and transitions out cleanly on expiry.
-   */
   private tickCaffeine(): void {
     const now = this.scene.time.now;
     if (this.caffeine.isActive(now)) {
@@ -421,18 +414,12 @@ export class Player {
     }
   }
 
-  /**
-   * Activate (or refresh) the caffeine buff. Re-applying while active
-   * refreshes the timer to the full `durationMs` — no stacking.
-   */
+  /** No stacking — re-applying refreshes the timer to the full `durationMs`. */
   applyCaffeine(durationMs: number = CAFFEINE_DURATION_MS): void {
     const now = this.scene.time.now;
     this.caffeine.activate(now, durationMs);
     this.caffeineSteam?.setPosition(this.sprite.x, this.sprite.y - 10);
     this.caffeineSteam?.start();
-    // Emit on every activation — the HUD listener resets its countdown
-    // ring to full, which is the right behaviour for both a fresh buff
-    // and a refresh of an already-active one.
     eventBus.emit('buff:caffeine_start', durationMs);
   }
 

--- a/src/entities/Player.ts
+++ b/src/entities/Player.ts
@@ -2,6 +2,13 @@ import * as Phaser from 'phaser';
 import { PLAYER_SPEED, PLAYER_JUMP_VELOCITY } from '../config/gameConfig';
 import { eventBus } from '../systems/EventBus';
 import { activeContext } from '../input';
+import { CaffeineBuff } from '../systems/CaffeineBuff';
+
+/** Coffee buff tuning. Air speed is deliberately NOT buffed — see
+ *  AIR_HORIZONTAL_SPEED note above for the shaft-width invariant. */
+export const CAFFEINE_DURATION_MS = 6000;
+export const CAFFEINE_SPEED_MULT = 1.4;
+export const CAFFEINE_JUMP_MULT = 1.15;
 
 type PlayerAnimState = 'idle' | 'walk' | 'flip' | 'fall' | 'land';
 
@@ -75,6 +82,10 @@ export class Player {
   /** Last applied walk fps, rounded — avoids restarting the tween every frame. */
   private currentWalkFps = 10;
 
+  /** Caffeine buff timer + steam particle trail. */
+  private caffeine = new CaffeineBuff();
+  private caffeineSteam?: Phaser.GameObjects.Particles.ParticleEmitter;
+
   constructor(scene: Phaser.Scene, x: number, y: number) {
     this.scene = scene;
 
@@ -87,6 +98,7 @@ export class Player {
     this.createAnimations();
     this.sprite.on(Phaser.Animations.Events.ANIMATION_UPDATE, this.onAnimationFrame, this);
     this.createDustEmitter();
+    this.createCaffeineEmitter();
   }
 
   private createAnimations(): void {
@@ -166,6 +178,8 @@ export class Player {
     const body = this.sprite.body as Phaser.Physics.Arcade.Body;
     const onGround = body.blocked.down || body.touching.down;
 
+    this.tickCaffeine();
+
     // Clear the mid-jump flag the moment we land so subsequent input/anim
     // logic reflects that the player is grounded again.
     if (this.isFlipping && onGround && body.velocity.y >= 0) {
@@ -229,8 +243,12 @@ export class Player {
 
     // Horizontal movement. Air control is capped below ground speed so the
     // player can't clear wide gaps (in particular the elevator shaft) by
-    // jumping off the edge.
-    const maxX = onGround ? PLAYER_SPEED : AIR_HORIZONTAL_SPEED;
+    // jumping off the edge. Coffee buff multiplies ground speed only —
+    // air speed stays at the base cap to preserve the shaft invariant.
+    const groundSpeed = this.isCaffeinated()
+      ? PLAYER_SPEED * CAFFEINE_SPEED_MULT
+      : PLAYER_SPEED;
+    const maxX = onGround ? groundSpeed : AIR_HORIZONTAL_SPEED;
     if (h < 0) {
       this.sprite.setVelocityX(-maxX);
       this.facingRight = false;
@@ -271,7 +289,10 @@ export class Player {
    */
   private startJump(): void {
     this.isFlipping = true;
-    this.sprite.setVelocityY(PLAYER_JUMP_VELOCITY);
+    const jumpV = this.isCaffeinated()
+      ? PLAYER_JUMP_VELOCITY * CAFFEINE_JUMP_MULT
+      : PLAYER_JUMP_VELOCITY;
+    this.sprite.setVelocityY(jumpV);
 
     this.currentAnim = 'flip';
     this.sprite.anims.play('player_flip', true);
@@ -366,6 +387,57 @@ export class Player {
       this.dustEmitter.setPosition(this.sprite.x, this.sprite.y + 70);
       this.dustEmitter.explode(5);
     }
+  }
+
+  private createCaffeineEmitter(): void {
+    if (!this.scene.textures.exists('particle')) return;
+    this.caffeineSteam = this.scene.add.particles(0, 0, 'particle', {
+      speed: { min: 20, max: 60 },
+      angle: { min: 250, max: 290 },
+      scale: { start: 0.5, end: 0 },
+      alpha: { start: 0.55, end: 0 },
+      lifespan: 520,
+      frequency: 80,
+      quantity: 1,
+      tint: 0xe8d8c0,
+      emitting: false,
+    });
+    this.caffeineSteam.setDepth(9);
+  }
+
+  /**
+   * Called every tick from {@link update}. Follows the steam emitter to
+   * the sprite while active and transitions out cleanly on expiry.
+   */
+  private tickCaffeine(): void {
+    const now = this.scene.time.now;
+    if (this.caffeine.isActive(now)) {
+      if (this.caffeineSteam) {
+        this.caffeineSteam.setPosition(this.sprite.x, this.sprite.y - 10);
+      }
+    } else if (this.caffeineSteam?.emitting) {
+      this.caffeineSteam.stop();
+      eventBus.emit('buff:caffeine_end');
+    }
+  }
+
+  /**
+   * Activate (or refresh) the caffeine buff. Re-applying while active
+   * refreshes the timer to the full `durationMs` — no stacking.
+   */
+  applyCaffeine(durationMs: number = CAFFEINE_DURATION_MS): void {
+    const now = this.scene.time.now;
+    this.caffeine.activate(now, durationMs);
+    this.caffeineSteam?.setPosition(this.sprite.x, this.sprite.y - 10);
+    this.caffeineSteam?.start();
+    // Emit on every activation — the HUD listener resets its countdown
+    // ring to full, which is the right behaviour for both a fresh buff
+    // and a refresh of an already-active one.
+    eventBus.emit('buff:caffeine_start', durationMs);
+  }
+
+  isCaffeinated(): boolean {
+    return this.caffeine.isActive(this.scene.time.now);
   }
 
   setFlipEnabled(enabled: boolean): void {

--- a/src/features/floors/_shared/LevelCoffeeManager.ts
+++ b/src/features/floors/_shared/LevelCoffeeManager.ts
@@ -9,12 +9,7 @@ export interface CoffeeManagerDeps {
   player: Player;
 }
 
-/**
- * Owns the coffee pickups for a level. Unlike {@link LevelTokenManager},
- * coffee has no progression persistence — every scene entry spawns a
- * fresh mug at each configured position. On overlap the mug tweens out
- * and the player's caffeine buff is applied.
- */
+/** Coffee pickups are consumable — no progression persistence, respawn on scene entry. */
 export class LevelCoffeeManager {
   readonly coffeeGroup: Phaser.Physics.Arcade.StaticGroup;
 

--- a/src/features/floors/_shared/LevelCoffeeManager.ts
+++ b/src/features/floors/_shared/LevelCoffeeManager.ts
@@ -1,0 +1,72 @@
+import * as Phaser from 'phaser';
+import { Coffee } from '../../../entities/Coffee';
+import { Player } from '../../../entities/Player';
+import { eventBus } from '../../../systems/EventBus';
+import type { LevelConfig } from './LevelScene';
+
+export interface CoffeeManagerDeps {
+  scene: Phaser.Scene;
+  player: Player;
+}
+
+/**
+ * Owns the coffee pickups for a level. Unlike {@link LevelTokenManager},
+ * coffee has no progression persistence — every scene entry spawns a
+ * fresh mug at each configured position. On overlap the mug tweens out
+ * and the player's caffeine buff is applied.
+ */
+export class LevelCoffeeManager {
+  readonly coffeeGroup: Phaser.Physics.Arcade.StaticGroup;
+
+  constructor(private readonly deps: CoffeeManagerDeps) {
+    this.coffeeGroup = deps.scene.physics.add.staticGroup();
+  }
+
+  spawn(config: LevelConfig): void {
+    const coffees = config.coffees;
+    if (!coffees?.length) return;
+    for (const c of coffees) {
+      const mug = new Coffee(this.deps.scene, c.x, c.y);
+      this.coffeeGroup.add(mug);
+    }
+  }
+
+  wireColliders(): void {
+    this.deps.scene.physics.add.overlap(
+      this.deps.player.sprite,
+      this.coffeeGroup,
+      this.onCollect as Phaser.Types.Physics.Arcade.ArcadePhysicsCallback,
+      undefined,
+      this,
+    );
+  }
+
+  private onCollect = (
+    _player: Phaser.Types.Physics.Arcade.GameObjectWithBody | Phaser.Tilemaps.Tile,
+    mugObj: Phaser.Types.Physics.Arcade.GameObjectWithBody | Phaser.Tilemaps.Tile,
+  ): void => {
+    const mug = mugObj as Coffee;
+    this.emitSipBurst(mug.x, mug.y);
+    mug.collect();
+    this.deps.player.applyCaffeine();
+    eventBus.emit('sfx:coffee_sip');
+  };
+
+  private emitSipBurst(x: number, y: number): void {
+    const scene = this.deps.scene;
+    if (!scene.textures.exists('particle')) return;
+    const emitter = scene.add.particles(x, y - 8, 'particle', {
+      speed: { min: 40, max: 140 },
+      angle: { min: 220, max: 320 },
+      scale: { start: 0.6, end: 0 },
+      alpha: { start: 0.9, end: 0 },
+      lifespan: 480,
+      gravityY: -40,
+      tint: 0xe8d8c0,
+      emitting: false,
+    });
+    emitter.setDepth(11);
+    emitter.explode(8);
+    scene.time.delayedCall(600, () => emitter.destroy());
+  }
+}

--- a/src/features/floors/_shared/LevelScene.ts
+++ b/src/features/floors/_shared/LevelScene.ts
@@ -98,11 +98,7 @@ export interface LevelConfig {
     maxX?: number;
     speed?: number;
   }>;
-  /**
-   * Consumable coffee pickups. Applying a caffeine buff on collection —
-   * faster ground speed + a slightly higher jump for a few seconds.
-   * Not persisted; respawns every scene entry.
-   */
+  /** Consumable — not persisted, respawns every scene entry. */
   coffees?: Array<{ x: number; y: number }>;
 }
 

--- a/src/features/floors/_shared/LevelScene.ts
+++ b/src/features/floors/_shared/LevelScene.ts
@@ -13,6 +13,7 @@ import { allKeyLabels } from '../../../input';
 import type { NavigationContext } from '../../../scenes/NavigationContext';
 import { LevelEnemySpawner } from './LevelEnemySpawner';
 import { LevelTokenManager } from './LevelTokenManager';
+import { LevelCoffeeManager } from './LevelCoffeeManager';
 import { LevelZoneSetup } from './LevelZoneSetup';
 import { createLevelDialogs } from './LevelDialogBindings';
 import { drawSceneBackdrop, type FloorPatternId } from './sceneBackdrop';
@@ -97,6 +98,12 @@ export interface LevelConfig {
     maxX?: number;
     speed?: number;
   }>;
+  /**
+   * Consumable coffee pickups. Applying a caffeine buff on collection —
+   * faster ground speed + a slightly higher jump for a few seconds.
+   * Not persisted; respawns every scene entry.
+   */
+  coffees?: Array<{ x: number; y: number }>;
 }
 
 /**
@@ -155,6 +162,7 @@ export class LevelScene extends Phaser.Scene {
 
   private enemySpawner!: LevelEnemySpawner;
   private tokenMgr!: LevelTokenManager;
+  private coffeeMgr!: LevelCoffeeManager;
   private zones!: LevelZoneSetup;
 
   /** Grounding shadow tracked to the player each frame. */
@@ -225,6 +233,10 @@ export class LevelScene extends Phaser.Scene {
       droppedAUGroup: this.tokenMgr.droppedAUGroup,
       camera: this.cameras.main,
     });
+    this.coffeeMgr = new LevelCoffeeManager({
+      scene: this,
+      player: this.player,
+    });
     this.zones = new LevelZoneSetup({
       scene: this,
       player: this.player,
@@ -235,11 +247,13 @@ export class LevelScene extends Phaser.Scene {
     const cfg = this.getLevelConfig();
     this.tokenMgr.spawn(cfg);
     this.enemySpawner.spawn(cfg);
+    this.coffeeMgr.spawn(cfg);
     this.zones.create(cfg);
 
     this.physics.add.collider(this.player.sprite, this.platformGroup);
     this.tokenMgr.wireColliders();
     this.enemySpawner.wireColliders();
+    this.coffeeMgr.wireColliders();
 
     for (let i = 0; i < this.roomLifts.length; i++) {
       const idx = i;

--- a/src/features/floors/architecture/ArchitectureTeamScene.ts
+++ b/src/features/floors/architecture/ArchitectureTeamScene.ts
@@ -322,7 +322,6 @@ export class ArchitectureTeamScene extends LevelScene {
         { x: 1200, y: G - 40, index: K + 3 },
       ],
 
-      // Single coffee tucked between the C4 whiteboard and the slice wall.
       coffees: [
         { x: 600, y: G - 40 },
       ],

--- a/src/features/floors/architecture/ArchitectureTeamScene.ts
+++ b/src/features/floors/architecture/ArchitectureTeamScene.ts
@@ -322,6 +322,11 @@ export class ArchitectureTeamScene extends LevelScene {
         { x: 1200, y: G - 40, index: K + 3 },
       ],
 
+      // Single coffee tucked between the C4 whiteboard and the slice wall.
+      coffees: [
+        { x: 600, y: G - 40 },
+      ],
+
       infoPoints: [
         {
           x: 230, y: G, contentId: 'architecture-team',

--- a/src/features/floors/customer/CustomerSuccessScene.ts
+++ b/src/features/floors/customer/CustomerSuccessScene.ts
@@ -67,6 +67,10 @@ export class CustomerSuccessScene extends LevelScene {
         { x: 900,  y: G - 40, index: off + 4 },
       ],
 
+      coffees: [
+        { x: 120, y: G - 40 },
+      ],
+
       infoPoints: [
         {
           x: 1050, y: G, contentId: 'customer-success',

--- a/src/features/floors/executive/ExecutiveSuiteScene.ts
+++ b/src/features/floors/executive/ExecutiveSuiteScene.ts
@@ -193,8 +193,6 @@ export class ExecutiveSuiteScene extends LevelScene {
         { x: 740,  y: T1 - 40 },
       ],
 
-      // An executive espresso on the strategy-lounge mezzanine — rewards
-      // the detour up the in-room lift before strolling toward the doors.
       coffees: [
         { x: 680, y: T1 - 40 },
       ],

--- a/src/features/floors/executive/ExecutiveSuiteScene.ts
+++ b/src/features/floors/executive/ExecutiveSuiteScene.ts
@@ -193,6 +193,12 @@ export class ExecutiveSuiteScene extends LevelScene {
         { x: 740,  y: T1 - 40 },
       ],
 
+      // An executive espresso on the strategy-lounge mezzanine — rewards
+      // the detour up the in-room lift before strolling toward the doors.
+      coffees: [
+        { x: 680, y: T1 - 40 },
+      ],
+
       infoPoints: [
         {
           x: 380, y: G, contentId: 'executive-suite',

--- a/src/features/floors/platform/PlatformTeamScene.ts
+++ b/src/features/floors/platform/PlatformTeamScene.ts
@@ -592,10 +592,8 @@ export class PlatformTeamScene extends LevelScene {
         { x: 540,  y: T4 - 40, index: 6 }, // T4 island-left (ride lift B, step left)
       ],
 
-      // A caffeine hit on the T4 island — rewards climbing the spine lift
-      // and smooths the return trip across the mezzanines.
       coffees: [
-        { x: 720, y: T4 - 40 }, // T4 island-right
+        { x: 720, y: T4 - 40 },
       ],
 
       infoPoints: [

--- a/src/features/floors/platform/PlatformTeamScene.ts
+++ b/src/features/floors/platform/PlatformTeamScene.ts
@@ -592,6 +592,12 @@ export class PlatformTeamScene extends LevelScene {
         { x: 540,  y: T4 - 40, index: 6 }, // T4 island-left (ride lift B, step left)
       ],
 
+      // A caffeine hit on the T4 island — rewards climbing the spine lift
+      // and smooths the return trip across the mezzanines.
+      coffees: [
+        { x: 720, y: T4 - 40 }, // T4 island-right
+      ],
+
       infoPoints: [
         // Ground signpost. Default offsetY = -h/2 places the rect
         // directly above the anchor (y ≈ 632..832). No catwalk body sits

--- a/src/features/floors/product/ProductLeadershipScene.ts
+++ b/src/features/floors/product/ProductLeadershipScene.ts
@@ -66,6 +66,10 @@ export class ProductLeadershipScene extends LevelScene {
         { x: 1040, y: G - 40, index: off + 4 },
       ],
 
+      coffees: [
+        { x: 1180, y: G - 40 },
+      ],
+
       infoPoints: [
         {
           x: 230, y: G, contentId: 'product-leadership',

--- a/src/systems/CaffeineBuff.test.ts
+++ b/src/systems/CaffeineBuff.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect } from 'vitest';
+import { CaffeineBuff } from './CaffeineBuff';
+
+describe('CaffeineBuff', () => {
+  it('is inactive by default', () => {
+    const b = new CaffeineBuff();
+    expect(b.isActive(0)).toBe(false);
+    expect(b.remaining(0)).toBe(0);
+    expect(b.ratio(0)).toBe(0);
+  });
+
+  it('activates for the given window', () => {
+    const b = new CaffeineBuff();
+    b.activate(1000, 6000);
+    expect(b.isActive(1000)).toBe(true);
+    expect(b.isActive(4000)).toBe(true);
+    expect(b.isActive(6999)).toBe(true);
+    expect(b.isActive(7000)).toBe(false);
+  });
+
+  it('reports remaining time that decays to zero', () => {
+    const b = new CaffeineBuff();
+    b.activate(0, 5000);
+    expect(b.remaining(0)).toBe(5000);
+    expect(b.remaining(2000)).toBe(3000);
+    expect(b.remaining(5000)).toBe(0);
+    expect(b.remaining(9000)).toBe(0);
+  });
+
+  it('reports ratio in 0..1 and clamps outside the window', () => {
+    const b = new CaffeineBuff();
+    b.activate(0, 4000);
+    expect(b.ratio(0)).toBe(1);
+    expect(b.ratio(2000)).toBeCloseTo(0.5);
+    expect(b.ratio(4000)).toBe(0);
+    expect(b.ratio(10000)).toBe(0);
+  });
+
+  it('re-activating refreshes the window (no stacking)', () => {
+    const b = new CaffeineBuff();
+    b.activate(0, 4000);
+    // Half-elapsed, then refresh at t=2000 with a 4s window.
+    b.activate(2000, 4000);
+    expect(b.remaining(2000)).toBe(4000);
+    expect(b.isActive(5999)).toBe(true);
+    expect(b.isActive(6000)).toBe(false);
+  });
+
+  it('clear() immediately ends the buff', () => {
+    const b = new CaffeineBuff();
+    b.activate(0, 6000);
+    b.clear();
+    expect(b.isActive(100)).toBe(false);
+    expect(b.ratio(100)).toBe(0);
+  });
+});

--- a/src/systems/CaffeineBuff.ts
+++ b/src/systems/CaffeineBuff.ts
@@ -1,18 +1,9 @@
-/**
- * Pure timer for the caffeine (coffee) buff. Kept framework-agnostic so it
- * can be driven by Phaser's scene clock in the game and by a plain number
- * in tests. Callers pass `now` (ms) to every query — the helper itself
- * has no ambient time source.
- */
+/** Pure timer for the caffeine buff — no ambient time source; callers pass `now`. */
 export class CaffeineBuff {
   private activeUntil = 0;
-  /** Total duration of the current buff window — used by UI to render a ratio. */
   private currentDurationMs = 0;
 
-  /**
-   * Activate or refresh the buff. Re-activating while already active simply
-   * resets the end-time to `now + durationMs` (no stacking).
-   */
+  /** No stacking — re-activating resets the end-time. */
   activate(now: number, durationMs: number): void {
     this.activeUntil = now + durationMs;
     this.currentDurationMs = durationMs;
@@ -22,18 +13,16 @@ export class CaffeineBuff {
     return now < this.activeUntil;
   }
 
-  /** Remaining ms (0 when expired). */
   remaining(now: number): number {
     return Math.max(0, this.activeUntil - now);
   }
 
-  /** 0..1 fraction of the current buff window still remaining. */
+  /** 0..1 of the current window still remaining. */
   ratio(now: number): number {
     if (this.currentDurationMs <= 0) return 0;
     return Math.max(0, Math.min(1, this.remaining(now) / this.currentDurationMs));
   }
 
-  /** Force-clear — used when the buff is cancelled externally. */
   clear(): void {
     this.activeUntil = 0;
     this.currentDurationMs = 0;

--- a/src/systems/CaffeineBuff.ts
+++ b/src/systems/CaffeineBuff.ts
@@ -1,0 +1,41 @@
+/**
+ * Pure timer for the caffeine (coffee) buff. Kept framework-agnostic so it
+ * can be driven by Phaser's scene clock in the game and by a plain number
+ * in tests. Callers pass `now` (ms) to every query — the helper itself
+ * has no ambient time source.
+ */
+export class CaffeineBuff {
+  private activeUntil = 0;
+  /** Total duration of the current buff window — used by UI to render a ratio. */
+  private currentDurationMs = 0;
+
+  /**
+   * Activate or refresh the buff. Re-activating while already active simply
+   * resets the end-time to `now + durationMs` (no stacking).
+   */
+  activate(now: number, durationMs: number): void {
+    this.activeUntil = now + durationMs;
+    this.currentDurationMs = durationMs;
+  }
+
+  isActive(now: number): boolean {
+    return now < this.activeUntil;
+  }
+
+  /** Remaining ms (0 when expired). */
+  remaining(now: number): number {
+    return Math.max(0, this.activeUntil - now);
+  }
+
+  /** 0..1 fraction of the current buff window still remaining. */
+  ratio(now: number): number {
+    if (this.currentDurationMs <= 0) return 0;
+    return Math.max(0, Math.min(1, this.remaining(now) / this.currentDurationMs));
+  }
+
+  /** Force-clear — used when the buff is cancelled externally. */
+  clear(): void {
+    this.activeUntil = 0;
+    this.currentDurationMs = 0;
+  }
+}

--- a/src/systems/EventBus.ts
+++ b/src/systems/EventBus.ts
@@ -46,6 +46,13 @@ export interface GameEvents {
   'sfx:drop_au': [];
   /** Dropped AU recovered. */
   'sfx:recover_au': [];
+  /** Coffee pickup — a short slurp. */
+  'sfx:coffee_sip': [];
+
+  /** Caffeine buff activated; payload is the total duration in ms. */
+  'buff:caffeine_start': [durationMs: number];
+  /** Caffeine buff expired. */
+  'buff:caffeine_end': [];
 }
 
 export type GameEventName = keyof GameEvents;

--- a/src/systems/SoundGenerator.ts
+++ b/src/systems/SoundGenerator.ts
@@ -15,6 +15,7 @@ import {
   generateRecoverAUSound,
 } from './sounds/movement';
 import { generateDatacenterAmbience } from './sounds/ambience';
+import { generateCoffeeSipSound } from './sounds/items';
 
 /**
  * Composition root for runtime audio generation.
@@ -39,6 +40,7 @@ export function generateSounds(scene: Phaser.Scene): void {
   loadWav(scene, 'drop_au', generateDropAUSound());
   loadWav(scene, 'recover_au', generateRecoverAUSound());
   loadWav(scene, 'ambience_datacenter', generateDatacenterAmbience());
+  loadWav(scene, 'coffee_sip', generateCoffeeSipSound());
 }
 
 export { loadWav, encodeWAV } from './sounds/wav';

--- a/src/systems/SpriteGenerator.ts
+++ b/src/systems/SpriteGenerator.ts
@@ -13,6 +13,7 @@ import { generateInfraSprites } from './sprites/infra';
 import { generateEnemySprites } from './sprites/enemies';
 import { generateGeirSprite } from './sprites/npcGeir';
 import { generateReceptionistSprite } from './sprites/receptionist';
+import { generateCoffeeSprites } from './sprites/coffee';
 
 /**
  * Composition root for runtime sprite generation.
@@ -36,4 +37,5 @@ export function generateSprites(scene: Phaser.Scene): void {
   generateEnemySprites(scene);
   generateGeirSprite(scene);
   generateReceptionistSprite(scene);
+  generateCoffeeSprites(scene);
 }

--- a/src/systems/sounds/items.ts
+++ b/src/systems/sounds/items.ts
@@ -1,0 +1,31 @@
+import { SAMPLE_RATE, encodeWAV } from './wav';
+
+/**
+ * Coffee sip — low filtered noise + descending whistle. Short (~180 ms)
+ * slurp that reads as a drink being sipped quickly.
+ */
+export function generateCoffeeSipSound(): ArrayBuffer {
+  const duration = 0.18;
+  const numSamples = Math.floor(SAMPLE_RATE * duration);
+  const samples = new Float32Array(numSamples);
+
+  let phase = 0;
+  let noisePrev = 0;
+  for (let i = 0; i < numSamples; i++) {
+    const progress = numSamples > 1 ? i / (numSamples - 1) : 1;
+    // Descending whistle from 520 Hz → 220 Hz.
+    const freq = 520 - 300 * progress;
+    phase += (2 * Math.PI * freq) / SAMPLE_RATE;
+    const tone = Math.sin(phase) * 0.18;
+
+    // Low-pass filtered noise for the slurp body.
+    const noise = Math.random() * 2 - 1;
+    noisePrev = noisePrev * 0.82 + noise * 0.18;
+
+    // Bell envelope: fade in fast, hold, fade out.
+    const env = Math.sin(Math.PI * progress);
+    samples[i] = (tone + noisePrev * 0.25) * env * 0.6;
+  }
+
+  return encodeWAV(samples, SAMPLE_RATE);
+}

--- a/src/systems/sounds/items.ts
+++ b/src/systems/sounds/items.ts
@@ -1,9 +1,5 @@
 import { SAMPLE_RATE, encodeWAV } from './wav';
 
-/**
- * Coffee sip — low filtered noise + descending whistle. Short (~180 ms)
- * slurp that reads as a drink being sipped quickly.
- */
 export function generateCoffeeSipSound(): ArrayBuffer {
   const duration = 0.18;
   const numSamples = Math.floor(SAMPLE_RATE * duration);
@@ -13,16 +9,13 @@ export function generateCoffeeSipSound(): ArrayBuffer {
   let noisePrev = 0;
   for (let i = 0; i < numSamples; i++) {
     const progress = numSamples > 1 ? i / (numSamples - 1) : 1;
-    // Descending whistle from 520 Hz → 220 Hz.
     const freq = 520 - 300 * progress;
     phase += (2 * Math.PI * freq) / SAMPLE_RATE;
     const tone = Math.sin(phase) * 0.18;
 
-    // Low-pass filtered noise for the slurp body.
     const noise = Math.random() * 2 - 1;
     noisePrev = noisePrev * 0.82 + noise * 0.18;
 
-    // Bell envelope: fade in fast, hold, fade out.
     const env = Math.sin(Math.PI * progress);
     samples[i] = (tone + noisePrev * 0.25) * env * 0.6;
   }

--- a/src/systems/sprites/coffee.ts
+++ b/src/systems/sprites/coffee.ts
@@ -1,0 +1,71 @@
+import * as Phaser from 'phaser';
+
+/**
+ * Coffee mug pickup sprite + soft steam halo. Mug is a short brown
+ * ceramic cup with a D-shaped handle, dark rim, and cream-colored
+ * coffee surface showing through the top. Steam texture is a soft
+ * white blob used by `Coffee` for the pulsing halo.
+ */
+export function generateCoffeeSprites(scene: Phaser.Scene): void {
+  generateCoffeeMug(scene);
+  generateCoffeeSteam(scene);
+}
+
+function generateCoffeeMug(scene: Phaser.Scene): void {
+  const W = 40;
+  const H = 40;
+  const g = scene.make.graphics({ x: 0, y: 0 }, false);
+
+  // Handle — ring on the right side. Draw as thick stroked arc so the
+  // interior is transparent.
+  g.lineStyle(4, 0x4a2b1a, 1);
+  g.beginPath();
+  g.arc(29, 22, 7, -Math.PI / 2, Math.PI / 2, false);
+  g.strokePath();
+
+  // Cup body — rounded rectangle, tapered ever so slightly so it reads as
+  // ceramic rather than a can.
+  g.fillStyle(0x6b3b23, 1);
+  g.fillRoundedRect(10, 14, 20, 20, 3);
+
+  // Side highlight — a thin lighter stripe on the left for form.
+  g.fillStyle(0x8a4f33, 1);
+  g.fillRect(12, 16, 2, 16);
+
+  // Dark rim around the top edge of the cup.
+  g.fillStyle(0x3a1e10, 1);
+  g.fillRect(10, 14, 20, 3);
+
+  // Coffee surface — cream top with a dark ring inside the rim.
+  g.fillStyle(0x2a1608, 1);
+  g.fillRect(11, 15, 18, 2);
+  g.fillStyle(0xc9a27a, 1);
+  g.fillRect(12, 15, 16, 1);
+
+  // Saucer base — a small plate the mug sits on.
+  g.fillStyle(0x5a2f1c, 1);
+  g.fillRect(7, 34, 26, 2);
+  g.fillStyle(0x3a1e10, 1);
+  g.fillRect(7, 36, 26, 1);
+
+  g.generateTexture('coffee_mug', W, H);
+  g.destroy();
+}
+
+function generateCoffeeSteam(scene: Phaser.Scene): void {
+  const R = 22;
+  const D = R * 2;
+  const g = scene.make.graphics({ x: 0, y: 0 }, false);
+
+  // Soft radial falloff approximated with three concentric circles —
+  // matches the halo idiom from the token sprite.
+  g.fillStyle(0xffffff, 0.18);
+  g.fillCircle(R, R, R);
+  g.fillStyle(0xffffff, 0.28);
+  g.fillCircle(R, R, R - 7);
+  g.fillStyle(0xffffff, 0.45);
+  g.fillCircle(R, R, R - 13);
+
+  g.generateTexture('coffee_steam', D, D);
+  g.destroy();
+}

--- a/src/systems/sprites/coffee.ts
+++ b/src/systems/sprites/coffee.ts
@@ -1,11 +1,5 @@
 import * as Phaser from 'phaser';
 
-/**
- * Coffee mug pickup sprite + soft steam halo. Mug is a short brown
- * ceramic cup with a D-shaped handle, dark rim, and cream-colored
- * coffee surface showing through the top. Steam texture is a soft
- * white blob used by `Coffee` for the pulsing halo.
- */
 export function generateCoffeeSprites(scene: Phaser.Scene): void {
   generateCoffeeMug(scene);
   generateCoffeeSteam(scene);
@@ -16,33 +10,25 @@ function generateCoffeeMug(scene: Phaser.Scene): void {
   const H = 40;
   const g = scene.make.graphics({ x: 0, y: 0 }, false);
 
-  // Handle — ring on the right side. Draw as thick stroked arc so the
-  // interior is transparent.
   g.lineStyle(4, 0x4a2b1a, 1);
   g.beginPath();
   g.arc(29, 22, 7, -Math.PI / 2, Math.PI / 2, false);
   g.strokePath();
 
-  // Cup body — rounded rectangle, tapered ever so slightly so it reads as
-  // ceramic rather than a can.
   g.fillStyle(0x6b3b23, 1);
   g.fillRoundedRect(10, 14, 20, 20, 3);
 
-  // Side highlight — a thin lighter stripe on the left for form.
   g.fillStyle(0x8a4f33, 1);
   g.fillRect(12, 16, 2, 16);
 
-  // Dark rim around the top edge of the cup.
   g.fillStyle(0x3a1e10, 1);
   g.fillRect(10, 14, 20, 3);
 
-  // Coffee surface — cream top with a dark ring inside the rim.
   g.fillStyle(0x2a1608, 1);
   g.fillRect(11, 15, 18, 2);
   g.fillStyle(0xc9a27a, 1);
   g.fillRect(12, 15, 16, 1);
 
-  // Saucer base — a small plate the mug sits on.
   g.fillStyle(0x5a2f1c, 1);
   g.fillRect(7, 34, 26, 2);
   g.fillStyle(0x3a1e10, 1);
@@ -57,8 +43,6 @@ function generateCoffeeSteam(scene: Phaser.Scene): void {
   const D = R * 2;
   const g = scene.make.graphics({ x: 0, y: 0 }, false);
 
-  // Soft radial falloff approximated with three concentric circles —
-  // matches the halo idiom from the token sprite.
   g.fillStyle(0xffffff, 0.18);
   g.fillCircle(R, R, R);
   g.fillStyle(0xffffff, 0.28);

--- a/src/ui/HUD.test.ts
+++ b/src/ui/HUD.test.ts
@@ -25,6 +25,7 @@ function makeGraphics() {
     'fillStyle',
     'fillCircle',
     'fillRect',
+    'fillRoundedRect',
     'fillGradientStyle',
     'lineStyle',
     'beginPath',
@@ -32,8 +33,10 @@ function makeGraphics() {
     'lineTo',
     'strokePath',
     'fillEllipse',
+    'arc',
     'setPosition',
     'setAlpha',
+    'setVisible',
     'setX',
     'setScale',
   ];

--- a/src/ui/HUD.ts
+++ b/src/ui/HUD.ts
@@ -33,10 +33,9 @@ export class HUD {
   private progressTween?: Phaser.Tweens.Tween;
   private onMuteChanged = (muted: boolean): void => this.renderMuteIcon(muted);
 
-  /** Caffeine buff indicator — mug + shrinking countdown arc. */
   private caffeineIcon!: Phaser.GameObjects.Graphics;
   private caffeineRing!: Phaser.GameObjects.Graphics;
-  /** Scene time (ms) when the active buff ends. 0 when inactive. */
+  /** 0 when inactive. */
   private caffeineEndAt = 0;
   private caffeineDuration = 0;
   private onCaffeineStart = (durationMs: number): void => {
@@ -105,8 +104,6 @@ export class HUD {
     this.container.add(this.muteHit);
     this.renderMuteIcon(this.getAudio()?.isMuted() ?? false);
 
-    // Caffeine buff indicator — mug + shrinking arc, sits between the
-    // floor label and the mute icon. Hidden until the first buff start.
     const CAF_X = GAME_WIDTH - 76;
     const CAF_Y = 22;
     this.caffeineRing = this.scene.add.graphics().setPosition(CAF_X, CAF_Y).setVisible(false);
@@ -289,25 +286,18 @@ export class HUD {
     });
   }
 
-  /**
-   * Draw the mug icon + a shrinking arc. `ratio` is 1..0 over the buff
-   * window. Called on `buff:caffeine_start` and every HUD update tick
-   * while the buff is active.
-   */
   private renderCaffeineIcon(ratio: number): void {
     this.caffeineIcon.setVisible(true);
     this.caffeineRing.setVisible(true);
 
     const icon = this.caffeineIcon;
     icon.clear();
-    // Mug body.
     icon.fillStyle(0x6b3b23, 1);
     icon.fillRoundedRect(-6, -5, 11, 12, 2);
     icon.fillStyle(0x3a1e10, 1);
     icon.fillRect(-6, -5, 11, 2);
     icon.fillStyle(0xc9a27a, 1);
     icon.fillRect(-5, -5, 9, 1);
-    // Handle stroke (right).
     icon.lineStyle(1.5, 0x4a2b1a, 1);
     icon.beginPath();
     icon.arc(6, 1, 4, -Math.PI / 2, Math.PI / 2, false);
@@ -315,12 +305,10 @@ export class HUD {
 
     const ring = this.caffeineRing;
     ring.clear();
-    // Background track — full circle, dim.
     ring.lineStyle(2, 0x3b4a5c, 0.6);
     ring.beginPath();
     ring.arc(0, 0, 12, 0, Math.PI * 2);
     ring.strokePath();
-    // Countdown arc — shrinks clockwise from the top.
     const start = -Math.PI / 2;
     const end = start + Math.PI * 2 * Math.max(0, Math.min(1, ratio));
     ring.lineStyle(2, 0xffb84a, 0.95);

--- a/src/ui/HUD.ts
+++ b/src/ui/HUD.ts
@@ -33,6 +33,24 @@ export class HUD {
   private progressTween?: Phaser.Tweens.Tween;
   private onMuteChanged = (muted: boolean): void => this.renderMuteIcon(muted);
 
+  /** Caffeine buff indicator — mug + shrinking countdown arc. */
+  private caffeineIcon!: Phaser.GameObjects.Graphics;
+  private caffeineRing!: Phaser.GameObjects.Graphics;
+  /** Scene time (ms) when the active buff ends. 0 when inactive. */
+  private caffeineEndAt = 0;
+  private caffeineDuration = 0;
+  private onCaffeineStart = (durationMs: number): void => {
+    this.caffeineDuration = durationMs;
+    this.caffeineEndAt = this.scene.time.now + durationMs;
+    this.renderCaffeineIcon(1);
+  };
+  private onCaffeineEnd = (): void => {
+    this.caffeineEndAt = 0;
+    this.caffeineDuration = 0;
+    this.caffeineIcon.setVisible(false);
+    this.caffeineRing.setVisible(false);
+  };
+
   constructor(scene: Phaser.Scene, progression: ProgressionSystem) {
     this.scene = scene;
     this.progression = progression;
@@ -86,7 +104,20 @@ export class HUD {
     this.muteHit.on('pointerdown', () => this.punchMuteIcon());
     this.container.add(this.muteHit);
     this.renderMuteIcon(this.getAudio()?.isMuted() ?? false);
-    createSceneLifecycle(this.scene).bindEventBus('audio:mute-changed', this.onMuteChanged);
+
+    // Caffeine buff indicator — mug + shrinking arc, sits between the
+    // floor label and the mute icon. Hidden until the first buff start.
+    const CAF_X = GAME_WIDTH - 76;
+    const CAF_Y = 22;
+    this.caffeineRing = this.scene.add.graphics().setPosition(CAF_X, CAF_Y).setVisible(false);
+    this.container.add(this.caffeineRing);
+    this.caffeineIcon = this.scene.add.graphics().setPosition(CAF_X, CAF_Y).setVisible(false);
+    this.container.add(this.caffeineIcon);
+
+    const lifecycle = createSceneLifecycle(this.scene);
+    lifecycle.bindEventBus('audio:mute-changed', this.onMuteChanged);
+    lifecycle.bindEventBus('buff:caffeine_start', this.onCaffeineStart);
+    lifecycle.bindEventBus('buff:caffeine_end', this.onCaffeineEnd);
 
     // Floor indicator — to the left of the mute icon
     this.floorText = this.scene.add.text(GAME_WIDTH - 48, 10, '', {
@@ -258,6 +289,46 @@ export class HUD {
     });
   }
 
+  /**
+   * Draw the mug icon + a shrinking arc. `ratio` is 1..0 over the buff
+   * window. Called on `buff:caffeine_start` and every HUD update tick
+   * while the buff is active.
+   */
+  private renderCaffeineIcon(ratio: number): void {
+    this.caffeineIcon.setVisible(true);
+    this.caffeineRing.setVisible(true);
+
+    const icon = this.caffeineIcon;
+    icon.clear();
+    // Mug body.
+    icon.fillStyle(0x6b3b23, 1);
+    icon.fillRoundedRect(-6, -5, 11, 12, 2);
+    icon.fillStyle(0x3a1e10, 1);
+    icon.fillRect(-6, -5, 11, 2);
+    icon.fillStyle(0xc9a27a, 1);
+    icon.fillRect(-5, -5, 9, 1);
+    // Handle stroke (right).
+    icon.lineStyle(1.5, 0x4a2b1a, 1);
+    icon.beginPath();
+    icon.arc(6, 1, 4, -Math.PI / 2, Math.PI / 2, false);
+    icon.strokePath();
+
+    const ring = this.caffeineRing;
+    ring.clear();
+    // Background track — full circle, dim.
+    ring.lineStyle(2, 0x3b4a5c, 0.6);
+    ring.beginPath();
+    ring.arc(0, 0, 12, 0, Math.PI * 2);
+    ring.strokePath();
+    // Countdown arc — shrinks clockwise from the top.
+    const start = -Math.PI / 2;
+    const end = start + Math.PI * 2 * Math.max(0, Math.min(1, ratio));
+    ring.lineStyle(2, 0xffb84a, 0.95);
+    ring.beginPath();
+    ring.arc(0, 0, 12, start, end);
+    ring.strokePath();
+  }
+
   private getAudio(): AudioManager | undefined {
     return this.scene.registry.get('audio') as AudioManager | undefined;
   }
@@ -324,6 +395,15 @@ export class HUD {
       this.lastProgressSig = sig;
       const target = next ? Phaser.Math.Clamp(au / next.auRequired, 0, 1) : 0;
       this.tweenProgressTo(target);
+    }
+
+    if (this.caffeineEndAt > 0 && this.caffeineDuration > 0) {
+      const remaining = this.caffeineEndAt - this.scene.time.now;
+      if (remaining <= 0) {
+        this.onCaffeineEnd();
+      } else {
+        this.renderCaffeineIcon(remaining / this.caffeineDuration);
+      }
     }
   }
 }


### PR DESCRIPTION
Adds a consumable coffee mug collectible that grants +40% ground speed
and +15% jump velocity for 6 seconds. Re-pickup refreshes the timer.
Placed on Platform, Architecture, Product Leadership, Customer Success,
and Executive floors (lobby intentionally skipped).

Air speed stays unbuffed to preserve the documented shaft-width
invariant in Player.ts — the player must not be able to jump across
the elevator shaft.

- New Coffee entity + procedural mug/steam sprites + sip SFX
- LevelCoffeeManager mirrors LevelTokenManager without persistence
- CaffeineBuff pure timer unit; Player composes it and emits
  buff:caffeine_start / buff:caffeine_end via EventBus
- HUD renders a mug icon with a shrinking countdown arc while active

https://claude.ai/code/session_01Q1CZNeybLHZsjb32W1uomd