### PR TITLE
feat(elevator): per-floor themed near-layer backdrop

### DIFF
--- a/src/scenes/elevator/ElevatorSceneLayout.ts
+++ b/src/scenes/elevator/ElevatorSceneLayout.ts
@@ -8,6 +8,8 @@ import { ElevatorController } from './ElevatorController';
 import { drawSkyBackdrop } from './skyBackdrop';
 import { drawDistantSkyline } from './distantSkyline';
 import { drawBuildingFacade, type FacadeBand } from './buildingFacade';
+import { drawFloorBackdrops, type FloorBackdropBand, type BlockedRange } from './floorBackdrops';
+import { ProductDoorManager } from './ProductDoorManager';
 
 const FLOOR_TILE_ROWS = 2;
 const FLOOR_H = FLOOR_TILE_ROWS * TILE_SIZE; // 256
@@ -248,6 +250,52 @@ export class ElevatorSceneLayout {
     }
 
     drawBuildingFacade(this.deps.scene, { sides, bands });
+
+    this.createFloorBackdrops(sides, sorted, top, bottom);
+  }
+
+  /**
+   * Per-floor themed near-layer backdrop. Sits just in front of the far
+   * façade (depth 0.4) and behind the shaft pillars (depth 2.1), at
+   * scrollFactor 1 so each band stays locked to its real floor slab —
+   * this is the layer that carries per-floor identity (server racks,
+   * whiteboard, monitor, panelling, pipes, etc.). See `./floorBackdrops`.
+   */
+  private createFloorBackdrops(
+    sides: { xLeft: number; xRight: number }[],
+    sortedFloors: { id: FloorId; y: number }[],
+    shaftTop: number,
+    shaftBottom: number,
+  ): void {
+    const left = sides[0];
+    const right = sides[1];
+    if (!left || !right) return;
+
+    const bands: FloorBackdropBand[] = [];
+    for (let i = 0; i < sortedFloors.length; i++) {
+      const cur = sortedFloors[i];
+      if (!cur) continue;
+      const next = sortedFloors[i + 1];
+      const yTop = i === 0 ? shaftTop : cur.y;
+      const yBottom = next ? next.y : shaftBottom;
+      bands.push({ floorId: cur.id, yTop, yBottom });
+    }
+
+    // PRODUCTS-floor décor must steer clear of the product doors. Pull
+    // door positions from the static accessor so this stays in sync if
+    // doors are repositioned. We treat each door as a 120-px-wide
+    // blocked range to leave room for door sprites + above-door labels.
+    const DOOR_KEEPOUT_HALF_WIDTH = 60;
+    const blockedRanges: BlockedRange[] = ProductDoorManager.doors.map((d) => ({
+      xMin: d.x - DOOR_KEEPOUT_HALF_WIDTH,
+      xMax: d.x + DOOR_KEEPOUT_HALF_WIDTH,
+    }));
+
+    drawFloorBackdrops(this.deps.scene, {
+      sides: [left, right],
+      bands,
+      blockedRanges,
+    });
   }
 
   /**

--- a/src/scenes/elevator/floorBackdrops.test.ts
+++ b/src/scenes/elevator/floorBackdrops.test.ts
@@ -1,0 +1,136 @@
+/**
+ * Unit tests for `floorBackdrops` spec generators. We only test the pure
+ * helpers — the Phaser renderer is exercised in Playwright integration /
+ * visual specs.
+ */
+import { describe, it, expect } from 'vitest';
+import { FLOORS } from '../../config/gameConfig';
+import {
+  specForBand,
+  type FloorBackdropBand,
+  type SideRect,
+  type BlockedRange,
+} from './floorBackdrops';
+
+const band = (floorId: number, yTop = 0, yBottom = 200): FloorBackdropBand => ({
+  floorId: floorId as FloorBackdropBand['floorId'],
+  yTop,
+  yBottom,
+});
+
+const rect = (xLeft = 0, xRight = 240, yTop = 0, yBottom = 200): SideRect => ({
+  xLeft,
+  xRight,
+  yTop,
+  yBottom,
+});
+
+describe('floorBackdrops / specForBand', () => {
+  it('is deterministic for the same floor + side + rect', () => {
+    const a = specForBand(band(FLOORS.PLATFORM_TEAM), 'left', rect());
+    const b = specForBand(band(FLOORS.PLATFORM_TEAM), 'left', rect());
+    expect(a).toEqual(b);
+  });
+
+  it('returns different specs for left vs right of split-room floors', () => {
+    const left = specForBand(band(FLOORS.PLATFORM_TEAM), 'left', rect());
+    const right = specForBand(band(FLOORS.PLATFORM_TEAM), 'right', rect());
+    // Platform left = server racks (has blink LEDs); right = whiteboard (no blinks).
+    expect(left.blinkRects.length).toBeGreaterThan(0);
+    expect(right.blinkRects.length).toBe(0);
+    expect(left.staticRects).not.toEqual(right.staticRects);
+  });
+
+  it('returns different specs for left vs right of business floor', () => {
+    const left = specForBand(band(FLOORS.BUSINESS), 'left', rect());
+    const right = specForBand(band(FLOORS.BUSINESS), 'right', rect());
+    // Both sides have blinks (chart on left, ticket dot on right) but
+    // the static layouts must differ.
+    expect(left.staticRects).not.toEqual(right.staticRects);
+  });
+
+  it('returns empty spec for unknown floor ids', () => {
+    const spec = specForBand(band(999), 'left', rect());
+    expect(spec.staticRects).toEqual([]);
+    expect(spec.blinkRects).toEqual([]);
+  });
+
+  it('returns empty spec when the side rect is too small', () => {
+    const tiny: SideRect = { xLeft: 0, xRight: 30, yTop: 0, yBottom: 30 };
+    for (const floor of Object.values(FLOORS)) {
+      const spec = specForBand(band(floor), 'left', tiny);
+      expect(spec.staticRects).toEqual([]);
+      expect(spec.blinkRects).toEqual([]);
+    }
+  });
+
+  it('keeps every rect strictly inside the supplied side rect', () => {
+    const r = rect(40, 280, 50, 250);
+    for (const floor of Object.values(FLOORS)) {
+      for (const side of ['left', 'right'] as const) {
+        const spec = specForBand(band(floor, r.yTop, r.yBottom), side, r);
+        for (const rectSpec of [...spec.staticRects, ...spec.blinkRects]) {
+          expect(rectSpec.x).toBeGreaterThanOrEqual(r.xLeft);
+          expect(rectSpec.x + rectSpec.width).toBeLessThanOrEqual(r.xRight);
+          expect(rectSpec.y).toBeGreaterThanOrEqual(r.yTop);
+          expect(rectSpec.y + rectSpec.height).toBeLessThanOrEqual(r.yBottom);
+        }
+      }
+    }
+  });
+
+  it('PRODUCTS spec respects blocked X ranges', () => {
+    const r = rect(0, 1280, 0, 200);
+    // Block the entire span — every potential décor X should be filtered.
+    const fullyBlocked: BlockedRange[] = [{ xMin: -10_000, xMax: 10_000 }];
+    const spec = specForBand(band(FLOORS.PRODUCTS), 'left', r, fullyBlocked);
+    expect(spec.staticRects).toEqual([]);
+    expect(spec.blinkRects).toEqual([]);
+  });
+
+  it('PRODUCTS spec produces décor when no ranges are blocked', () => {
+    const r = rect(0, 200, 0, 200);
+    const spec = specForBand(band(FLOORS.PRODUCTS), 'left', r, []);
+    expect(spec.staticRects.length).toBeGreaterThan(0);
+  });
+
+  it('PRODUCTS spec only places content outside blocked ranges', () => {
+    // Block the centre 80 px; the side rect is 0..240. Anything that
+    // would land inside 80..160 must be omitted.
+    const r = rect(0, 240, 0, 200);
+    const blocked: BlockedRange[] = [{ xMin: 80, xMax: 160 }];
+    const spec = specForBand(band(FLOORS.PRODUCTS), 'left', r, blocked);
+    for (const rectSpec of spec.staticRects) {
+      const xMax = rectSpec.x + rectSpec.width;
+      const overlaps = xMax >= 80 && rectSpec.x <= 160;
+      expect(overlaps).toBe(false);
+    }
+  });
+
+  it('LOBBY spec includes a blinking sconce', () => {
+    const spec = specForBand(band(FLOORS.LOBBY), 'left', rect());
+    expect(spec.blinkRects.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('EXECUTIVE spec includes a blinking lamp', () => {
+    const spec = specForBand(band(FLOORS.EXECUTIVE), 'left', rect());
+    expect(spec.blinkRects.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('every blink rect carries valid blink params', () => {
+    const r = rect(0, 240, 0, 200);
+    for (const floor of Object.values(FLOORS)) {
+      for (const side of ['left', 'right'] as const) {
+        const spec = specForBand(band(floor), side, r);
+        for (const b of spec.blinkRects) {
+          expect(b.blink.lo).toBeGreaterThanOrEqual(0);
+          expect(b.blink.lo).toBeLessThanOrEqual(1);
+          expect(b.blink.hi).toBeGreaterThan(b.blink.lo);
+          expect(b.blink.hi).toBeLessThanOrEqual(1);
+          expect(b.blink.durationMs).toBeGreaterThan(0);
+          expect(b.blink.delayMs).toBeGreaterThanOrEqual(0);
+        }
+      }
+    }
+  });
+});

--- a/src/scenes/elevator/floorBackdrops.ts
+++ b/src/scenes/elevator/floorBackdrops.ts
@@ -1,0 +1,949 @@
+/**
+ * Per-floor themed near-layer backdrop for the elevator scene's hallway
+ * strips on either side of the shaft. Sits in front of `buildingFacade`
+ * (depth 0.4, parallax 0.85) but behind the shaft pillars (depth 2.1).
+ * Drawn at scrollFactor 1 so each band stays locked to its real floor
+ * slab — sidesteps the parallax-misalignment issue that forced the far
+ * façade to stay floor-agnostic.
+ *
+ * Two-step pipeline (matches the codebase's pure-helper + thin-renderer
+ * convention used by `skyBackdrop.ts`, `buildingFacade.ts`, and
+ * `distantSkyline.ts`):
+ *
+ *   1. `specForBand(band, sideRect, blocked)` returns a deterministic
+ *      `FloorBackdropSpec` (static rects + blinking rects). No Phaser
+ *      dependency — fully unit-testable.
+ *   2. `drawFloorBackdrops(scene, opts)` renders all specs: static rects
+ *      collapsed into one `Graphics` per side per band, blinking rects
+ *      become individual `Rectangle` game objects with their own alpha
+ *      tweens (so each blink can be animated independently).
+ *
+ * Themed contents per floor (silhouette / architectural — restraint
+ * applied where the floor scene already has dense foreground décor):
+ *
+ *   LOBBY        — wainscot stripe + framed picture silhouettes + sconce blink
+ *   PLATFORM_TEAM
+ *     left       — server-rack silhouettes with blinking LED rows
+ *     right      — whiteboard with diagram blocks + marker tray
+ *   BUSINESS
+ *     left       — desk + monitor with blinking data points
+ *     right      — cubicle dividers + support headset glyph + ticket screen
+ *   EXECUTIVE    — wood panelling + bookshelf + warm lamp blink
+ *   PRODUCTS     — utility corridor: pipes + vent + signage, avoiding
+ *                  X ranges blocked by product doors.
+ *
+ * Depth: 0.5 (above façade 0.4, below hallway floor tiles 2).
+ */
+import type * as Phaser from 'phaser';
+import { theme } from '../../style/theme';
+import { FLOORS, FloorId } from '../../config/gameConfig';
+
+/** Static rectangle (no animation). */
+export interface BackdropRect {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  color: number;
+  alpha?: number;
+}
+
+/** Rectangle that pulses alpha between `lo` and `hi` on a yoyo loop. */
+export interface BackdropBlinkRect extends BackdropRect {
+  blink: { lo: number; hi: number; durationMs: number; delayMs: number };
+}
+
+export interface FloorBackdropSpec {
+  staticRects: BackdropRect[];
+  blinkRects: BackdropBlinkRect[];
+}
+
+/** One floor band. yTop/yBottom are world coordinates (slab-aligned). */
+export interface FloorBackdropBand {
+  floorId: FloorId;
+  yTop: number;
+  yBottom: number;
+}
+
+/** Side strip in world coordinates, left or right of the shaft. */
+export interface SideRect {
+  xLeft: number;
+  xRight: number;
+  yTop: number;
+  yBottom: number;
+}
+
+/** A blocked horizontal range, used to keep PRODUCTS clutter clear of doors. */
+export interface BlockedRange {
+  xMin: number;
+  xMax: number;
+}
+
+export interface FloorBackdropOptions {
+  /** Two side strips: [left of shaft, right of shaft] in world coords. */
+  sides: [
+    { xLeft: number; xRight: number },
+    { xLeft: number; xRight: number },
+  ];
+  bands: FloorBackdropBand[];
+  /**
+   * Static keep-out X ranges in world coordinates. Currently consumed
+   * only by the PRODUCTS band so backdrop décor doesn't overlap product
+   * doors / door labels. Pass empty / omit if not relevant.
+   */
+  blockedRanges?: BlockedRange[];
+}
+
+export interface FloorBackdropHandle {
+  objects: Phaser.GameObjects.GameObject[];
+  tweens: Phaser.Tweens.Tween[];
+}
+
+/** xorshift-based deterministic RNG (matches sibling backdrop modules). */
+function rng(seed: number): () => number {
+  let s = seed | 0;
+  if (s === 0) s = 0x12345678;
+  return () => {
+    s ^= s << 13;
+    s ^= s >>> 17;
+    s ^= s << 5;
+    return ((s >>> 0) % 1_000_000) / 1_000_000;
+  };
+}
+
+/** True if `[xMin, xMax]` overlaps any blocked range. */
+function overlapsBlocked(xMin: number, xMax: number, blocked: BlockedRange[]): boolean {
+  for (const b of blocked) {
+    if (xMax >= b.xMin && xMin <= b.xMax) return true;
+  }
+  return false;
+}
+
+type Side = 'left' | 'right';
+
+/* -------------------------------------------------------------------------- *
+ * Per-floor spec generators. Each takes the side rect in absolute world
+ * coordinates and returns rects in absolute world coordinates too — the
+ * caller doesn't have to do any offsetting.
+ * -------------------------------------------------------------------------- */
+
+function specForLobby(rect: SideRect, side: Side, seed: number): FloorBackdropSpec {
+  const rand = rng(seed ^ 0x10b1_a000);
+  const c = theme.color.floorBackdrop;
+  const w = rect.xRight - rect.xLeft;
+  const h = rect.yBottom - rect.yTop;
+  const staticRects: BackdropRect[] = [];
+  const blinkRects: BackdropBlinkRect[] = [];
+
+  if (w < 60 || h < 60) return { staticRects, blinkRects };
+
+  // Wainscot: low horizontal panel along bottom 22 px of the band.
+  const wainscotH = 22;
+  const wainscotY = rect.yBottom - wainscotH - 6;
+  staticRects.push({
+    x: rect.xLeft + 4,
+    y: wainscotY,
+    width: w - 8,
+    height: wainscotH,
+    color: c.panelMid,
+    alpha: 0.85,
+  });
+  // Wainscot top trim — single brighter pixel line.
+  staticRects.push({
+    x: rect.xLeft + 4,
+    y: wainscotY,
+    width: w - 8,
+    height: 1,
+    color: c.panelEdge,
+    alpha: 0.9,
+  });
+
+  // 2 framed picture silhouettes spaced across the wall.
+  const frameH = Math.min(28, Math.max(16, Math.floor(h * 0.32)));
+  const frameW = Math.min(34, Math.max(20, Math.floor(w * 0.18)));
+  const frameY = rect.yTop + Math.floor(h * 0.22);
+  const slots = 2;
+  const stride = Math.floor(w / (slots + 1));
+  for (let i = 0; i < slots; i++) {
+    const fx = rect.xLeft + stride * (i + 1) - Math.floor(frameW / 2);
+    // Frame outer
+    staticRects.push({
+      x: fx,
+      y: frameY,
+      width: frameW,
+      height: frameH,
+      color: c.panelEdge,
+      alpha: 0.9,
+    });
+    // Frame inner (canvas)
+    staticRects.push({
+      x: fx + 2,
+      y: frameY + 2,
+      width: frameW - 4,
+      height: frameH - 4,
+      color: c.panelDark,
+      alpha: 0.9,
+    });
+    // Tiny abstract "art" stripe inside the frame.
+    staticRects.push({
+      x: fx + 4,
+      y: frameY + Math.floor(frameH / 2),
+      width: frameW - 8,
+      height: 2,
+      color: c.boardMarker,
+      alpha: 0.6,
+    });
+  }
+
+  // Wall sconce: small lit puck near the top with a soft blink.
+  const sconceX =
+    side === 'left' ? rect.xRight - 14 : rect.xLeft + 8;
+  const sconceY = rect.yTop + 12 + Math.floor(rand() * 8);
+  staticRects.push({
+    x: sconceX,
+    y: sconceY,
+    width: 6,
+    height: 3,
+    color: c.panelEdge,
+    alpha: 0.9,
+  });
+  blinkRects.push({
+    x: sconceX - 1,
+    y: sconceY + 3,
+    width: 8,
+    height: 3,
+    color: c.lampWarm,
+    alpha: 0.6,
+    blink: { lo: 0.35, hi: 0.7, durationMs: 2400, delayMs: Math.floor(rand() * 600) },
+  });
+
+  return { staticRects, blinkRects };
+}
+
+function specForPlatform(rect: SideRect, side: Side, seed: number): FloorBackdropSpec {
+  const rand = rng(seed ^ 0xfa1_da7a);
+  const c = theme.color.floorBackdrop;
+  const w = rect.xRight - rect.xLeft;
+  const h = rect.yBottom - rect.yTop;
+  const staticRects: BackdropRect[] = [];
+  const blinkRects: BackdropBlinkRect[] = [];
+  if (w < 70 || h < 70) return { staticRects, blinkRects };
+
+  // 2 server-rack columns. Rack is a tall dark cabinet with horizontal
+  // LED rows. Each rack is ~ 32 px wide, separated by an 18 px gap.
+  const rackW = 32;
+  const gap = 18;
+  const rackH = Math.min(h - 16, 96);
+  const rackY = rect.yBottom - rackH - 6;
+  const totalW = 2 * rackW + gap;
+  const startX = rect.xLeft + Math.floor((w - totalW) / 2);
+
+  for (let r = 0; r < 2; r++) {
+    const rx = startX + r * (rackW + gap);
+    // Rack body
+    staticRects.push({
+      x: rx,
+      y: rackY,
+      width: rackW,
+      height: rackH,
+      color: c.rackBody,
+      alpha: 0.95,
+    });
+    // Rack frame (lighter edge)
+    staticRects.push({ x: rx, y: rackY, width: rackW, height: 1, color: c.rackEdge, alpha: 0.9 });
+    staticRects.push({
+      x: rx,
+      y: rackY + rackH - 1,
+      width: rackW,
+      height: 1,
+      color: c.rackEdge,
+      alpha: 0.9,
+    });
+    // LED rows: 6 rows, each row has 4 small LEDs. Most are dim; a few blink.
+    const rows = 6;
+    const rowH = Math.floor((rackH - 8) / rows);
+    for (let row = 0; row < rows; row++) {
+      const ly = rackY + 4 + row * rowH;
+      // Row strip (off colour)
+      staticRects.push({
+        x: rx + 4,
+        y: ly,
+        width: rackW - 8,
+        height: 2,
+        color: c.rackLedOff,
+        alpha: 0.85,
+      });
+      // 4 LED dots
+      for (let i = 0; i < 4; i++) {
+        const lx = rx + 5 + i * Math.floor((rackW - 10) / 4);
+        const isOn = rand() < 0.55;
+        const isBlink = isOn && rand() < 0.18;
+        if (isBlink) {
+          blinkRects.push({
+            x: lx,
+            y: ly,
+            width: 2,
+            height: 2,
+            color: rand() < 0.35 ? c.rackLedAmber : c.rackLedOn,
+            alpha: 0.95,
+            blink: {
+              lo: 0.25,
+              hi: 0.95,
+              durationMs: 900 + Math.floor(rand() * 1400),
+              delayMs: Math.floor(rand() * 1200),
+            },
+          });
+        } else if (isOn) {
+          staticRects.push({
+            x: lx,
+            y: ly,
+            width: 2,
+            height: 2,
+            color: c.rackLedOn,
+            alpha: 0.7,
+          });
+        }
+      }
+    }
+  }
+
+  return { staticRects, blinkRects };
+}
+
+function specForArchitecture(rect: SideRect, _side: Side, seed: number): FloorBackdropSpec {
+  const rand = rng(seed ^ 0xa1c_b0a1);
+  const c = theme.color.floorBackdrop;
+  const w = rect.xRight - rect.xLeft;
+  const h = rect.yBottom - rect.yTop;
+  const staticRects: BackdropRect[] = [];
+  const blinkRects: BackdropBlinkRect[] = [];
+  if (w < 80 || h < 70) return { staticRects, blinkRects };
+
+  // Whiteboard: large light rect centered on the wall.
+  const boardW = Math.min(w - 16, 110);
+  const boardH = Math.min(h - 22, 56);
+  const boardX = rect.xLeft + Math.floor((w - boardW) / 2);
+  const boardY = rect.yTop + Math.floor((h - boardH) / 2) - 4;
+  // Frame
+  staticRects.push({
+    x: boardX - 2,
+    y: boardY - 2,
+    width: boardW + 4,
+    height: boardH + 4,
+    color: c.boardFrame,
+    alpha: 0.9,
+  });
+  // Surface
+  staticRects.push({
+    x: boardX,
+    y: boardY,
+    width: boardW,
+    height: boardH,
+    color: c.boardSurface,
+    alpha: 0.85,
+  });
+  // Marker tray
+  staticRects.push({
+    x: boardX,
+    y: boardY + boardH + 2,
+    width: boardW,
+    height: 2,
+    color: c.boardFrame,
+    alpha: 0.9,
+  });
+
+  // 4 diagram blocks connected by thin horizontal lines.
+  const blockW = 16;
+  const blockH = 10;
+  const blockY = boardY + Math.floor(boardH / 2) - blockH / 2;
+  const blockSpacing = Math.floor((boardW - blockW * 4) / 5);
+  for (let i = 0; i < 4; i++) {
+    const bx = boardX + blockSpacing + i * (blockW + blockSpacing);
+    const color = i === 1 || i === 3 ? c.boardMarkerAlt : c.boardMarker;
+    staticRects.push({
+      x: bx,
+      y: blockY,
+      width: blockW,
+      height: blockH,
+      color,
+      alpha: 0.85,
+    });
+    // Connecting arrow (thin horizontal line) to next block
+    if (i < 3) {
+      staticRects.push({
+        x: bx + blockW,
+        y: blockY + Math.floor(blockH / 2),
+        width: blockSpacing,
+        height: 1,
+        color: c.boardMarker,
+        alpha: 0.7,
+      });
+    }
+  }
+  // Title bar above blocks (a marker-stroke).
+  staticRects.push({
+    x: boardX + 6,
+    y: boardY + 6,
+    width: Math.floor(boardW * 0.4) + Math.floor(rand() * 6),
+    height: 2,
+    color: c.boardMarker,
+    alpha: 0.7,
+  });
+
+  return { staticRects, blinkRects };
+}
+
+function specForBusinessPL(rect: SideRect, _side: Side, seed: number): FloorBackdropSpec {
+  const rand = rng(seed ^ 0xb1a_de51);
+  const c = theme.color.floorBackdrop;
+  const w = rect.xRight - rect.xLeft;
+  const h = rect.yBottom - rect.yTop;
+  const staticRects: BackdropRect[] = [];
+  const blinkRects: BackdropBlinkRect[] = [];
+  if (w < 80 || h < 70) return { staticRects, blinkRects };
+
+  // Desk runs along bottom of the band.
+  const deskH = 16;
+  const deskY = rect.yBottom - deskH - 6;
+  staticRects.push({
+    x: rect.xLeft + 6,
+    y: deskY,
+    width: w - 12,
+    height: deskH,
+    color: c.deskSurface,
+    alpha: 0.95,
+  });
+  // Desk top edge highlight
+  staticRects.push({
+    x: rect.xLeft + 6,
+    y: deskY,
+    width: w - 12,
+    height: 1,
+    color: c.deskEdge,
+    alpha: 0.9,
+  });
+
+  // Monitor centered on the desk.
+  const monW = Math.min(54, Math.max(36, Math.floor(w * 0.45)));
+  const monH = Math.min(34, Math.max(24, Math.floor(h * 0.45)));
+  const monX = rect.xLeft + Math.floor((w - monW) / 2);
+  const monY = deskY - monH - 2;
+  // Bezel
+  staticRects.push({
+    x: monX,
+    y: monY,
+    width: monW,
+    height: monH,
+    color: c.monitorBezel,
+    alpha: 0.95,
+  });
+  // Screen
+  const screenInset = 2;
+  staticRects.push({
+    x: monX + screenInset,
+    y: monY + screenInset,
+    width: monW - screenInset * 2,
+    height: monH - screenInset * 2,
+    color: c.monitorScreen,
+    alpha: 0.95,
+  });
+  // Stand
+  staticRects.push({
+    x: monX + Math.floor(monW / 2) - 2,
+    y: monY + monH,
+    width: 4,
+    height: 2,
+    color: c.monitorBezel,
+    alpha: 0.95,
+  });
+
+  // Chart: 5 bars rising along the screen, 2 of them blink to imply
+  // "live data."
+  const barCount = 5;
+  const screenX = monX + screenInset;
+  const screenY = monY + screenInset;
+  const screenW = monW - screenInset * 2;
+  const screenH = monH - screenInset * 2;
+  const barGap = 2;
+  const barW = Math.max(2, Math.floor((screenW - 6 - barGap * (barCount - 1)) / barCount));
+  const heights = [3, 5, 4, 7, 6];
+  for (let i = 0; i < barCount; i++) {
+    const bh = Math.min(screenH - 6, (heights[i] ?? 4) + Math.floor(rand() * 2));
+    const bx = screenX + 3 + i * (barW + barGap);
+    const by = screenY + screenH - 3 - bh;
+    if (i === 1 || i === 3) {
+      blinkRects.push({
+        x: bx,
+        y: by,
+        width: barW,
+        height: bh,
+        color: c.monitorChart,
+        alpha: 0.95,
+        blink: {
+          lo: 0.4,
+          hi: 1,
+          durationMs: 1400 + i * 380,
+          delayMs: i * 220,
+        },
+      });
+    } else {
+      staticRects.push({
+        x: bx,
+        y: by,
+        width: barW,
+        height: bh,
+        color: c.monitorChart,
+        alpha: 0.7,
+      });
+    }
+  }
+
+  // Coffee mug silhouette on the desk.
+  const mugX = rect.xLeft + 12 + Math.floor(rand() * 6);
+  staticRects.push({
+    x: mugX,
+    y: deskY - 5,
+    width: 5,
+    height: 5,
+    color: c.panelEdge,
+    alpha: 0.9,
+  });
+
+  return { staticRects, blinkRects };
+}
+
+function specForBusinessCS(rect: SideRect, _side: Side, seed: number): FloorBackdropSpec {
+  const rand = rng(seed ^ 0xc05_5dee);
+  const c = theme.color.floorBackdrop;
+  const w = rect.xRight - rect.xLeft;
+  const h = rect.yBottom - rect.yTop;
+  const staticRects: BackdropRect[] = [];
+  const blinkRects: BackdropBlinkRect[] = [];
+  if (w < 80 || h < 70) return { staticRects, blinkRects };
+
+  // Cubicle dividers — vertical short walls along the band, evenly spaced.
+  const dividerCount = 3;
+  const dividerW = 4;
+  const dividerH = Math.min(48, Math.floor(h * 0.55));
+  const dividerY = rect.yBottom - dividerH - 6;
+  const stride = Math.floor((w - 16) / dividerCount);
+  for (let i = 0; i < dividerCount; i++) {
+    const dx = rect.xLeft + 8 + Math.floor(stride * (i + 0.5)) - dividerW / 2;
+    staticRects.push({
+      x: dx,
+      y: dividerY,
+      width: dividerW,
+      height: dividerH,
+      color: c.cubicleDivider,
+      alpha: 0.9,
+    });
+    // Divider top accent.
+    staticRects.push({
+      x: dx,
+      y: dividerY,
+      width: dividerW,
+      height: 1,
+      color: c.cubicleAccent,
+      alpha: 0.95,
+    });
+  }
+
+  // "Ticket queue" mini-screen mounted on the wall.
+  const screenW = 22;
+  const screenH = 14;
+  const screenX = rect.xLeft + Math.floor((w - screenW) / 2);
+  const screenY = rect.yTop + 14 + Math.floor(rand() * 4);
+  staticRects.push({
+    x: screenX - 1,
+    y: screenY - 1,
+    width: screenW + 2,
+    height: screenH + 2,
+    color: c.monitorBezel,
+    alpha: 0.95,
+  });
+  staticRects.push({
+    x: screenX,
+    y: screenY,
+    width: screenW,
+    height: screenH,
+    color: c.ticketScreen,
+    alpha: 0.95,
+  });
+  // Ticket-number rows inside (3 horizontal lines).
+  for (let row = 0; row < 3; row++) {
+    staticRects.push({
+      x: screenX + 2,
+      y: screenY + 3 + row * 4,
+      width: screenW - 6 - row * 2,
+      height: 1,
+      color: c.ticketGlow,
+      alpha: 0.7,
+    });
+  }
+  // Blinking "current" indicator dot.
+  blinkRects.push({
+    x: screenX + screenW - 4,
+    y: screenY + 2,
+    width: 2,
+    height: 2,
+    color: c.ticketGlow,
+    alpha: 0.95,
+    blink: { lo: 0.3, hi: 1, durationMs: 1100, delayMs: 0 },
+  });
+
+  // Headset glyph silhouette on a divider — small arc + earcup pair.
+  const hsX = rect.xLeft + 12;
+  const hsY = rect.yTop + 24;
+  // Headband
+  staticRects.push({ x: hsX, y: hsY, width: 10, height: 1, color: c.cubicleAccent, alpha: 0.9 });
+  // Earcups
+  staticRects.push({ x: hsX - 1, y: hsY + 1, width: 3, height: 4, color: c.cubicleAccent, alpha: 0.9 });
+  staticRects.push({ x: hsX + 8, y: hsY + 1, width: 3, height: 4, color: c.cubicleAccent, alpha: 0.9 });
+
+  return { staticRects, blinkRects };
+}
+
+function specForExecutive(rect: SideRect, side: Side, seed: number): FloorBackdropSpec {
+  const rand = rng(seed ^ 0xe7e_c0a7);
+  const c = theme.color.floorBackdrop;
+  const w = rect.xRight - rect.xLeft;
+  const h = rect.yBottom - rect.yTop;
+  const staticRects: BackdropRect[] = [];
+  const blinkRects: BackdropBlinkRect[] = [];
+  if (w < 70 || h < 60) return { staticRects, blinkRects };
+
+  // Wood panelling: 3 horizontal bands faking grain lighting.
+  const wainscotH = Math.min(h - 8, 80);
+  const wainscotY = rect.yBottom - wainscotH - 4;
+  staticRects.push({
+    x: rect.xLeft + 4,
+    y: wainscotY,
+    width: w - 8,
+    height: wainscotH,
+    color: c.woodMid,
+    alpha: 0.92,
+  });
+  // Top trim (lighter).
+  staticRects.push({
+    x: rect.xLeft + 4,
+    y: wainscotY,
+    width: w - 8,
+    height: 2,
+    color: c.woodLight,
+    alpha: 0.95,
+  });
+  // Vertical chair-rail divisions every ~36 px.
+  for (let x = rect.xLeft + 18; x < rect.xRight - 8; x += 36) {
+    staticRects.push({
+      x,
+      y: wainscotY + 4,
+      width: 1,
+      height: wainscotH - 8,
+      color: c.woodDark,
+      alpha: 0.7,
+    });
+  }
+  // Brass kickplate near floor.
+  staticRects.push({
+    x: rect.xLeft + 4,
+    y: rect.yBottom - 6,
+    width: w - 8,
+    height: 1,
+    color: c.brass,
+    alpha: 0.4,
+  });
+
+  // Bookshelf silhouette (one tall shelf cluster on the inboard side).
+  const shelfW = Math.min(46, Math.floor(w * 0.55));
+  const shelfH = Math.min(wainscotH - 8, 56);
+  const shelfX =
+    side === 'left'
+      ? rect.xRight - shelfW - 10
+      : rect.xLeft + 10;
+  const shelfY = wainscotY + Math.floor((wainscotH - shelfH) / 2);
+  // Shelf carcase (slightly darker than panel).
+  staticRects.push({
+    x: shelfX,
+    y: shelfY,
+    width: shelfW,
+    height: shelfH,
+    color: c.woodDark,
+    alpha: 0.9,
+  });
+  // 3 horizontal shelves
+  const shelves = 3;
+  for (let i = 1; i <= shelves; i++) {
+    const sy = shelfY + Math.floor((shelfH * i) / (shelves + 1));
+    staticRects.push({
+      x: shelfX + 2,
+      y: sy,
+      width: shelfW - 4,
+      height: 1,
+      color: c.woodLight,
+      alpha: 0.9,
+    });
+    // Books on each shelf — small vertical ticks of varying heights.
+    let bx = shelfX + 3;
+    while (bx < shelfX + shelfW - 4) {
+      const bw = 2 + Math.floor(rand() * 2);
+      const bh = 6 + Math.floor(rand() * 5);
+      const palette = [c.boardMarker, c.boardMarkerAlt, c.brass, c.woodLight];
+      const colour = palette[Math.floor(rand() * palette.length)] ?? c.woodLight;
+      staticRects.push({
+        x: bx,
+        y: sy - bh,
+        width: bw,
+        height: bh,
+        color: colour,
+        alpha: 0.9,
+      });
+      bx += bw + 1;
+    }
+  }
+
+  // Warm desk lamp blink — a small puck above one of the shelves.
+  const lampX = side === 'left' ? rect.xLeft + 14 : rect.xRight - 18;
+  const lampY = wainscotY + 6;
+  staticRects.push({
+    x: lampX,
+    y: lampY,
+    width: 4,
+    height: 4,
+    color: c.brass,
+    alpha: 0.95,
+  });
+  blinkRects.push({
+    x: lampX - 2,
+    y: lampY + 4,
+    width: 8,
+    height: 4,
+    color: c.lampWarm,
+    alpha: 0.7,
+    blink: { lo: 0.45, hi: 0.85, durationMs: 2800, delayMs: 0 },
+  });
+
+  return { staticRects, blinkRects };
+}
+
+function specForProducts(
+  rect: SideRect,
+  side: Side,
+  seed: number,
+  blocked: BlockedRange[],
+): FloorBackdropSpec {
+  const rand = rng(seed ^ 0x9b07_d05);
+  const c = theme.color.floorBackdrop;
+  const w = rect.xRight - rect.xLeft;
+  const h = rect.yBottom - rect.yTop;
+  const staticRects: BackdropRect[] = [];
+  const blinkRects: BackdropBlinkRect[] = [];
+  if (w < 60 || h < 60) return { staticRects, blinkRects };
+
+  // Vertical pipe runs along the inboard edge (closest to the shaft) so
+  // they stay clear of the outer wall window grid. Skip if the pipe X
+  // overlaps a blocked range.
+  const pipeX = side === 'left' ? rect.xRight - 10 : rect.xLeft + 6;
+  if (!overlapsBlocked(pipeX, pipeX + 4, blocked)) {
+    staticRects.push({
+      x: pipeX,
+      y: rect.yTop + 2,
+      width: 4,
+      height: h - 4,
+      color: c.pipeBody,
+      alpha: 0.95,
+    });
+    // Highlight stripe
+    staticRects.push({
+      x: pipeX,
+      y: rect.yTop + 2,
+      width: 1,
+      height: h - 4,
+      color: c.pipeEdge,
+      alpha: 0.9,
+    });
+    // Pipe collars every 36 px.
+    for (let py = rect.yTop + 16; py < rect.yBottom - 4; py += 36) {
+      staticRects.push({
+        x: pipeX - 1,
+        y: py,
+        width: 6,
+        height: 3,
+        color: c.pipeEdge,
+        alpha: 0.95,
+      });
+    }
+  }
+
+  // Vent grille near the middle of the band, only if it fits clear of doors.
+  const ventW = 28;
+  const ventH = 16;
+  const ventX = rect.xLeft + Math.floor((w - ventW) / 2);
+  const ventY = rect.yTop + Math.floor(h * 0.35);
+  if (!overlapsBlocked(ventX, ventX + ventW, blocked)) {
+    // Frame
+    staticRects.push({
+      x: ventX - 1,
+      y: ventY - 1,
+      width: ventW + 2,
+      height: ventH + 2,
+      color: c.pipeEdge,
+      alpha: 0.95,
+    });
+    // Body
+    staticRects.push({
+      x: ventX,
+      y: ventY,
+      width: ventW,
+      height: ventH,
+      color: c.ventGrille,
+      alpha: 0.95,
+    });
+    // Slits — 5 horizontal stripes.
+    for (let i = 0; i < 5; i++) {
+      staticRects.push({
+        x: ventX + 2,
+        y: ventY + 2 + i * 3,
+        width: ventW - 4,
+        height: 1,
+        color: c.ventSlit,
+        alpha: 0.9,
+      });
+    }
+  }
+
+  // Signage rectangle with a contrasting bar — yellow caution or red exit.
+  const signW = 18;
+  const signH = 10;
+  // Place sign offset toward the outer wall, half-band above the vent.
+  const signX = rect.xLeft + 8 + Math.floor(rand() * Math.max(1, w - 24));
+  const signY = rect.yTop + Math.max(8, Math.floor(h * 0.18));
+  if (!overlapsBlocked(signX, signX + signW, blocked)) {
+    const isExit = rand() < 0.5;
+    staticRects.push({
+      x: signX,
+      y: signY,
+      width: signW,
+      height: signH,
+      color: c.panelDark,
+      alpha: 0.9,
+    });
+    staticRects.push({
+      x: signX + 2,
+      y: signY + 2,
+      width: signW - 4,
+      height: signH - 4,
+      color: isExit ? c.signRed : c.signYellow,
+      alpha: 0.9,
+    });
+    // Tiny inner "letter" stripe.
+    staticRects.push({
+      x: signX + 4,
+      y: signY + Math.floor(signH / 2) - 1,
+      width: signW - 8,
+      height: 2,
+      color: c.panelDark,
+      alpha: 0.95,
+    });
+  }
+
+  return { staticRects, blinkRects };
+}
+
+/* -------------------------------------------------------------------------- */
+
+/**
+ * Pick the right per-floor / per-side spec. PLATFORM and BUSINESS bands
+ * carry split-room scenes (Platform/Architecture and Product
+ * Leadership/Customer Success), so left and right sides get different
+ * themes. Other floors use the same theme on both sides.
+ */
+export function specForBand(
+  band: FloorBackdropBand,
+  side: Side,
+  rect: SideRect,
+  blocked: BlockedRange[] = [],
+): FloorBackdropSpec {
+  const seed = (band.floorId * 0x9e3779b1) ^ (side === 'left' ? 0x1111 : 0x2222);
+  switch (band.floorId) {
+    case FLOORS.LOBBY:
+      return specForLobby(rect, side, seed);
+    case FLOORS.PLATFORM_TEAM:
+      return side === 'left'
+        ? specForPlatform(rect, side, seed)
+        : specForArchitecture(rect, side, seed);
+    case FLOORS.BUSINESS:
+      return side === 'left'
+        ? specForBusinessPL(rect, side, seed)
+        : specForBusinessCS(rect, side, seed);
+    case FLOORS.EXECUTIVE:
+      return specForExecutive(rect, side, seed);
+    case FLOORS.PRODUCTS:
+      return specForProducts(rect, side, seed, blocked);
+    default:
+      return { staticRects: [], blinkRects: [] };
+  }
+}
+
+/**
+ * Render every per-floor backdrop into the scene. Static rects collapse
+ * into one `Graphics` per side per band; blinking rects each become a
+ * `Rectangle` GameObject with its own alpha tween. All objects sit at
+ * depth 0.5 with scrollFactor 1 so they stay slab-aligned.
+ */
+export function drawFloorBackdrops(
+  scene: Phaser.Scene,
+  opts: FloorBackdropOptions,
+): FloorBackdropHandle {
+  const { sides, bands, blockedRanges = [] } = opts;
+  const objects: Phaser.GameObjects.GameObject[] = [];
+  const tweens: Phaser.Tweens.Tween[] = [];
+  const DEPTH_STATIC = 0.5;
+  const DEPTH_BLINK = 0.51;
+
+  for (let s = 0; s < sides.length; s++) {
+    const side: Side = s === 0 ? 'left' : 'right';
+    const sideCfg = sides[s];
+    if (!sideCfg) continue;
+    if (sideCfg.xRight - sideCfg.xLeft <= 0) continue;
+
+    for (const band of bands) {
+      const rect: SideRect = {
+        xLeft: sideCfg.xLeft,
+        xRight: sideCfg.xRight,
+        yTop: band.yTop,
+        yBottom: band.yBottom,
+      };
+      if (rect.yBottom - rect.yTop <= 0) continue;
+      const spec = specForBand(band, side, rect, blockedRanges);
+
+      if (spec.staticRects.length > 0) {
+        const gfx = scene.add.graphics().setDepth(DEPTH_STATIC).setScrollFactor(1, 1);
+        for (const r of spec.staticRects) {
+          gfx.fillStyle(r.color, r.alpha ?? 1);
+          gfx.fillRect(r.x, r.y, r.width, r.height);
+        }
+        objects.push(gfx);
+      }
+
+      for (const b of spec.blinkRects) {
+        const rectObj = scene.add
+          .rectangle(b.x + b.width / 2, b.y + b.height / 2, b.width, b.height, b.color, b.alpha ?? 1)
+          .setDepth(DEPTH_BLINK)
+          .setScrollFactor(1, 1);
+        objects.push(rectObj);
+        const tw = scene.tweens.add({
+          targets: rectObj,
+          alpha: { from: b.blink.hi, to: b.blink.lo },
+          duration: b.blink.durationMs,
+          delay: b.blink.delayMs,
+          yoyo: true,
+          repeat: -1,
+          ease: 'Sine.inOut',
+        });
+        tweens.push(tw);
+      }
+    }
+  }
+
+  return { objects, tweens };
+}

--- a/src/style/theme.ts
+++ b/src/style/theme.ts
@@ -53,6 +53,56 @@ export const theme = {
       windowBlinds: 0x3a2e18,
     },
 
+    /**
+     * Per-floor near-layer backdrop palette. Used by `floorBackdrops.ts` to
+     * draw themed silhouettes inside the hallway strips on either side of
+     * the elevator shaft (server racks, whiteboard, monitor, panelling,
+     * pipes, etc.). Tuned darker / desaturated so backdrop reads as
+     * "behind the floor" against the foreground decor at depth 3+.
+     */
+    floorBackdrop: {
+      // Generic
+      panelDark: 0x1a1a22,
+      panelMid: 0x2a2a36,
+      panelEdge: 0x3a3a48,
+      stencil: 0x55556a,
+      // Platform Team — server cabinets
+      rackBody: 0x14181f,
+      rackEdge: 0x2a3140,
+      rackLedOff: 0x223028,
+      rackLedOn: 0x4cd07a,
+      rackLedAmber: 0xe0a040,
+      // Architecture — whiteboard
+      boardSurface: 0xc8cdd4,
+      boardFrame: 0x6a6a78,
+      boardMarker: 0x2a3d6b,
+      boardMarkerAlt: 0x8a3a3a,
+      // Business — desk + monitor
+      deskSurface: 0x3a2e22,
+      deskEdge: 0x5a4a36,
+      monitorBezel: 0x14181c,
+      monitorScreen: 0x0e2030,
+      monitorChart: 0x4cc0d0,
+      // Customer Success — cubicles
+      cubicleDivider: 0x44485a,
+      cubicleAccent: 0x5a607a,
+      ticketScreen: 0x143a3a,
+      ticketGlow: 0x4cd0c0,
+      // Executive — wood panelling + bookshelf
+      woodDark: 0x2a1a10,
+      woodMid: 0x4a2e1c,
+      woodLight: 0x6a4830,
+      brass: 0xd8a040,
+      lampWarm: 0xffb060,
+      // Products — utility corridor
+      pipeBody: 0x4a4f5a,
+      pipeEdge: 0x6a7080,
+      ventGrille: 0x14181c,
+      ventSlit: 0x2a3036,
+      signYellow: 0xe0c040,
+      signRed: 0xc04040,
+    },
+
     /** Floor-specific palettes mirroring `config/levelData.ts`. */
     floor: {
       lobby:     { platform: 0x444466, background: 0x1a1a2e, wall: 0x333355, token: 0xffd700 },


### PR DESCRIPTION
Adds a new near-layer backdrop behind the elevator shaft hallway strips that carries per-floor visual identity. The existing `buildingFacade` (depth 0.4, parallax 0.85) stays as a far backdrop; the new layer sits at depth 0.5 with scrollFactor 1 so each band stays slab-aligned (sidesteps the documented parallax-misalignment caveat).

### Per-floor themes
- **LOBBY** wainscot stripe + framed picture silhouettes + sconce blink
- **PLATFORM_TEAM left** server-rack silhouettes with blinking LED rows
- **PLATFORM_TEAM right (Architecture)** whiteboard with diagram blocks + marker tray
- **BUSINESS left (Product Leadership)** desk + monitor with blinking chart bars
- **BUSINESS right (Customer Success)** cubicle dividers + headset glyph + ticket-queue screen
- **EXECUTIVE** wood panelling + bookshelf with books + warm lamp blink
- **PRODUCTS** utility corridor — vertical pipes, vent grille, signage; skips x ranges blocked by product doors (`ProductDoorManager.doors`)

### Module shape
Mirrors `skyBackdrop` / `buildingFacade` / `distantSkyline`:
- Pure spec generators per floor return `FloorBackdropSpec` (deterministic, seeded)
- Thin renderer `drawFloorBackdrops` collapses static rects into one `Graphics` per side per band; blinking rects each get an alpha-tween `Rectangle`
- New `theme.color.floorBackdrop` palette tokens

### Motion budget
~8 alpha-pulse tweens spread across all bands (LEDs, chart bars, ticket dot, sconce, lamp). Sits inside the project's "modest" guidance.

### Tests
- New `floorBackdrops.test.ts` covers determinism, split-room left/right divergence, side-rect containment, PRODUCTS keep-out, blink-param validity (12 tests, all pass)
- Pre-existing test failures on main (`MotionPreference`, `HUD`, `ProductDoorManager` mock typings) are untouched and unrelated

### Verification
- `npm run typecheck` clean for changed files
- `npm run lint` clean for changed files
- `npm run test:unit` — 12 new tests pass
- E2E / visual snapshots not run (skipped per repo convention; visual snapshots will likely need `test:visual:update` once reviewed)

### Notes
- LOBBY band intentionally restrained — that floor already has dense foreground décor (reception desk, sofa, clock, Geir on F4)
- PRODUCTS keep-out uses static `ProductDoorManager.doors`, no runtime ordering coupling