### PR TITLE
fix(test): de-flake elevator-ride and player-freeze-on-dialog specs

### DIFF
--- a/tests/elevator-ride.spec.ts
+++ b/tests/elevator-ride.spec.ts
@@ -72,10 +72,28 @@ test.describe('elevator ride controls', () => {
       return ctrl.elevator.platform.y;
     });
 
-    // Hold ArrowUp for long enough to ramp past the commit threshold.
+    // Hold ArrowUp until the cab has clearly lifted off the starting
+    // floor. Using a wall-clock waitForTimeout is flaky on CI where
+    // Phaser's update loop can be starved — we'd release the key
+    // before the cab accumulated enough velocity to cross the commit
+    // threshold, and it would coast back to the start stop.
     await page.keyboard.down('ArrowUp');
-    await page.waitForTimeout(800);
-    await page.keyboard.up('ArrowUp');
+    try {
+      await page.waitForFunction((startY: number) => {
+        const g = window.__game as unknown as {
+          scene: { getScenes: (a?: boolean) => { sys: { settings: { key: string } } }[] };
+        } | undefined;
+        if (!g) return false;
+        const scene = g.scene
+          .getScenes(true)
+          .find((s) => s.sys.settings.key === 'ElevatorScene') as unknown as Record<string, unknown>;
+        const ctrl = scene?.['elevatorCtrl'] as { elevator: { platform: { y: number } } } | undefined;
+        if (!ctrl) return false;
+        return ctrl.elevator.platform.y < startY - 50;
+      }, cabYBefore, { timeout: 15_000 });
+    } finally {
+      await page.keyboard.up('ArrowUp');
+    }
 
     const state = await page.evaluate(() => {
       const g = window.__game as unknown as {

--- a/tests/player-freeze-on-dialog.spec.ts
+++ b/tests/player-freeze-on-dialog.spec.ts
@@ -167,7 +167,13 @@ test.describe('Player freezes when a dialog opens mid-walk', () => {
     // to 0 immediately, but the `player_land` squash anim (played if the
     // player just finished the initial spawn drop) gates animation
     // updates for up to 120ms. We want to observe the steady state.
-    await page.waitForFunction(() => {
+    //
+    // Read the snapshot INSIDE the wait and return it when the freeze
+    // condition holds. This avoids a flake where the wait succeeds, then
+    // between ticks a 1-frame onGround/touching jitter or anim swap leaks
+    // into the follow-up `snapshotPlayer(page)` roundtrip and the final
+    // asserts see stale/other values.
+    const frozenHandle = await page.waitForFunction(() => {
       const g = window.__game!;
       const scene = g.scene
         .getScenes(true)
@@ -180,14 +186,18 @@ test.describe('Player freezes when a dialog opens mid-walk', () => {
         };
       };
       const b = player.sprite.body;
-      return (
+      const animKey = player.sprite.anims?.currentAnim?.key ?? null;
+      if (
         b.velocity.x === 0 &&
         (b.blocked.down || b.touching.down) &&
-        player.sprite.anims?.currentAnim?.key === 'player_idle'
-      );
+        animKey === 'player_idle'
+      ) {
+        return { vx: b.velocity.x, anim: animKey };
+      }
+      return null;
     }, undefined, { timeout: 15_000 });
+    const frozen = (await frozenHandle.jsonValue()) as { vx: number; anim: string };
 
-    const frozen = await snapshotPlayer(page);
     // ArrowRight is still held — the freeze must come from the input
     // context check, not from the player releasing the key.
     expect(frozen.vx).toBe(0);


### PR DESCRIPTION
CI on main is red on two Playwright specs. Both failures are snapshot/timing races, not product regressions.

### elevator-ride.spec.ts > `pressing Up on the cab rides it upward`
- Test held `ArrowUp` for a fixed `waitForTimeout(800)`. Under CI's starved frame loop the cab did not accumulate enough velocity to cross the commit threshold before the key released, then coasted back to the start stop and `cabY < start - 50` failed.
- Fix: replace the blind timeout with `waitForFunction` polling `ctrl.elevator.platform.y` so `ArrowUp` is held until the cab has actually lifted. Release in a `finally` so a regression still cleans up.

### player-freeze-on-dialog.spec.ts > `holding ArrowRight then opening an info dialog`
- Test did `waitForFunction(freeze-condition)` then a second `snapshotPlayer(page)` roundtrip. A 1-frame `blocked.down` / anim swap between the two calls leaked into the snapshot and `expect(frozen.anim).toBe('player_idle')` failed.
- Fix: read the snapshot inside the `waitForFunction` and return it when the condition holds, so the assertion sees the exact values that satisfied the wait.

### Verification
- `npm run typecheck` ✅
- `npm run lint` ✅ (pre-existing warnings only)
- `npm run test:unit` ✅ 306/306
- `npx playwright test tests/elevator-ride.spec.ts tests/player-freeze-on-dialog.spec.ts` ✅ 3/3 in 17.2s