### PR TITLE
fix(ci): bump actions/cache v4 → v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -87,7 +87,7 @@ jobs:
 
       - name: Cache Playwright browsers
         id: playwright-cache
-        uses: actions/cache@v4
+        uses: actions/cache@v5
         with:
           path: ~/.cache/ms-playwright
           key: ${{ runner.os }}-playwright-${{ hashFiles('package-lock.json') }}


### PR DESCRIPTION
## Why
`actions/cache@v4` is one major version behind; v5.0.5 (Apr 2025) runs on Node.js 24 runtime vs v4's Node 20.

## What changed
- `.github/workflows/ci.yml:90` — `actions/cache@v4` → `@v5` (Playwright browser cache)

## Evidence
- Latest release: https://github.com/actions/cache/releases (v5.0.5, Apr 13 2025)
- v5 requires Actions Runner ≥ 2.327.1; `ubuntu-latest` GitHub-hosted runners satisfy this

## Verification
- [ ] CI green on this PR
- [ ] Required checks on `main` still match job names

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDmV599qWPhPTx5SZiP8F8)_