### PR TITLE
fix(ci): bump actions/setup-node v4 → v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,7 +37,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm
@@ -78,7 +78,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -20,7 +20,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Why
`actions/setup-node@v4` is two major versions behind; v6.4.0 is the current stable major.

## What changed
- `.github/workflows/ci.yml:40` — `actions/setup-node@v4` → `@v6` (lint-and-unit job)
- `.github/workflows/ci.yml:81` — `actions/setup-node@v4` → `@v6` (e2e job)
- `.github/workflows/deploy.yml:23` — `actions/setup-node@v4` → `@v6` (build job)

## Evidence
- Latest release: https://github.com/actions/setup-node/releases (v6.4.0)
- `cache: npm` interface unchanged; `node-version: 22` resolved identically

## Verification
- [ ] CI green on this PR
- [ ] Required checks on `main` still match job names

---
_Generated by [Claude Code](https://claude.ai/code/session_01KDmV599qWPhPTx5SZiP8F8)_