### PR TITLE
fix(ci): bump actions/upload-artifact v4 → v7

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - name: Upload coverage report
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: coverage
           path: coverage/
@@ -109,7 +109,7 @@ jobs:
 
       - name: Upload Playwright report
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: playwright-report-shard-${{ matrix.shard }}
           path: playwright-report/
@@ -117,7 +117,7 @@ jobs:
 
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: tests-screenshots-shard-${{ matrix.shard }}
           path: tests/screenshots/


### PR DESCRIPTION
## Why
`actions/upload-artifact@v3` was deprecated; v4 is next in line — already 3 major versions behind latest (v7.0.1, Apr 2026).

## What changed
- `.github/workflows/ci.yml:55` — `actions/upload-artifact@v4` → `@v7` (coverage upload)
- `.github/workflows/ci.yml:113` — `actions/upload-artifact@v4` → `@v7` (Playwright report)
- `.github/workflows/ci.yml:121` — `actions/upload-artifact@v4` → `@v7` (screenshots)

## Evidence
- Latest release: https://github.com/actions/upload-artifact/releases (v7.0.1, Apr 10 2026)
- v7.0.0 adds direct single-file upload + ESM; no breaking API changes for path-based uploads used here

## Verification
- [ ] CI green on this PR
- [ ] Required checks on `main` still match job names

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDmV599qWPhPTx5SZiP8F8)_