### PR TITLE
fix(deploy): bump actions/deploy-pages v4 → v5

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,4 +40,4 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     steps:
       - id: deployment
-        uses: actions/deploy-pages@v4
+        uses: actions/deploy-pages@v5


### PR DESCRIPTION
## Why
`actions/deploy-pages@v4` is one major version behind; v5.0.0 (Mar 2026) runs on Node.js 24 runtime.

## What changed
- `.github/workflows/deploy.yml:43` — `actions/deploy-pages@v4` → `@v5`

## Evidence
- Latest release: https://github.com/actions/deploy-pages/releases (v5.0.0, Mar 25 2026)
- v5 updates Node.js runtime to 24.x; no interface changes

## Verification
- [ ] Merge to `main` and confirm deploy workflow completes successfully
- [ ] GitHub Pages URL still resolves after deploy

> **Note:** `deploy.yml` triggers only on `push: branches: [main]` and `workflow_dispatch` — not on `pull_request`. CI checks on this PR run `ci.yml` only; deploy correctness must be verified post-merge.