### PR TITLE
fix(ci): bump dorny/paths-filter v3 → v4

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,7 @@ jobs:
       # Detect whether this push/PR touches anything outside docs/**.
       # If only docs/** changed, downstream jobs are skipped — skipped jobs
       # satisfy required status checks, so doc-only PRs can still merge.
-      - uses: dorny/paths-filter@v3
+      - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |


### PR DESCRIPTION
## Why

`dorny/paths-filter@v3` is behind the current stable major. v4.0.1 was released 2026-03-17 and updates the action runtime from Node 20 to Node 24. No deprecation notice on v3, but v4 is the upstream-maintained version.

## What changed

- `.github/workflows/ci.yml:24` — `dorny/paths-filter@v3` → `dorny/paths-filter@v4`

The action interface (`filters:` input, `outputs.code`) is unchanged between v3 and v4 — only the internal Node runtime version changed.

## Evidence

- Release: https://github.com/dorny/paths-filter/releases/tag/v4.0.1
- Changelog: v4.0.0 — "update action runtime to node24"

## Verification

- [ ] CI green on this PR (confirms `changes` job output still drives `lint-and-unit` and `e2e` correctly)
- [ ] Required checks on `main` still match job names


---
_Generated by [Claude Code](https://claude.ai/code/session_01PTovVwfV4TdAEMhKucBhWM)_