### PR TITLE
fix(ci): bump actions/checkout v4 → v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     outputs:
       code: ${{ steps.filter.outputs.code }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       # Detect whether this push/PR touches anything outside docs/**.
       # If only docs/** changed, downstream jobs are skipped — skipped jobs
@@ -35,7 +35,7 @@ jobs:
     if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:
@@ -76,7 +76,7 @@ jobs:
         shard: [1, 2]
         total: [2]
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
       - uses: actions/setup-node@v4
         with:


### PR DESCRIPTION
## Why
`actions/checkout@v4` is two major versions behind; v6.0.2 (Jan 2025) is the current stable major.

## What changed
- `.github/workflows/ci.yml:20` — `actions/checkout@v4` → `@v6` (changes job)
- `.github/workflows/ci.yml:38` — `actions/checkout@v4` → `@v6` (lint-and-unit job)
- `.github/workflows/ci.yml:79` — `actions/checkout@v4` → `@v6` (e2e job)
- `.github/workflows/deploy.yml:21` — `actions/checkout@v4` → `@v6` (build job)

## Evidence
- Latest release: https://github.com/actions/checkout/releases (v6.0.2, Jan 9 2025)
- v6 requires Actions Runner ≥ 2.329.0 for Docker container actions; non-Docker workflows (this repo) unaffected

## Verification
- [ ] CI green on this PR
- [ ] Required checks on `main` still match job names

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDmV599qWPhPTx5SZiP8F8)_