### PR TITLE
fix(deploy): explicit vi.fn signatures so tsc passes

### DIFF
--- a/src/scenes/elevator/ProductDoorManager.test.ts
+++ b/src/scenes/elevator/ProductDoorManager.test.ts
@@ -50,7 +50,7 @@ describe('ProductDoorManager proximity + open-on-approach', () => {
     setOrigin?: ReturnType<typeof vi.fn>;
     visible: boolean;
   };
-  let onEnter: ReturnType<typeof vi.fn>;
+  let onEnter: ReturnType<typeof vi.fn<(door: ProductDoor) => void>>;
   let playerX: number;
   let playerBottom: number;
   let onElevator: boolean;
@@ -59,7 +59,7 @@ describe('ProductDoorManager proximity + open-on-approach', () => {
 
   beforeEach(() => {
     stubs = [];
-    onEnter = vi.fn();
+    onEnter = vi.fn<(door: ProductDoor) => void>();
     playerX = 0;
     playerBottom = WALK_Y;
     onElevator = false;

--- a/src/ui/HUD.test.ts
+++ b/src/ui/HUD.test.ts
@@ -176,7 +176,7 @@ function makeScene(muted = false) {
 describe('HUD', () => {
   let progression: ProgressionSystem;
   let scene: ReturnType<typeof makeScene> | undefined;
-  let toggleSpy: ReturnType<typeof vi.fn> | undefined;
+  let toggleSpy: ReturnType<typeof vi.fn<() => void>> | undefined;
 
   beforeEach(() => {
     setPlayerSlot('hud-test');
@@ -222,7 +222,7 @@ describe('HUD', () => {
     scene = makeScene(false);
     new HUD(scene as unknown as Phaser.Scene, progression);
 
-    toggleSpy = vi.fn();
+    toggleSpy = vi.fn<() => void>();
     eventBus.on('audio:toggle-mute', toggleSpy);
 
     scene.zoneHandlers.get('pointerup')?.();


### PR DESCRIPTION
## Problem

Deploy to GitHub Pages workflow failing on `npm run build` (`tsc && vite build`):

```
src/scenes/elevator/ProductDoorManager.test.ts(106,7): error TS2322: Type 'Mock<Procedure | Constructable>' is not assignable to type '(door: ProductDoor) => void'.
src/ui/HUD.test.ts(192,54): error TS2345: Argument of type 'Mock<Procedure | Constructable>' is not assignable to parameter of type 'GameEventHandler<"audio:toggle-mute">'.
src/ui/HUD.test.ts(226,38): error TS2345: ...
```

## Cause

vitest 4.x's `vi.fn()` (no generic) returns `Mock<Procedure | Constructable>` which has no plain callable signature, so direct assignment to typed callback params (`onEnter: (door: ProductDoor) => void`, `GameEventHandler<...>`) now fails.

## Fix

Explicit type args on `vi.fn()` + matching `ReturnType<typeof vi.fn<...>>` declarations:

- `ProductDoorManager.test.ts`: `vi.fn<(door: ProductDoor) => void>()`
- `HUD.test.ts`: `vi.fn<() => void>()`

## Verification

- `npm run typecheck` → clean
- `npm run build` → clean
- `npm run lint` → only pre-existing warnings

Note: 6 unrelated `MotionPreference.test.ts` failures exist on main but don't affect deploy (Pages workflow only runs `tsc && vite build`).
