### PR TITLE
feat(architecture): mezzanines, moving platforms, themed enemies

### DIFF
--- a/src/config/levelData.ts
+++ b/src/config/levelData.ts
@@ -48,7 +48,7 @@ export const LEVEL_DATA: Record<FloorId, FloorData> = {
     sceneKey: 'PlatformTeamScene',
     auRequired: 0,
     auLabel: 'Infrastructure AU',
-    totalAU: 8,
+    totalAU: 15,
     rooms: { left: 'Platform Team', right: 'Architecture Team' },
     theme: {
       platformColor: 0x2d6a4f,

--- a/src/entities/Enemy.ts
+++ b/src/entities/Enemy.ts
@@ -27,6 +27,13 @@ export abstract class Enemy extends Phaser.Physics.Arcade.Sprite {
   /** True once onStomp() or similar kills the enemy. Overlap callback must check this. */
   public defeated = false;
 
+  /**
+   * When false, this enemy is skipped from the level's platform/moving-
+   * platform colliders — it phases through walls and catwalks. Player
+   * overlap (damage) is unaffected.
+   */
+  public collidesWithLevel = true;
+
   constructor(scene: Phaser.Scene, x: number, y: number, texture: string) {
     super(scene, x, y, texture);
     scene.add.existing(this);

--- a/src/entities/MovingPlatform.test.ts
+++ b/src/entities/MovingPlatform.test.ts
@@ -1,0 +1,199 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+import { createFakeScene, createFakeBody } from '../../tests/helpers/phaserMock';
+import type * as Phaser from 'phaser';
+
+// Minimal Phaser.Physics.Arcade.Image stand-in — MovingPlatform extends it at
+// runtime. The fake body extends phaserMock's body with the extra methods
+// Arcade.Body exposes and MovingPlatform calls: setSize / setVelocity.
+function makeFakeBody() {
+  const body = createFakeBody() as ReturnType<typeof createFakeBody> & {
+    setSize: (w: number, h: number, center?: boolean) => unknown;
+    setVelocity: (x: number, y: number) => unknown;
+    setVelocityX: (x: number) => unknown;
+    setVelocityY: (y: number) => unknown;
+    checkCollision: { up: boolean; down: boolean; left: boolean; right: boolean };
+  };
+  body.checkCollision = { up: true, down: true, left: true, right: true };
+  body.setSize = vi.fn(() => body);
+  body.setVelocity = vi.fn((x: number, y: number) => {
+    body.velocity.x = x;
+    body.velocity.y = y;
+    return body;
+  });
+  body.setVelocityX = vi.fn((x: number) => {
+    body.velocity.x = x;
+    return body;
+  });
+  body.setVelocityY = vi.fn((y: number) => {
+    body.velocity.y = y;
+    return body;
+  });
+  return body;
+}
+
+vi.mock('phaser', () => {
+  class Image {
+    scene: unknown;
+    x: number;
+    y: number;
+    body = makeFakeBody();
+    constructor(scene: unknown, x: number, y: number) {
+      this.scene = scene;
+      this.x = x;
+      this.y = y;
+    }
+    setDepth() { return this; }
+    setDisplaySize() { return this; }
+    destroy() { /* no-op */ }
+  }
+  const Phaser = {
+    Physics: { Arcade: { Image } },
+    Math: {
+      Clamp: (v: number, min: number, max: number) => Math.min(Math.max(v, min), max),
+    },
+  };
+  return { ...Phaser, default: Phaser };
+});
+
+import { MovingPlatform } from './MovingPlatform';
+
+function makePlatform(overrides: Partial<ConstructorParameters<typeof MovingPlatform>[1]> = {}) {
+  const scene = createFakeScene();
+  const cfg = {
+    x: 100,
+    y: 500,
+    width: 80,
+    axis: 'x' as const,
+    distance: 200,
+    mode: 'bounce' as const,
+    speed: 60,
+    ...overrides,
+  };
+  const platform = new MovingPlatform(scene as unknown as Phaser.Scene, cfg);
+  return { scene, platform };
+}
+
+describe('MovingPlatform', () => {
+  describe('bounce mode', () => {
+    let platform: MovingPlatform;
+
+    beforeEach(() => {
+      ({ platform } = makePlatform());
+    });
+
+    it('starts immovable, gravity-free, with forward velocity', () => {
+      const body = platform.body as ReturnType<typeof createFakeBody>;
+      expect(body.setImmovable).toHaveBeenCalledWith(true);
+      expect(body.setAllowGravity).toHaveBeenCalledWith(false);
+      expect(body.velocity.x).toBe(60);
+    });
+
+    it('is one-way: solid from above, pass-through from below/sides', () => {
+      const body = platform.body as unknown as {
+        checkCollision: { up: boolean; down: boolean; left: boolean; right: boolean };
+      };
+      expect(body.checkCollision.up).toBe(true);
+      expect(body.checkCollision.down).toBe(false);
+      expect(body.checkCollision.left).toBe(false);
+      expect(body.checkCollision.right).toBe(false);
+    });
+
+    it('flips velocity when it passes the max bound', () => {
+      const body = platform.body as ReturnType<typeof createFakeBody>;
+      platform.x = 400;
+      body.velocity.x = 60;
+      platform.update();
+      expect(body.velocity.x).toBe(-60);
+    });
+
+    it('flips velocity when it passes the min bound', () => {
+      const body = platform.body as ReturnType<typeof createFakeBody>;
+      platform.x = 100;
+      body.velocity.x = -60;
+      platform.update();
+      expect(body.velocity.x).toBe(60);
+    });
+
+    it('negative distance starts backwards', () => {
+      const { platform: p } = makePlatform({ distance: -120 });
+      const body = p.body as ReturnType<typeof createFakeBody>;
+      expect(body.velocity.x).toBe(-60);
+    });
+
+    it('axis=y bouncer drives vertical velocity', () => {
+      const { platform: p } = makePlatform({ axis: 'y', distance: -140, y: 600 });
+      const body = p.body as ReturnType<typeof createFakeBody>;
+      expect(body.velocity.y).toBe(-60);
+      // Simulate reaching the top bound.
+      p.y -= 140;
+      body.velocity.y = -60;
+      p.update();
+      expect(body.velocity.y).toBe(60);
+    });
+
+    it('pause() zeros velocity and resume() restores it', () => {
+      const body = platform.body as ReturnType<typeof createFakeBody>;
+      body.velocity.x = 60;
+      platform.pause();
+      expect(body.velocity.x).toBe(0);
+      platform.resume();
+      expect(body.velocity.x).toBe(60);
+    });
+
+    it('pause() and resume() are idempotent', () => {
+      const body = platform.body as ReturnType<typeof createFakeBody>;
+      body.velocity.x = 60;
+      platform.pause();
+      platform.pause();
+      expect(body.velocity.x).toBe(0);
+      platform.resume();
+      platform.resume();
+      expect(body.velocity.x).toBe(60);
+    });
+
+    it('update() is a no-op while paused', () => {
+      const body = platform.body as ReturnType<typeof createFakeBody>;
+      platform.x = 400; // would flip if not paused
+      body.velocity.x = 60;
+      platform.pause();
+      platform.update();
+      // Still zero (update didn't run flip logic because paused).
+      expect(body.velocity.x).toBe(0);
+    });
+
+    // Scenes mark MovingPlatform shutdown.
+    it('destroy() stops the (non-existent) tween without throwing', () => {
+      expect(() => platform.destroy()).not.toThrow();
+    });
+  });
+
+  describe('tween mode', () => {
+    it('registers a yoyo tween on the axis property', () => {
+      const { scene } = makePlatform({ mode: 'tween', duration: 1500, ease: 'Linear' });
+      const add = scene.tweens.add as unknown as ReturnType<typeof vi.fn>;
+      expect(add).toHaveBeenCalled();
+      const cfg = add.mock.calls[0][0] as Record<string, unknown>;
+      expect(cfg['duration']).toBe(1500);
+      expect(cfg['ease']).toBe('Linear');
+      expect(cfg['yoyo']).toBe(true);
+      expect(cfg['repeat']).toBe(-1);
+    });
+
+    it('update() does nothing for tween-mode platforms', () => {
+      const { platform } = makePlatform({ mode: 'tween' });
+      const body = platform.body as ReturnType<typeof createFakeBody>;
+      // Place past the max bound — bounce mode would flip, tween mode shouldn't.
+      platform.x = 9999;
+      body.velocity.x = 0;
+      expect(() => platform.update()).not.toThrow();
+      expect(body.velocity.x).toBe(0);
+    });
+
+    it('phase delays the tween start', () => {
+      const { scene } = makePlatform({ mode: 'tween', duration: 2000, phase: 0.5 });
+      const add = scene.tweens.add as unknown as ReturnType<typeof vi.fn>;
+      const cfg = add.mock.calls[0][0] as Record<string, unknown>;
+      expect(cfg['delay']).toBe(1000);
+    });
+  });
+});

--- a/src/entities/MovingPlatform.ts
+++ b/src/entities/MovingPlatform.ts
@@ -1,0 +1,170 @@
+import * as Phaser from 'phaser';
+
+export type MovingPlatformConfig = {
+  /** Top-left x of the walking surface at `t=0`. */
+  x: number;
+  /** Top-y of the walking surface at `t=0`. */
+  y: number;
+  width: number;
+  thickness?: number;
+  axis: 'x' | 'y';
+  /**
+   * Signed travel along the axis from the start position to the far
+   * endpoint. Negative values travel up/left, positive down/right.
+   */
+  distance: number;
+  mode: 'bounce' | 'tween';
+  /** bounce only (px/s), default 60. */
+  speed?: number;
+  /** tween only, one-way duration in ms, default 2000. */
+  duration?: number;
+  /** tween only, default `Sine.inOut`. */
+  ease?: string;
+  /** tween only, 0..1 delayed-start offset so paired movers can stagger. */
+  phase?: number;
+};
+
+const DEFAULT_SPEED = 60;
+const DEFAULT_DURATION = 2000;
+const DEFAULT_THICKNESS = 18;
+
+/**
+ * Floating platform the player can stand on.
+ *
+ * - `mode: 'bounce'` drives motion via Arcade velocity, flipping at the
+ *   configured bounds. Mirrors the in-room elevator pattern in LevelScene
+ *   so Arcade's built-in carry behaviour moves the player along with it.
+ * - `mode: 'tween'` uses a yoyo'ing Phaser tween on the body position.
+ *   Smoother ease but the rider is carried by body-delta propagation,
+ *   which can micro-separate on direction change.
+ *
+ * `x` / `y` match `catwalks` semantics: top-left of the walking surface
+ * at `t=0`. The platform then travels `distance` px along `axis` before
+ * reversing. Negative `distance` travels up/left.
+ */
+export class MovingPlatform extends Phaser.Physics.Arcade.Image {
+  readonly mode: 'bounce' | 'tween';
+  private axis: 'x' | 'y';
+  private speed: number;
+  private direction: 1 | -1;
+  private minPos: number;
+  private maxPos: number;
+  private motionTween?: Phaser.Tweens.Tween;
+  private paused = false;
+  private pausedVelocity?: { x: number; y: number };
+
+  constructor(scene: Phaser.Scene, cfg: MovingPlatformConfig) {
+    const thickness = cfg.thickness ?? DEFAULT_THICKNESS;
+    const cx = cfg.x + cfg.width / 2;
+    const cy = cfg.y + thickness / 2;
+    super(scene, cx, cy, 'moving_platform');
+    scene.add.existing(this);
+    scene.physics.add.existing(this);
+
+    this.mode = cfg.mode;
+    this.axis = cfg.axis;
+    this.speed = cfg.speed ?? DEFAULT_SPEED;
+    this.direction = cfg.distance >= 0 ? 1 : -1;
+
+    this.setDepth(3);
+    this.setDisplaySize(cfg.width, thickness);
+
+    const body = this.body as Phaser.Physics.Arcade.Body;
+    body.setImmovable(true);
+    body.setAllowGravity(false);
+    body.setSize(cfg.width, thickness, true);
+
+    const startPos = cfg.axis === 'x' ? cx : cy;
+    const endPos = startPos + cfg.distance;
+    this.minPos = Math.min(startPos, endPos);
+    this.maxPos = Math.max(startPos, endPos);
+
+    if (cfg.mode === 'bounce') {
+      this.startBounce();
+    } else {
+      this.startTween(cfg, endPos);
+    }
+  }
+
+  private startBounce(): void {
+    const body = this.body as Phaser.Physics.Arcade.Body;
+    if (this.axis === 'x') body.setVelocityX(this.speed * this.direction);
+    else body.setVelocityY(this.speed * this.direction);
+  }
+
+  private startTween(cfg: MovingPlatformConfig, endPos: number): void {
+    const duration = cfg.duration ?? DEFAULT_DURATION;
+    const ease = cfg.ease ?? 'Sine.inOut';
+    const phase = Phaser.Math.Clamp(cfg.phase ?? 0, 0, 1);
+    const prop = this.axis;
+
+    this.motionTween = this.scene.tweens.add({
+      targets: this,
+      [prop]: endPos,
+      duration,
+      yoyo: true,
+      repeat: -1,
+      ease,
+      delay: duration * phase,
+    });
+  }
+
+  /**
+   * Freeze motion (velocity snapshot + tween pause). Used so a moving
+   * platform doesn't drift out of bounds while a dialog holds the main
+   * update loop. Idempotent.
+   */
+  pause(): void {
+    if (this.paused) return;
+    this.paused = true;
+    const body = this.body as Phaser.Physics.Arcade.Body | null;
+    if (body) {
+      this.pausedVelocity = { x: body.velocity.x, y: body.velocity.y };
+      body.setVelocity(0, 0);
+    }
+    this.motionTween?.pause();
+  }
+
+  /** Restore motion captured by {@link pause}. Idempotent. */
+  resume(): void {
+    if (!this.paused) return;
+    this.paused = false;
+    const body = this.body as Phaser.Physics.Arcade.Body | null;
+    if (body && this.pausedVelocity) {
+      body.setVelocity(this.pausedVelocity.x, this.pausedVelocity.y);
+    }
+    this.pausedVelocity = undefined;
+    this.motionTween?.resume();
+  }
+
+  /** Called from LevelScene.update() for bounce-mode instances. */
+  update(): void {
+    if (this.mode !== 'bounce' || this.paused) return;
+    const body = this.body as Phaser.Physics.Arcade.Body | null;
+    if (!body) return;
+
+    if (this.axis === 'x') {
+      if (this.x <= this.minPos && body.velocity.x < 0) {
+        this.x = this.minPos;
+        body.setVelocityX(this.speed);
+      } else if (this.x >= this.maxPos && body.velocity.x > 0) {
+        this.x = this.maxPos;
+        body.setVelocityX(-this.speed);
+      }
+    } else {
+      if (this.y <= this.minPos && body.velocity.y < 0) {
+        this.y = this.minPos;
+        body.setVelocityY(this.speed);
+      } else if (this.y >= this.maxPos && body.velocity.y > 0) {
+        this.y = this.maxPos;
+        body.setVelocityY(-this.speed);
+      }
+    }
+  }
+
+  override destroy(fromScene?: boolean): void {
+    this.motionTween?.stop();
+    this.motionTween = undefined;
+    super.destroy(fromScene);
+  }
+}

--- a/src/entities/MovingPlatform.ts
+++ b/src/entities/MovingPlatform.ts
@@ -73,6 +73,13 @@ export class MovingPlatform extends Phaser.Physics.Arcade.Image {
     body.setImmovable(true);
     body.setAllowGravity(false);
     body.setSize(cfg.width, thickness, true);
+    // One-way collision — match the catwalk pattern in LevelScene.buildCatwalks:
+    // solid from above (the player lands on top), pass-through from below and
+    // the sides so a head-bonk or side-bump doesn't block jumps across a
+    // mezzanine gap.
+    body.checkCollision.down = false;
+    body.checkCollision.left = false;
+    body.checkCollision.right = false;
 
     const startPos = cfg.axis === 'x' ? cx : cy;
     const endPos = startPos + cfg.distance;

--- a/src/entities/enemies/ArchitectureAstronaut.test.ts
+++ b/src/entities/enemies/ArchitectureAstronaut.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createFakeScene, createFakeBody } from '../../../tests/helpers/phaserMock';
+import type * as Phaser from 'phaser';
+
+function makeFakeBody() {
+  const body = createFakeBody() as ReturnType<typeof createFakeBody> & {
+    setSize: (w: number, h: number) => unknown;
+    setOffset: (x: number, y: number) => unknown;
+    setCollideWorldBounds: (b: boolean) => unknown;
+  };
+  body.setSize = vi.fn(() => body);
+  body.setOffset = vi.fn(() => body);
+  body.setCollideWorldBounds = vi.fn(() => body);
+  return body;
+}
+
+vi.mock('phaser', () => {
+  class Sprite {
+    scene: unknown;
+    x: number;
+    y: number;
+    body = makeFakeBody();
+    constructor(scene: unknown, x: number, y: number) {
+      this.scene = scene;
+      this.x = x;
+      this.y = y;
+    }
+    setDepth() { return this; }
+    setAlpha() { return this; }
+    setFlipX() { return this; }
+    setTintFill() { return this; }
+    clearTint() { return this; }
+    setVelocityX(v: number) { this.body.velocity.x = v; return this; }
+    setVelocityY(v: number) { this.body.velocity.y = v; return this; }
+    destroy() { /* no-op */ }
+  }
+  const Phaser = { Physics: { Arcade: { Sprite } } };
+  return { ...Phaser, default: Phaser };
+});
+
+import { ArchitectureAstronaut } from './ArchitectureAstronaut';
+
+describe('ArchitectureAstronaut', () => {
+  it('is stompable, hovers (gravity off), and starts moving forward', () => {
+    const scene = createFakeScene();
+    const a = new ArchitectureAstronaut(scene as unknown as Phaser.Scene, 500, 600, {
+      minX: 300, maxX: 700, speed: 60,
+    });
+    expect(a.canBeStomped).toBe(true);
+    expect((a.body as ReturnType<typeof makeFakeBody>).setAllowGravity).toHaveBeenCalledWith(false);
+    expect((a.body as { velocity: { x: number } }).velocity.x).toBe(60);
+  });
+
+  it('flips at bounds', () => {
+    const scene = createFakeScene();
+    const a = new ArchitectureAstronaut(scene as unknown as Phaser.Scene, 500, 600, {
+      minX: 300, maxX: 700, speed: 60,
+    });
+    a.x = 700;
+    (a.body as { velocity: { x: number } }).velocity.x = 60;
+    a.update();
+    expect((a.body as { velocity: { x: number } }).velocity.x).toBe(-60);
+
+    a.x = 300;
+    (a.body as { velocity: { x: number } }).velocity.x = -60;
+    a.update();
+    expect((a.body as { velocity: { x: number } }).velocity.x).toBe(60);
+  });
+
+  it('defaults speed to 60', () => {
+    const scene = createFakeScene();
+    const a = new ArchitectureAstronaut(scene as unknown as Phaser.Scene, 500, 600, {
+      minX: 300, maxX: 700,
+    });
+    expect((a.body as { velocity: { x: number } }).velocity.x).toBe(60);
+  });
+
+  it('update() is a no-op once defeated', () => {
+    const scene = createFakeScene();
+    const a = new ArchitectureAstronaut(scene as unknown as Phaser.Scene, 500, 600);
+    a.defeated = true;
+    a.x = 700;
+    (a.body as { velocity: { x: number } }).velocity.x = 60;
+    a.update();
+    expect((a.body as { velocity: { x: number } }).velocity.x).toBe(60);
+  });
+});

--- a/src/entities/enemies/ArchitectureAstronaut.ts
+++ b/src/entities/enemies/ArchitectureAstronaut.ts
@@ -1,0 +1,57 @@
+import * as Phaser from 'phaser';
+import { Enemy } from '../Enemy';
+
+/**
+ * Architecture Astronaut — hovering enemy lost in abstract space.
+ *
+ * No gravity: patrols horizontally at a fixed altitude with a subtle Y
+ * bob. Stompable from above — which means the player has to reach its
+ * altitude via a moving platform or catwalk first.
+ */
+export class ArchitectureAstronaut extends Enemy {
+  private minX: number;
+  private maxX: number;
+  private speed: number;
+
+  constructor(
+    scene: Phaser.Scene,
+    x: number,
+    y: number,
+    opts: { minX: number; maxX: number; speed?: number } = { minX: x - 180, maxX: x + 180 },
+  ) {
+    super(scene, x, y, 'enemy_astronaut');
+    this.canBeStomped = true;
+    this.hitCost = 1;
+    this.minX = opts.minX;
+    this.maxX = opts.maxX;
+    this.speed = opts.speed ?? 60;
+
+    const body = this.body as Phaser.Physics.Arcade.Body;
+    body.setAllowGravity(false);
+    body.setSize(34, 40);
+    body.setOffset(3, 4);
+
+    scene.tweens.add({
+      targets: this,
+      y: y - 8,
+      duration: 600,
+      yoyo: true,
+      repeat: -1,
+      ease: 'Sine.easeInOut',
+    });
+
+    this.setVelocityX(this.speed);
+  }
+
+  override update(): void {
+    if (this.defeated) return;
+    const body = this.body as Phaser.Physics.Arcade.Body;
+    if (this.x <= this.minX && body.velocity.x < 0) {
+      this.setVelocityX(this.speed);
+      this.setFlipX(false);
+    } else if (this.x >= this.maxX && body.velocity.x > 0) {
+      this.setVelocityX(-this.speed);
+      this.setFlipX(true);
+    }
+  }
+}

--- a/src/entities/enemies/ScopeCreep.test.ts
+++ b/src/entities/enemies/ScopeCreep.test.ts
@@ -1,0 +1,97 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createFakeScene, createFakeBody } from '../../../tests/helpers/phaserMock';
+import type * as Phaser from 'phaser';
+
+function makeFakeBody() {
+  const body = createFakeBody() as ReturnType<typeof createFakeBody> & {
+    setSize: (w: number, h: number) => unknown;
+    setOffset: (x: number, y: number) => unknown;
+    setCollideWorldBounds: (b: boolean) => unknown;
+  };
+  body.setSize = vi.fn(() => body);
+  body.setOffset = vi.fn(() => body);
+  body.setCollideWorldBounds = vi.fn(() => body);
+  return body;
+}
+
+vi.mock('phaser', () => {
+  class Sprite {
+    scene: unknown;
+    x: number;
+    y: number;
+    body = makeFakeBody();
+    constructor(scene: unknown, x: number, y: number) {
+      this.scene = scene;
+      this.x = x;
+      this.y = y;
+    }
+    setDepth() { return this; }
+    setAlpha() { return this; }
+    setFlipX() { return this; }
+    setTintFill() { return this; }
+    clearTint() { return this; }
+    setVelocityX(v: number) { this.body.velocity.x = v; return this; }
+    setVelocityY(v: number) { this.body.velocity.y = v; return this; }
+    destroy() { /* no-op */ }
+  }
+  const Phaser = { Physics: { Arcade: { Sprite } } };
+  return { ...Phaser, default: Phaser };
+});
+
+import { ScopeCreep } from './ScopeCreep';
+
+describe('ScopeCreep', () => {
+  it('spawns stompable, with forward velocity and a creep-pulse tween', () => {
+    const scene = createFakeScene();
+    const creep = new ScopeCreep(scene as unknown as Phaser.Scene, 500, 800, {
+      minX: 400, maxX: 600, speed: 35,
+    });
+    expect(creep.canBeStomped).toBe(true);
+    expect(creep.hitCost).toBe(1);
+    expect((creep.body as { velocity: { x: number } }).velocity.x).toBe(35);
+    const add = scene.tweens.add as unknown as ReturnType<typeof vi.fn>;
+    expect(add).toHaveBeenCalled();
+  });
+
+  it('flips velocity at the max bound', () => {
+    const scene = createFakeScene();
+    const creep = new ScopeCreep(scene as unknown as Phaser.Scene, 500, 800, {
+      minX: 400, maxX: 600, speed: 40,
+    });
+    creep.x = 600;
+    (creep.body as { velocity: { x: number } }).velocity.x = 40;
+    creep.update();
+    expect((creep.body as { velocity: { x: number } }).velocity.x).toBe(-40);
+  });
+
+  it('flips velocity at the min bound', () => {
+    const scene = createFakeScene();
+    const creep = new ScopeCreep(scene as unknown as Phaser.Scene, 500, 800, {
+      minX: 400, maxX: 600,
+    });
+    creep.x = 400;
+    (creep.body as { velocity: { x: number } }).velocity.x = -35;
+    creep.update();
+    expect((creep.body as { velocity: { x: number } }).velocity.x).toBe(35);
+  });
+
+  it('defaults speed when none supplied', () => {
+    const scene = createFakeScene();
+    const creep = new ScopeCreep(scene as unknown as Phaser.Scene, 500, 800, {
+      minX: 400, maxX: 600,
+    });
+    expect((creep.body as { velocity: { x: number } }).velocity.x).toBe(35);
+  });
+
+  it('update() is a no-op once defeated', () => {
+    const scene = createFakeScene();
+    const creep = new ScopeCreep(scene as unknown as Phaser.Scene, 500, 800, {
+      minX: 400, maxX: 600, speed: 35,
+    });
+    creep.defeated = true;
+    creep.x = 600;
+    (creep.body as { velocity: { x: number } }).velocity.x = 35;
+    creep.update();
+    expect((creep.body as { velocity: { x: number } }).velocity.x).toBe(35);
+  });
+});

--- a/src/entities/enemies/ScopeCreep.ts
+++ b/src/entities/enemies/ScopeCreep.ts
@@ -1,0 +1,57 @@
+import * as Phaser from 'phaser';
+import { Enemy } from '../Enemy';
+
+/**
+ * Scope Creep — oversized, lumbering ground patrol. Stompable but a
+ * bigger hitbox than a slime and slower to evade. Thematically: that
+ * feature that was supposed to ship last quarter and now eats the roadmap.
+ */
+export class ScopeCreep extends Enemy {
+  private minX: number;
+  private maxX: number;
+  private speed: number;
+
+  constructor(
+    scene: Phaser.Scene,
+    x: number,
+    y: number,
+    opts: { minX: number; maxX: number; speed?: number } = { minX: x - 160, maxX: x + 160 },
+  ) {
+    super(scene, x, y, 'enemy_scope_creep');
+    this.canBeStomped = true;
+    this.hitCost = 1;
+    this.minX = opts.minX;
+    this.maxX = opts.maxX;
+    this.speed = opts.speed ?? 35;
+
+    const body = this.body as Phaser.Physics.Arcade.Body;
+    body.setSize(58, 34);
+    body.setOffset(5, 10);
+
+    // Creep pulse — slow, heavier than a slime's bob, so it reads as
+    // *growing* rather than bouncing.
+    scene.tweens.add({
+      targets: this,
+      scaleX: 1.08,
+      scaleY: 0.92,
+      duration: 780,
+      yoyo: true,
+      repeat: -1,
+      ease: 'Sine.easeInOut',
+    });
+
+    this.setVelocityX(this.speed);
+  }
+
+  override update(): void {
+    if (this.defeated) return;
+    const body = this.body as Phaser.Physics.Arcade.Body;
+    if (this.x <= this.minX && body.velocity.x < 0) {
+      this.setVelocityX(this.speed);
+      this.setFlipX(false);
+    } else if (this.x >= this.maxX && body.velocity.x > 0) {
+      this.setVelocityX(-this.speed);
+      this.setFlipX(true);
+    }
+  }
+}

--- a/src/entities/enemies/TechDebtGhost.test.ts
+++ b/src/entities/enemies/TechDebtGhost.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi } from 'vitest';
+import { createFakeScene, createFakeBody } from '../../../tests/helpers/phaserMock';
+import type * as Phaser from 'phaser';
+
+function makeFakeBody() {
+  const body = createFakeBody() as ReturnType<typeof createFakeBody> & {
+    setSize: (w: number, h: number) => unknown;
+    setOffset: (x: number, y: number) => unknown;
+    setCollideWorldBounds: (b: boolean) => unknown;
+  };
+  body.setSize = vi.fn(() => body);
+  body.setOffset = vi.fn(() => body);
+  body.setCollideWorldBounds = vi.fn(() => body);
+  return body;
+}
+
+vi.mock('phaser', () => {
+  class Sprite {
+    scene: unknown;
+    x: number;
+    y: number;
+    body = makeFakeBody();
+    constructor(scene: unknown, x: number, y: number) {
+      this.scene = scene;
+      this.x = x;
+      this.y = y;
+    }
+    setDepth() { return this; }
+    setAlpha() { return this; }
+    setFlipX() { return this; }
+    setTintFill() { return this; }
+    clearTint() { return this; }
+    setVelocityX(v: number) { this.body.velocity.x = v; return this; }
+    setVelocityY(v: number) { this.body.velocity.y = v; return this; }
+    destroy() { /* no-op */ }
+  }
+  const Phaser = { Physics: { Arcade: { Sprite } } };
+  return { ...Phaser, default: Phaser };
+});
+
+import { TechDebtGhost } from './TechDebtGhost';
+
+describe('TechDebtGhost', () => {
+  it('is not stompable, has no gravity, and phases through the level', () => {
+    const scene = createFakeScene();
+    const g = new TechDebtGhost(scene as unknown as Phaser.Scene, 700, 420, {
+      minX: 400, maxX: 1000, speed: 40,
+    });
+    expect(g.canBeStomped).toBe(false);
+    expect(g.collidesWithLevel).toBe(false);
+    expect((g.body as ReturnType<typeof makeFakeBody>).setAllowGravity).toHaveBeenCalledWith(false);
+  });
+
+  it('flips horizontal velocity at the bounds', () => {
+    const scene = createFakeScene();
+    const g = new TechDebtGhost(scene as unknown as Phaser.Scene, 700, 420, {
+      minX: 400, maxX: 1000, speed: 40,
+    });
+    g.x = 1000;
+    (g.body as { velocity: { x: number } }).velocity.x = 40;
+    g.update(0, 16);
+    expect((g.body as { velocity: { x: number } }).velocity.x).toBe(-40);
+
+    g.x = 400;
+    (g.body as { velocity: { x: number } }).velocity.x = -40;
+    g.update(0, 16);
+    expect((g.body as { velocity: { x: number } }).velocity.x).toBe(40);
+  });
+
+  it('oscillates y around the base line based on wobble phase', () => {
+    const scene = createFakeScene();
+    const baseY = 420;
+    const g = new TechDebtGhost(scene as unknown as Phaser.Scene, 700, baseY, {
+      minX: 400, maxX: 1000,
+    });
+    // Before any updates, y == baseY.
+    expect(g.y).toBe(baseY);
+    // Advance wobble phase: after enough delta, y should drift off baseY.
+    g.update(0, 1000);
+    expect(g.y).not.toBe(baseY);
+    // Range should stay within ±14 of baseY.
+    expect(Math.abs(g.y - baseY)).toBeLessThanOrEqual(14 + 0.0001);
+  });
+
+  it('update() is a no-op once defeated', () => {
+    const scene = createFakeScene();
+    const g = new TechDebtGhost(scene as unknown as Phaser.Scene, 700, 420);
+    const startY = g.y;
+    g.defeated = true;
+    g.update(0, 1000);
+    expect(g.y).toBe(startY);
+  });
+});

--- a/src/entities/enemies/TechDebtGhost.ts
+++ b/src/entities/enemies/TechDebtGhost.ts
@@ -1,0 +1,63 @@
+import * as Phaser from 'phaser';
+import { Enemy } from '../Enemy';
+
+/**
+ * Tech Debt Ghost — spectral drifter. Can't be stomped, phases through
+ * platforms and catwalks so hiding on a walkway won't save you. Damage-
+ * only; the player has to out-time it.
+ */
+export class TechDebtGhost extends Enemy {
+  private minX: number;
+  private maxX: number;
+  private speed: number;
+  private baseY: number;
+  private wobblePhase = 0;
+
+  constructor(
+    scene: Phaser.Scene,
+    x: number,
+    y: number,
+    opts: { minX: number; maxX: number; speed?: number } = { minX: x - 200, maxX: x + 200 },
+  ) {
+    super(scene, x, y, 'enemy_tech_debt_ghost');
+    this.canBeStomped = false;
+    this.hitCost = 1;
+    this.collidesWithLevel = false;
+    this.minX = opts.minX;
+    this.maxX = opts.maxX;
+    this.speed = opts.speed ?? 40;
+    this.baseY = y;
+
+    const body = this.body as Phaser.Physics.Arcade.Body;
+    body.setAllowGravity(false);
+    body.setSize(30, 34);
+    body.setOffset(4, 6);
+
+    this.setAlpha(0.85);
+    scene.tweens.add({
+      targets: this,
+      alpha: 0.55,
+      duration: 900,
+      yoyo: true,
+      repeat: -1,
+      ease: 'Sine.easeInOut',
+    });
+
+    this.setVelocityX(this.speed);
+  }
+
+  override update(_time: number, delta: number): void {
+    if (this.defeated) return;
+    const body = this.body as Phaser.Physics.Arcade.Body;
+    if (this.x <= this.minX && body.velocity.x < 0) {
+      this.setVelocityX(this.speed);
+      this.setFlipX(false);
+    } else if (this.x >= this.maxX && body.velocity.x > 0) {
+      this.setVelocityX(-this.speed);
+      this.setFlipX(true);
+    }
+
+    this.wobblePhase += delta * 0.004;
+    this.y = this.baseY + Math.sin(this.wobblePhase) * 14;
+  }
+}

--- a/src/features/floors/_shared/LevelEnemySpawner.ts
+++ b/src/features/floors/_shared/LevelEnemySpawner.ts
@@ -3,6 +3,9 @@ import { FLOORS, FloorId } from '../../../config/gameConfig';
 import { Enemy } from '../../../entities/Enemy';
 import { Slime } from '../../../entities/enemies/Slime';
 import { BureaucracyBot } from '../../../entities/enemies/BureaucracyBot';
+import { ScopeCreep } from '../../../entities/enemies/ScopeCreep';
+import { ArchitectureAstronaut } from '../../../entities/enemies/ArchitectureAstronaut';
+import { TechDebtGhost } from '../../../entities/enemies/TechDebtGhost';
 import { DroppedAU } from '../../../entities/DroppedAU';
 import { Player } from '../../../entities/Player';
 import { ProgressionSystem } from '../../../systems/ProgressionSystem';
@@ -35,9 +38,24 @@ export class LevelEnemySpawner {
       const minX = e.minX ?? e.x - 160;
       const maxX = e.maxX ?? e.x + 160;
       const opts = { minX, maxX, speed: e.speed };
-      const enemy: Enemy = e.type === 'slime'
-        ? new Slime(this.deps.scene, e.x, e.y, opts)
-        : new BureaucracyBot(this.deps.scene, e.x, e.y, opts);
+      let enemy: Enemy;
+      switch (e.type) {
+        case 'slime':
+          enemy = new Slime(this.deps.scene, e.x, e.y, opts);
+          break;
+        case 'bot':
+          enemy = new BureaucracyBot(this.deps.scene, e.x, e.y, opts);
+          break;
+        case 'scope-creep':
+          enemy = new ScopeCreep(this.deps.scene, e.x, e.y, opts);
+          break;
+        case 'astronaut':
+          enemy = new ArchitectureAstronaut(this.deps.scene, e.x, e.y, opts);
+          break;
+        case 'tech-debt-ghost':
+          enemy = new TechDebtGhost(this.deps.scene, e.x, e.y, opts);
+          break;
+      }
       this.enemies.push(enemy);
     }
   }
@@ -46,7 +64,8 @@ export class LevelEnemySpawner {
   wireColliders(): void {
     if (this.enemies.length === 0) return;
     const physics = this.deps.scene.physics;
-    physics.add.collider(this.enemies, this.deps.platformGroup);
+    const solid = this.enemies.filter((e) => e.collidesWithLevel);
+    if (solid.length > 0) physics.add.collider(solid, this.deps.platformGroup);
     physics.add.overlap(
       this.deps.player.sprite,
       this.enemies,

--- a/src/features/floors/_shared/LevelScene.ts
+++ b/src/features/floors/_shared/LevelScene.ts
@@ -11,6 +11,7 @@ import { ProgressionSystem } from '../../../systems/ProgressionSystem';
 import { GameStateManager } from '../../../systems/GameStateManager';
 import { allKeyLabels } from '../../../input';
 import type { NavigationContext } from '../../../scenes/NavigationContext';
+import { MovingPlatform, MovingPlatformConfig } from '../../../entities/MovingPlatform';
 import { LevelEnemySpawner } from './LevelEnemySpawner';
 import { LevelTokenManager } from './LevelTokenManager';
 import { LevelCoffeeManager } from './LevelCoffeeManager';
@@ -58,6 +59,14 @@ export interface LevelConfig {
    */
   catwalks?: Array<{ x: number; y: number; width: number; thickness?: number }>;
   /**
+   * Floating platforms that move along a single axis. Unlike catwalks
+   * (static) and room elevators (player-driven), these travel under their
+   * own steam, ferrying the player between tiers. See {@link MovingPlatform}
+   * for the semantics of each mode — `bounce` = velocity bouncer,
+   * `tween` = smoothed ease-in-out path.
+   */
+  movingPlatforms?: MovingPlatformConfig[];
+  /**
    * Tokens in the room. `index` overrides the default array-position
    * index used to key into the ProgressionSystem's collected-tokens
    * state. Useful when two scenes share the same floorId and need
@@ -91,7 +100,7 @@ export interface LevelConfig {
    * `minX` / `maxX` default to ±radius around `x`.
    */
   enemies?: Array<{
-    type: 'slime' | 'bot';
+    type: 'slime' | 'bot' | 'scope-creep' | 'astronaut' | 'tech-debt-ghost';
     x: number;
     y: number;
     minX?: number;
@@ -146,6 +155,9 @@ export class LevelScene extends Phaser.Scene {
   /** Which room-lift is the player currently riding? (-1 = none) */
   private activeRoomLift = -1;
 
+  /** Auto-moving floating platforms (bounce or tween). */
+  private movingPlatforms: MovingPlatform[] = [];
+
   /**
    * On-screen lift buttons for in-room elevators.
    * These are a gameplay mechanic (not content-zone gated) so visibility
@@ -196,6 +208,7 @@ export class LevelScene extends Phaser.Scene {
     this.isTransitioning = false;
     this.roomLifts = [];
     this.activeRoomLift = -1;
+    this.movingPlatforms = [];
   }
 
   create(): void {
@@ -204,6 +217,7 @@ export class LevelScene extends Phaser.Scene {
 
     this.createBackground();
     this.createPlatforms();
+    this.createMovingPlatforms();
     this.createRoomElevators();
     this.createDecorations();
     this.createExit();
@@ -250,6 +264,13 @@ export class LevelScene extends Phaser.Scene {
     this.tokenMgr.wireColliders();
     this.enemySpawner.wireColliders();
     this.coffeeMgr.wireColliders();
+
+    const solidEnemies = this.enemySpawner.enemies.filter((e) => e.collidesWithLevel);
+    for (const mp of this.movingPlatforms) {
+      this.physics.add.collider(this.player.sprite, mp);
+      if (solidEnemies.length > 0) this.physics.add.collider(solidEnemies, mp);
+      this.physics.add.collider(this.tokenMgr.droppedAUGroup, mp);
+    }
 
     for (let i = 0; i < this.roomLifts.length; i++) {
       const idx = i;
@@ -488,6 +509,15 @@ export class LevelScene extends Phaser.Scene {
     }
   }
 
+  /* ---- moving platforms ---- */
+  protected createMovingPlatforms(): void {
+    const config = this.getLevelConfig();
+    if (!config.movingPlatforms?.length) return;
+    for (const cfg of config.movingPlatforms) {
+      this.movingPlatforms.push(new MovingPlatform(this, cfg));
+    }
+  }
+
   /* ---- in-room elevators ---- */
   protected createRoomElevators(): void {
     const config = this.getLevelConfig();
@@ -641,15 +671,18 @@ export class LevelScene extends Phaser.Scene {
     // Other gameplay systems (enemies, room-lifts, zones, exit-proximity)
     // intentionally pause — the player is just reading the dialog.
     if (this.dialogs.isOpen) {
+      for (const mp of this.movingPlatforms) mp.pause();
       this.player.update(delta);
       this.hud.update();
       this.updateAtmosphericFx();
       return;
     }
+    for (const mp of this.movingPlatforms) mp.resume();
 
     this.player.update(delta);
     this.hud.update();
     this.updateRoomElevators();
+    for (const mp of this.movingPlatforms) mp.update();
     this.enemySpawner.update(_time, delta);
     this.updateAtmosphericFx();
 

--- a/src/features/floors/architecture/ArchitectureTeamScene.ts
+++ b/src/features/floors/architecture/ArchitectureTeamScene.ts
@@ -21,6 +21,16 @@ export class ArchitectureTeamScene extends LevelScene {
   /** First token index used in this room — must not overlap PlatformTeamScene. */
   private static readonly TOKEN_INDEX_OFFSET = 7;
 
+  /**
+   * Catwalk tiers match PlatformTeamScene so the jump physics carry
+   * across rooms on the same floor. Single jump from ground (G=832,
+   * gravity=900, jump=-520) clears ~150 px, and each tier sits 140 px
+   * above the one below.
+   */
+  private static readonly MID_Y = 692;
+  private static readonly UP_Y = 552;
+  private static readonly CAT_T = 20;
+
   constructor() {
     super('ArchitectureTeamScene', FLOORS.PLATFORM_TEAM);
     this.returnSide = 'right';
@@ -302,6 +312,9 @@ export class ArchitectureTeamScene extends LevelScene {
   protected getLevelConfig(): LevelConfig {
     const G = GAME_HEIGHT - TILE_SIZE;
     const K = ArchitectureTeamScene.TOKEN_INDEX_OFFSET;
+    const MID = ArchitectureTeamScene.MID_Y;
+    const UP = ArchitectureTeamScene.UP_Y;
+    const T = ArchitectureTeamScene.CAT_T;
 
     return {
       floorId: FLOORS.PLATFORM_TEAM,
@@ -312,18 +325,74 @@ export class ArchitectureTeamScene extends LevelScene {
         { x: 0, y: G, width: 10 },
       ],
 
+      // Mezzanines placed in the horizontal gaps between the four ground
+      // info zones so the 220-px-tall rect zones stay unobstructed.
+      // Gaps: 310..380, 600..710, 890..1000, 1160..1280.
+      catwalks: [
+        // Mid tier (reachable from ground in one jump).
+        { x: 310,  y: MID, width: 70,  thickness: T },
+        { x: 600,  y: MID, width: 110, thickness: T },
+        { x: 890,  y: MID, width: 110, thickness: T },
+        { x: 1160, y: MID, width: 120, thickness: T },
+        // Upper tier (reachable from mid in one jump). Only two — the
+        // horizontal tween bridges the long gap between them.
+        { x: 600,  y: UP,  width: 110, thickness: T },
+        { x: 1020, y: UP,  width: 100, thickness: T },
+      ],
+
+      movingPlatforms: [
+        // 1. Horizontal bouncer on mid-tier, ferrying between Cat-mid-L
+        // (x=310..380) and Cat-mid-C1 (x=600..710) *over* the c4 info zone.
+        {
+          x: 380, y: MID, width: 80, thickness: T,
+          axis: 'x', distance: 240, mode: 'bounce', speed: 70,
+        },
+        // 2. Vertical bouncer, mid → upper on the right side. Travels
+        // between y=MID (aligns with Cat-mid gap) and y=UP (Cat-up-R).
+        {
+          x: 1040, y: MID, width: 80, thickness: T,
+          axis: 'y', distance: UP - MID, mode: 'bounce', speed: 55,
+        },
+        // 3. Tween-driven bridge on upper tier: smooth Sine ease between
+        // Cat-up-C (600..710) and Cat-up-R (1020..1120). The only tween
+        // platform on the floor — deliberately the easiest to time.
+        {
+          x: 710, y: UP, width: 100, thickness: T,
+          axis: 'x', distance: 210, mode: 'tween', duration: 2400, ease: 'Sine.inOut',
+        },
+      ],
+
       roomElevators: [],
 
-      // Tokens arranged between anchors, reachable without overlapping info rects.
+      // Ground tokens 7..10 unchanged; new tokens 11..14 reward the
+      // mezzanine/mover chain.
       tokens: [
-        { x: 360,  y: G - 40, index: K + 0 },
-        { x: 670,  y: G - 40, index: K + 1 },
-        { x: 960,  y: G - 40, index: K + 2 },
-        { x: 1200, y: G - 40, index: K + 3 },
+        { x: 360,  y: G - 40,  index: K + 0 },
+        { x: 670,  y: G - 40,  index: K + 1 },
+        { x: 960,  y: G - 40,  index: K + 2 },
+        { x: 1200, y: G - 40,  index: K + 3 },
+        // Mid-tier: one on Cat-mid-L, one mid-air along the bouncer path
+        // (player collects while riding).
+        { x: 345,  y: MID - 40, index: K + 4 },
+        { x: 500,  y: MID - 40, index: K + 5 },
+        // Upper-tier: one on Cat-up-C, one on Cat-up-R (across the tween).
+        { x: 655,  y: UP  - 40, index: K + 6 },
+        { x: 1070, y: UP  - 40, index: K + 7 },
       ],
 
       coffees: [
         { x: 600, y: G - 40 },
+      ],
+
+      enemies: [
+        // Scope Creep — ground-level patrol in the c4↔vertical-slice gap.
+        { type: 'scope-creep', x: 660, y: G - 20, minX: 620, maxX: 700, speed: 35 },
+        // Architecture Astronaut — hovering above mid-tier catwalks, at
+        // a y the player can reach with a jump from mid-tier for stomping.
+        { type: 'astronaut', x: 500, y: 620, minX: 250, maxX: 900, speed: 65 },
+        // Tech Debt Ghost — drifts across the upper half, phases through
+        // catwalks so retreating upstairs is no escape.
+        { type: 'tech-debt-ghost', x: 700, y: 420, minX: 300, maxX: 1100, speed: 40 },
       ],
 
       infoPoints: [

--- a/src/systems/SpriteGenerator.ts
+++ b/src/systems/SpriteGenerator.ts
@@ -4,6 +4,7 @@ import { generateTileSprites } from './sprites/tiles';
 import { generateAUTokenSprites } from './sprites/token';
 import { generateElevatorSprites } from './sprites/elevator';
 import { generateRoomElevatorSprite } from './sprites/roomElevator';
+import { generateMovingPlatformSprite } from './sprites/movingPlatform';
 import { generateDoorSprites } from './sprites/doors';
 import { generateParticleSprite } from './sprites/particles';
 import { generatePlantSprites } from './sprites/plants';
@@ -28,6 +29,7 @@ export function generateSprites(scene: Phaser.Scene): void {
   generateAUTokenSprites(scene);
   generateElevatorSprites(scene);
   generateRoomElevatorSprite(scene);
+  generateMovingPlatformSprite(scene);
   generateDoorSprites(scene);
   generateParticleSprite(scene);
   generatePlantSprites(scene);

--- a/src/systems/sprites/enemies.ts
+++ b/src/systems/sprites/enemies.ts
@@ -220,7 +220,7 @@ function generateArchitectureAstronautSprite(scene: Phaser.Scene): void {
   g.fillCircle(W / 2 - 4, 11, 1.8);
 
   // Antenna
-  g.lineStyle(1.5, 0x888, 1);
+  g.lineStyle(1.5, 0x888888, 1);
   g.beginPath();
   g.moveTo(W / 2 + 8, 6);
   g.lineTo(W / 2 + 12, 1);

--- a/src/systems/sprites/enemies.ts
+++ b/src/systems/sprites/enemies.ts
@@ -10,6 +10,9 @@ import { theme } from '../../style/theme';
 export function generateEnemySprites(scene: Phaser.Scene): void {
   generateSlimeSprite(scene);
   generateBureaucracyBotSprite(scene);
+  generateScopeCreepSprite(scene);
+  generateArchitectureAstronautSprite(scene);
+  generateTechDebtGhostSprite(scene);
 }
 
 /** Green blob slime — 48×32. Simple Goomba analog. */
@@ -113,5 +116,175 @@ function generateBureaucracyBotSprite(scene: Phaser.Scene): void {
   g.fillRect(W - 6, 35, 4, 1);
 
   g.generateTexture('enemy_bot', W, H);
+  g.destroy();
+}
+
+/** Amber scope-creep blob — 68×44. Larger, uglier cousin of the slime. */
+function generateScopeCreepSprite(scene: Phaser.Scene): void {
+  const W = 68;
+  const H = 44;
+  const g = scene.make.graphics({ x: 0, y: 0 }, false);
+
+  g.fillStyle(0x4a2a08, 1);
+  g.fillEllipse(W / 2, H - 5, W - 6, 12);
+
+  g.fillStyle(0xc96a1a, 1);
+  g.fillEllipse(W / 2, H / 2 + 4, W - 8, H - 10);
+
+  g.fillStyle(0xe48a2c, 1);
+  g.fillEllipse(W / 2, H / 2, W - 18, H - 16);
+
+  g.fillStyle(0xf4b060, 1);
+  g.fillEllipse(W / 2 - 10, H / 2 - 4, 10, 6);
+
+  // Creeping blob lumps around the silhouette
+  g.fillStyle(0xd07a22, 1);
+  g.fillCircle(10, H - 10, 6);
+  g.fillCircle(W - 12, H - 10, 7);
+  g.fillCircle(W - 20, H - 14, 5);
+
+  // Eyes (angrier than a slime: oval + heavy brow)
+  g.fillStyle(0xffffff, 1);
+  g.fillEllipse(W / 2 - 10, H / 2 + 3, 7, 5);
+  g.fillEllipse(W / 2 + 10, H / 2 + 3, 7, 5);
+  g.fillStyle(0x1a0f05, 1);
+  g.fillCircle(W / 2 - 9, H / 2 + 4, 2);
+  g.fillCircle(W / 2 + 11, H / 2 + 4, 2);
+  g.lineStyle(2, 0x4a2a08, 1);
+  g.beginPath();
+  g.moveTo(W / 2 - 15, H / 2 - 3);
+  g.lineTo(W / 2 - 5, H / 2 + 1);
+  g.strokePath();
+  g.beginPath();
+  g.moveTo(W / 2 + 15, H / 2 - 3);
+  g.lineTo(W / 2 + 5, H / 2 + 1);
+  g.strokePath();
+
+  // Scowl
+  g.lineStyle(2, 0x2a1a05, 1);
+  g.beginPath();
+  g.moveTo(W / 2 - 6, H / 2 + 13);
+  g.lineTo(W / 2 + 6, H / 2 + 13);
+  g.strokePath();
+
+  g.generateTexture('enemy_scope_creep', W, H);
+  g.destroy();
+}
+
+/** Helmeted hovering astronaut — 40×48. */
+function generateArchitectureAstronautSprite(scene: Phaser.Scene): void {
+  const W = 40;
+  const H = 48;
+  const g = scene.make.graphics({ x: 0, y: 0 }, false);
+
+  // Body / suit
+  g.fillStyle(0xe8eef5, 1);
+  g.fillRoundedRect(8, 18, W - 16, H - 24, 4);
+  g.fillStyle(0xb8c2d0, 1);
+  g.fillRect(W - 12, 18, 4, H - 24);
+
+  // Belt
+  g.fillStyle(0x6a7080, 1);
+  g.fillRect(8, 30, W - 16, 3);
+
+  // Chest control panel
+  g.fillStyle(0x1a2238, 1);
+  g.fillRect(13, 22, 14, 6);
+  g.fillStyle(0xffb347, 1).fillRect(14, 23, 2, 2);
+  g.fillStyle(0x4fc3f7, 1).fillRect(18, 23, 2, 2);
+  g.fillStyle(0x81c784, 1).fillRect(22, 23, 2, 2);
+
+  // Arms
+  g.fillStyle(0xe8eef5, 1);
+  g.fillRect(4, 20, 5, 12);
+  g.fillRect(W - 9, 20, 5, 12);
+  g.fillStyle(0xffd77a, 1); // amber gloves
+  g.fillRect(4, 32, 5, 3);
+  g.fillRect(W - 9, 32, 5, 3);
+
+  // Boots dangle (no floor — he's floating)
+  g.fillStyle(0x3a3a4a, 1);
+  g.fillRect(12, H - 4, 6, 4);
+  g.fillRect(W - 18, H - 4, 6, 4);
+
+  // Helmet base
+  g.fillStyle(0xdfe6ee, 1);
+  g.fillCircle(W / 2, 14, 12);
+  // Visor
+  g.fillStyle(0x0a1a2a, 1);
+  g.fillEllipse(W / 2, 14, 16, 12);
+  g.fillStyle(0x5a8acc, 0.65);
+  g.fillEllipse(W / 2 - 2, 12, 10, 6);
+  // Visor glint
+  g.fillStyle(0xffffff, 0.9);
+  g.fillCircle(W / 2 - 4, 11, 1.8);
+
+  // Antenna
+  g.lineStyle(1.5, 0x888, 1);
+  g.beginPath();
+  g.moveTo(W / 2 + 8, 6);
+  g.lineTo(W / 2 + 12, 1);
+  g.strokePath();
+  g.fillStyle(0xff5555, 1);
+  g.fillCircle(W / 2 + 12, 1, 1.5);
+
+  // Backpack tube
+  g.fillStyle(0xb8c2d0, 1);
+  g.fillRect(2, 22, 4, 10);
+
+  g.generateTexture('enemy_astronaut', W, H);
+  g.destroy();
+}
+
+/** Translucent wraith trailing `// TODO` — 44×40. */
+function generateTechDebtGhostSprite(scene: Phaser.Scene): void {
+  const W = 44;
+  const H = 40;
+  const g = scene.make.graphics({ x: 0, y: 0 }, false);
+
+  // Wispy tail
+  g.fillStyle(0x6b78a8, 0.55);
+  for (let i = 0; i < 3; i++) {
+    const wx = 4 + i * 6;
+    g.fillTriangle(wx, H - 4, wx + 6, H - 4, wx + 3, H - 14 - i * 2);
+  }
+
+  // Body (cloud blob)
+  g.fillStyle(0x8f9cc8, 0.85);
+  g.fillEllipse(W / 2, H / 2, W - 6, H - 12);
+
+  // Highlight
+  g.fillStyle(0xcdd4ee, 0.7);
+  g.fillEllipse(W / 2 - 6, H / 2 - 4, 12, 6);
+
+  // Eyes — hollow sockets
+  g.fillStyle(0x0a0f1e, 1);
+  g.fillEllipse(W / 2 - 7, H / 2 - 1, 6, 8);
+  g.fillEllipse(W / 2 + 7, H / 2 - 1, 6, 8);
+  g.fillStyle(0xffe6ff, 0.9);
+  g.fillCircle(W / 2 - 7, H / 2 - 2, 1.5);
+  g.fillCircle(W / 2 + 7, H / 2 - 2, 1.5);
+
+  // Jagged mouth
+  g.lineStyle(1.5, 0x0a0f1e, 1);
+  g.beginPath();
+  g.moveTo(W / 2 - 6, H / 2 + 7);
+  g.lineTo(W / 2 - 3, H / 2 + 10);
+  g.lineTo(W / 2, H / 2 + 7);
+  g.lineTo(W / 2 + 3, H / 2 + 10);
+  g.lineTo(W / 2 + 6, H / 2 + 7);
+  g.strokePath();
+
+  // "// TODO" tag
+  g.fillStyle(0xffe6ff, 0.9);
+  g.fillRect(W / 2 - 10, 3, 20, 6);
+  g.fillStyle(0x4a3a8a, 1);
+  g.fillRect(W / 2 - 8, 5, 2, 2);
+  g.fillRect(W / 2 - 5, 5, 2, 2);
+  g.fillRect(W / 2 - 2, 5, 2, 2);
+  g.fillRect(W / 2 + 1, 5, 2, 2);
+  g.fillRect(W / 2 + 4, 5, 2, 2);
+
+  g.generateTexture('enemy_tech_debt_ghost', W, H);
   g.destroy();
 }

--- a/src/systems/sprites/movingPlatform.ts
+++ b/src/systems/sprites/movingPlatform.ts
@@ -1,0 +1,31 @@
+import * as Phaser from 'phaser';
+
+/**
+ * Floating mover platform — 96×18. Visually distinct from static catwalks
+ * (warmer amber trim, repeating hazard chevrons) so the player reads it
+ * as "this moves" at a glance. Width is fixed here; {@link MovingPlatform}
+ * scales horizontally to match the configured width.
+ */
+export function generateMovingPlatformSprite(scene: Phaser.Scene): void {
+  const W = 96;
+  const H = 18;
+  const g = scene.make.graphics({ x: 0, y: 0 }, false);
+
+  g.fillStyle(0x3a3024, 1).fillRect(0, 0, W, H);
+  g.fillStyle(0xc98a2e, 1).fillRect(0, 0, W, 3);
+  g.fillStyle(0x2a2218, 1).fillRect(0, H - 2, W, 2);
+
+  g.fillStyle(0x7a5a2a, 1);
+  for (let x = 4; x < W - 8; x += 10) {
+    g.fillTriangle(x, H - 5, x + 5, 5, x + 10, H - 5);
+  }
+
+  g.fillStyle(0xffd88a, 1);
+  for (let rx = 6; rx < W - 4; rx += 28) {
+    g.fillRect(rx, 5, 2, 2);
+    g.fillRect(rx, H - 7, 2, 2);
+  }
+
+  g.generateTexture('moving_platform', W, H);
+  g.destroy();
+}


### PR DESCRIPTION
## Summary

Turns the Architecture Team room from a flat educational walkthrough into a real platforming challenge while keeping the four info cards (team, C4, vertical slices, ADRs) readable at ground level.

- **New `MovingPlatform` entity** (`src/entities/MovingPlatform.ts`) supporting two motion modes:
  - `bounce` — Arcade velocity flipping at configured bounds; mirrors the room-elevator pattern so the player is carried natively.
  - `tween` — yoyo'ing Phaser tween with ease (default `Sine.inOut`) for smoother motion.
  - `pause()` / `resume()` wired from `LevelScene` so platforms don't drift while an info dialog is open.
- **Three architect-themed enemies**:
  - **Scope Creep** — oversized stompable slime; slow ground patrol.
  - **Architecture Astronaut** — no-gravity hovering enemy, stompable from above; pairs with the new movers.
  - **Tech Debt Ghost** — spectral damage-only drifter that phases through catwalks (new `Enemy.collidesWithLevel` flag lets the spawner skip it from the platform collider).
- **Architecture floor layout rework** — 4 mid-tier + 2 upper-tier catwalks placed in the gaps between the existing info rect zones, 3 movers (horizontal bouncer over C4, vertical lift on the right, tween bridge up top), and 4 extra tokens on the new routes.
- **`totalAU` 8 → 15** on the shared `PLATFORM_TEAM` floor to reflect the true collectable count across both rooms.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (no new warnings; 4 pre-existing)
- [x] `npm run test:unit` — 278 pass
- [ ] Manual smoke via `npm run dev`:
  - [ ] Enter Architecture via elevator → right. All 4 info dialogs still open at ground level.
  - [ ] Single jump from ground lands on Cat-mid-L; single jump from mid-tier reaches upper-tier.
  - [ ] Horizontal bouncer ferries the player across the C4 zone; tween bridge eases smoothly up top.
  - [ ] Stomp Scope Creep on ground; stomp Astronaut from upper-tier; Tech Debt Ghost ignores stomps and passes through catwalks.
  - [ ] All 8 architecture tokens collectable; HUD shows the bumped total.
  - [ ] Open a dialog while riding a mover → platform stops; close dialog → platform resumes.
- [ ] `npm run test:e2e` — skipped by default (Playwright is opt-in).

https://claude.ai/code/session_01L73ho8rjV3FBNVMWACVs15

---
_Generated by [Claude Code](https://claude.ai/code/session_01L73ho8rjV3FBNVMWACVs15)_