### PR TITLE
chore(ci): skip heavy jobs on docs-only changes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,8 +10,28 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
+  changes:
+    name: Detect non-docs changes
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v4
+
+      # Detect whether this push/PR touches anything outside docs/**.
+      # If only docs/** changed, downstream jobs are skipped — skipped jobs
+      # satisfy required status checks, so doc-only PRs can still merge.
+      - uses: dorny/paths-filter@v3
+        id: filter
+        with:
+          filters: |
+            code:
+              - '!docs/**'
+
   lint-and-unit:
     name: Lint + typecheck + unit tests
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -40,6 +60,8 @@ jobs:
 
   e2e:
     name: Playwright E2E (shard ${{ matrix.shard }}/${{ matrix.total }})
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     strategy:
       # Keep the other shard running if one fails so the full failure picture


### PR DESCRIPTION
Adds a changes detection job using dorny/paths-filter@v3 that flags whether any file outside docs/** changed. The lint-and-unit and 2e jobs now gate on that flag via 
eeds: changes + if: needs.changes.outputs.code == 'true'.

Doc-only PRs/pushes → both jobs skip. Skipped jobs satisfy required status checks, so branch protection still passes without running lint/typecheck/unit/Playwright.

Scope: only .github/workflows/ci.yml. Deploy workflow untouched.