### PR TITLE
fix(ci): unbreak unit + e2e suites

### DIFF
--- a/src/style/theme.test.ts
+++ b/src/style/theme.test.ts
@@ -5,7 +5,7 @@ describe('theme', () => {
   it('exposes a stable top-level shape', () => {
     expect(Object.keys(theme).sort()).toEqual(['color', 'space']);
     expect(Object.keys(theme.color).sort()).toEqual([
-      'bg', 'css', 'floor', 'sky', 'status', 'ui',
+      'bg', 'css', 'floor', 'floorBackdrop', 'sky', 'status', 'ui',
     ]);
   });
 

--- a/src/systems/MotionPreference.test.ts
+++ b/src/systems/MotionPreference.test.ts
@@ -23,6 +23,13 @@ describe('MotionPreference', () => {
   beforeEach(() => {
     fake = makeFakeStorage();
     _setMotionStorageForTest(fake.storage);
+    // jsdom does not define window.matchMedia; install a stub so vi.spyOn
+    // can replace it in individual tests.
+    Object.defineProperty(window, 'matchMedia', {
+      writable: true,
+      configurable: true,
+      value: vi.fn().mockReturnValue({ matches: false } as MediaQueryList),
+    });
     // Reset to "no override" state
     setReducedMotionOverride(null);
     vi.restoreAllMocks();

--- a/tests/elevator-ride.spec.ts
+++ b/tests/elevator-ride.spec.ts
@@ -27,6 +27,21 @@ test.describe('elevator ride controls', () => {
           'architect_info_seen_v1',
           JSON.stringify(['architecture-elevator']),
         );
+        // Mark onboarding complete so the WelcomeModal does not pop on
+        // arrival — its modal input context suppresses MoveUp/Interact
+        // and would otherwise block both ride and Enter-to-open assertions.
+        window.localStorage.setItem(
+          'architect_default_v1',
+          JSON.stringify({
+            version: 1,
+            totalAU: 0,
+            floorAU: {},
+            unlockedFloors: [0],
+            currentFloor: 0,
+            collectedTokens: {},
+            onboardingComplete: true,
+          }),
+        );
       } catch { /* noop */ }
     });
   });


### PR DESCRIPTION
Fixes the failing CI on main (run 354, commit fb10b10).

## Failures addressed

1. **`src/style/theme.test.ts`** — PR #146 added `theme.color.floorBackdrop` but the snapshot of expected color keys wasn't updated. Added `'floorBackdrop'` to the alphabetised array.

2. **`src/systems/MotionPreference.test.ts`** — 6 tests crashed with `can only spy on a function. Received undefined` because jsdom doesn't define `window.matchMedia`. Added an `Object.defineProperty` stub in `beforeEach` so `vi.spyOn(window, 'matchMedia')` has something to replace.

3. **`tests/elevator-ride.spec.ts`** — both specs timed out: pressing ArrowUp didn't ride the cab and pressing Enter didn't open the info dialog. Root cause: `clearStorage` leaves `onboardingComplete` unset, so `WelcomeModal` opens on `ElevatorScene.create()`. `ModalBase` pushes the `'modal'` input context, which suppresses `MoveUp`/`Interact` (both gameplay-only actions). The test now seeds a save with `onboardingComplete: true` in `beforeEach` so onboarding doesn't pop and the controls behave as documented.

## Verification

- `npm run typecheck` ✅
- `npm run lint` ✅ (pre-existing warnings only)
- Targeted vitest run on the two changed unit files ✅ (18/18 pass)
- Full vitest + Playwright suites: deferred to CI.
