### PR TITLE
fix(test): type BootScene mute spy as () => void

### DIFF
--- a/src/scenes/core/BootScene.test.ts
+++ b/src/scenes/core/BootScene.test.ts
@@ -59,10 +59,10 @@ import { BootScene } from './BootScene';
 
 describe('BootScene M-key mute hotkey', () => {
   let scene: BootScene;
-  let spy: ReturnType<typeof vi.fn>;
+  let spy: ReturnType<typeof vi.fn<() => void>>;
 
   beforeEach(() => {
-    spy = vi.fn();
+    spy = vi.fn<() => void>();
     eventBus.on('audio:toggle-mute', spy);
     scene = new BootScene();
     scene.create();


### PR DESCRIPTION
## Problem

CI build broken on main since 54face4. `tsc` errors in `src/scenes/core/BootScene.test.ts` lines 66 + 74:

```
error TS2345: Argument of type 'Mock<Procedure | Constructable>' is not assignable to parameter of type 'GameEventHandler<"audio:toggle-mute">'.
```

## Cause

`vi.fn()` with no generic infers `Mock<Procedure | Constructable>`. `GameEventHandler<'audio:toggle-mute'>` resolves to `() => void` (payload tuple is `[]`). TS rejects the assignment.

## Fix

Pin the spy generic: `vi.fn<() => void>()` and matching `ReturnType<typeof vi.fn<() => void>>`.

## Verify

- `npm run typecheck` ✅
- `npm run lint` ✅ (only pre-existing warnings)
- `npm run test:unit` ✅ 636 passed
