### PR TITLE
fix(ci): bump node-version 20.19.0 → 20.20.2 in both workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.19.0
+          node-version: 20.20.2
           cache: npm
 
       - run: npm ci
@@ -79,7 +79,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.19.0
+          node-version: 20.20.2
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -22,7 +22,7 @@ jobs:
 
       - uses: actions/setup-node@v4
         with:
-          node-version: 20.19.0
+          node-version: 20.20.2
           cache: npm
 
       - run: npm ci


### PR DESCRIPTION
## Why

Node 20.19.0 is a stale patch; latest LTS patch is 20.20.2 (released 2026-03-24). Node 20 reaches end-of-life **2026-04-30** (4 days from now) and will receive no further security patches after that date.

## What changed

- `.github/workflows/ci.yml:41` — `node-version: 20.19.0` → `node-version: 20.20.2`
- `.github/workflows/ci.yml:82` — `node-version: 20.19.0` → `node-version: 20.20.2`
- `.github/workflows/deploy.yml:26` — `node-version: 20.19.0` → `node-version: 20.20.2`

Note: `dorny/paths-filter` and `upload-pages-artifact` versions are unchanged in this PR — separate concerns, separate PRs/issues.

## Evidence

- Release: https://nodejs.org/en/blog/release/v20.20.2
- EOL schedule: https://nodejs.org/en/about/previous-releases

## Follow-up

Issue #187 tracks the Node 20 → 22 migration (the strategic upgrade; needs test-suite validation before merging).

## Verification

- [ ] CI green on this PR
- [ ] Required checks on `main` still match job names


---
_Generated by [Claude Code](https://claude.ai/code/session_01PTovVwfV4TdAEMhKucBhWM)_