### PR TITLE
docs: Die Hard-inspired boss battle feature spec for F4

### DIFF
--- a/idea/bossbattle/jfb/F4-executive-hostage-feature.md
+++ b/idea/bossbattle/jfb/F4-executive-hostage-feature.md
@@ -1,0 +1,210 @@
+# F4 Executive Hostage Rescue Feature
+
+**Status**: Design phase  
+**Inspired by**: Die Hard (hostage rescue on top floor)  
+**Related Floor**: Executive Suite (F4)
+
+---
+
+## Feature Overview
+
+The Executive Suite (F4) is under siege by an **external terrorist threat**. The C-suite leadership is held hostage. The player must navigate the floor, collect three critical items, disable an active bomb, and defeat the threat to liberate the leadership and progress.
+
+### Core Objective
+- Rescue the C-suite leadership held hostage by an external threat
+- Unlock access to the inner sanctum where leadership is held
+- Defeat/neutralize the threat
+- Reward: +AU and progression to next level
+
+---
+
+## Player Flow
+
+```
+1. Enter Executive Suite (F4)
+   ↓
+2. Discover leadership is held hostage (dialogue/visual hint)
+   ↓
+3. Collect 3 required items scattered across the floor:
+     - Pistol (weapon)
+     - Security Key Card
+     - Bomb Deactivation Code (or device)
+   ↓
+4. Navigate past/around the Terrorist Guard
+   ↓
+5. Disable the bomb (interactive puzzle)
+   ↓
+6. Confront the threat / Open the inner sanctum
+   ↓
+7. Free the leadership (cutscene/dialogue)
+   ↓
+8. Receive AU reward & proceed
+```
+
+---
+
+## Three Collectable Items
+
+### 1. **Pistol** (weapon)
+- **Location**: Scattered on challenging platforms (e.g., high catwalk, moving platform sequence)
+- **Visual**: Procedurally generated or simple pixel gun sprite
+- **Purpose**: Grants player ability to shoot / disable the threat from distance
+- **Interaction**: Walk over it or press Interact to equip
+
+### 2. **Security Key Card**
+- **Location**: In a zone near the terrorist's patrol route (risky to retrieve)
+- **Visual**: Small glowing card / key sprite
+- **Purpose**: Unlocks the inner sanctum door where leadership is held
+- **Interaction**: Press Interact when nearby
+
+### 3. **Bomb Deactivation Code** (or Device)
+- **Location**: Hidden in a separate sub-puzzle area (e.g., locked safe, guarded by enemy)
+- **Visual**: Glowing data pad, digital code display, or physical detonator mockup
+- **Purpose**: Disarms the active bomb on the floor
+- **Interaction**: Interactive dialogue / puzzle to input the code or press sequence
+
+**Status Tracking**:
+- HUD shows collected items (visual checklist or icon bar)
+- Once all 3 are collected, inner sanctum door becomes accessible
+- Bomb can be disarmed once Code is obtained
+
+---
+
+## Enemy: The Terrorist Threat
+
+### **Threat Type**
+- **Name**: TBD (e.g., "TerroristCommander", "HostageTaker", "ExternalThreat")
+- **Appearance**: Distinct from Slime/Bot/ScopeCreep enemies (e.g., armored, distinct color)
+- **Behavior**:
+  - Patrols a fixed horizontal zone in front of the inner sanctum
+  - Shoots projectiles at the player (or deals damage on collision)
+  - **Non-stompable** (requires weapon or puzzle solution to defeat)
+  - Health bar visible when near
+  
+### **Defeat Mechanic** (pick one or combine):
+- **Option A**: Player must equip Pistol and engage in combat (shoot/dodge)
+- **Option B**: Disarm Bomb first → Threat is distracted/stunned
+- **Option C**: Collect all 3 items → Threat surrenders or is "authorized" away
+- **Recommendation**: Hybrid — collect all 3 items + use Pistol to "intimidate" or "disable" the threat
+
+---
+
+## Bomb Disarming (Interactive Puzzle)
+
+### **Mechanic**
+- Once Deactivation Code is collected, player can approach the bomb
+- Press Interact to open a mini-dialog / UI panel
+- **Simple variant**: "Enter the 4-digit code" — press arrow keys and Enter
+- **Visual variant**: "Cut the correct wire" — a Minesweeper-style grid or pattern match
+- **Timing variant**: "Hold the button while the indicator passes the target zone" (Quicktime-ish)
+
+### **Outcome**
+- Success: Bomb disarmed, threat is weakened or distracted
+- Failure: Minor damage or reset (retry available)
+
+---
+
+## Inner Sanctum & Leadership Rescue
+
+### **Door/Gate**
+- Appears as locked gate blocking access to the inner sanctum
+- **Unlock requirement**: All 3 items collected + Threat defeated/distracted
+- Opens with a brief animation or chime sound
+
+### **Leadership Cutscene**
+- Brief dialogue from the C-suite:
+  - "Thank you, architect. You have saved the leadership."
+  - "This level has been secured. New floors await."
+  - Flavor text about the organization's resilience
+
+### **Reward**
+- **AU**: +5 or +10 (strategic tier, high-value floor)
+- **Achievement**: "Hostage Rescue" or "Die Hard Mode"
+- **Progression**: Unlock next floor or bonus content
+
+---
+
+## Integration with Existing Systems
+
+### **LevelConfig Extensions**
+```typescript
+{
+  floorId: FLOORS.EXECUTIVE,
+  name: 'Executive Suite',
+  // ... existing fields ...
+  
+  // New fields for hostage mechanic
+  collectedItems: ['pistol', 'keycard', 'bomb_code'],  // tracked in ProgressionSystem
+  terroristPosition: { x: 1000, y: 800 },
+  bombPosition: { x: 640, y: 850 },
+  innerSanctumDoor: { x: 1080, y: 800 },
+}
+```
+
+### **Persistent State**
+- Track collected items in `ProgressionSystem` under `executiveRescueProgress`
+- Save bomb-disarmed status
+- Save threat-defeated status
+
+### **EventBus Events** (new)
+- `hostage:item_collected` — fired when a collectable is picked up
+- `hostage:bomb_disarmed` — fired when bomb is successfully disarmed
+- `hostage:threat_defeated` — fired when threat is neutralized
+- `hostage:leadership_freed` — fired on final unlock & cutscene trigger
+
+### **New Enemy Type** (if not using existing)
+- Extend `Enemy` class → `TerroristCommander` or similar
+- Non-stompable, projectile-based, higher health
+
+---
+
+## Visual / Audio Hints
+
+- **Sirens / Alarm Ambience**: Low background siren or tension music in the Executive Suite
+- **Red Warning Light**: Pulsing light near the bomb
+- **Guard Patrol Animation**: Distinctive walking pose or weapon-drawn animation
+- **Item Highlights**: Subtle glow or shimmer on collectables
+- **HUD Feedback**: Show item count / bomb status in top-right
+
+---
+
+## Difficulty & Balancing
+
+- **Item Placement**: Ensure collectables are **challenging but not impossible** to reach
+- **Guard Patrol**: Patrol path gives player a **timing window** to move safely
+- **Bomb Puzzle**: Difficulty can scale (easy: memorize a code; hard: timed challenge)
+- **Boss Health**: Balanced so Pistol + dodging = winnable in ~10-15 seconds
+
+---
+
+## Open Questions / Design Decisions
+
+1. **Is the Threat truly a "boss" fight, or more a timed obstacle?**
+   - Full combat arena or scripted "intimidate → unlock" moment?
+
+2. **Should collecting all items auto-open the door, or do we need explicit bomb-disarm?**
+   - Full collection → door opens automatically?
+   - Or: collection + puzzle completion + combat = full unlock?
+
+3. **What is the Threat's motivation / backstory?**
+   - Espionage? Sabotage? Random terrorism?
+   - Should there be dialogue before/during confrontation?
+
+4. **Retry mechanism**
+   - If player dies or fails bomb disarm, do they restart the scene or respawn at a checkpoint?
+
+5. **Accessibility**
+   - Is bomb disarm a mandatory combat encounter, or can it be skipped with enough tokens?
+
+---
+
+## Next Steps
+
+1. **Design Decision**: Resolve open questions above
+2. **Create ExecutiveSuiteScene v2**: Add collectable items, bomb, terrorist enemy
+3. **Implement ProgressionSystem extension**: Track hostage-rescue state
+4. **Create Terrorist Enemy class**: Define behavior and combat rules
+5. **Add Bomb Interactive Puzzle**: UI + logic
+6. **Create Cutscene / Leadership Dialogue**: End-of-floor reward sequence
+7. **Testing**: Vitest + Playwright for item collection, combat, bomb puzzle
+8. **Audio / Music**: Tension cue for active bomb, victory chime on rescue

--- a/idea/bossbattle/jfb/implementation-plan.md
+++ b/idea/bossbattle/jfb/implementation-plan.md
@@ -1,0 +1,205 @@
+# Implementation Plan — F4 Executive Hostage Rescue ("Die Hard Mode")
+
+> Companion to `F4-executive-hostage-feature.md` in this folder.
+
+---
+
+## 1. Problem Statement
+
+The Executive Suite (F4, `FLOORS.EXECUTIVE`) currently has platforms, tokens,
+enemies, and a Finance door — but no narrative arc. We want a Die Hard–inspired
+hostage rescue layer: the C-suite is held captive by an external threat, the
+player collects three mission-critical items (Pistol, Security Key Card, Bomb
+Deactivation Code), disarms a bomb, defeats a boss-type enemy, and frees the
+leadership for bonus AU.
+
+---
+
+## 2. Approach Overview
+
+The feature is **additive** — it layers on top of the existing
+`ExecutiveSuiteScene` layout and LevelScene infrastructure.  No changes to
+`LevelScene` base mechanics are required if we model the three collectible items
+as scene-local pickups (like Coffee) and gate progression via scene state rather
+than `ProgressionSystem` persistence.  The bomb disarm is a zone-gated
+interactive dialog.  The boss is a new enemy subclass.
+
+### Key design decisions
+
+| Decision | Choice |
+| --- | --- |
+| Persist rescue progress across reloads? | **No** — scene-local like enemies/coffees. Restarting the scene resets the rescue. Keeps SaveData unchanged. |
+| New enemy type for boss? | **Yes** — `TerroristCommander` under `src/entities/enemies/`. Non-stompable, patrols, higher knockback. |
+| Bomb disarm mechanic | Zone-gated interact → short timed-button UI (hold Interact while indicator passes target zone). |
+| Item pickup model | New `MissionItem` entity (extends Phaser.Physics.Arcade.Sprite). 3 instances placed in LevelConfig-like data inside the scene. Overlap with player → collect. |
+| HUD for collected items | Small icon row in top-right of HUD (3 slots: grey → lit). Scene-local UI, not in the shared HUD component. |
+| Inner sanctum gate | Existing door pattern (like Finance door) but locked until all 3 items + bomb disarmed + boss defeated. |
+| Leadership rescue | Info-dialog with thank-you text + bonus AU award via `progression.addAU()`. |
+
+---
+
+## 3. Todos
+
+### Phase 1 — Foundation
+
+#### 1.1 Create `TerroristCommander` enemy class
+- **File**: `src/entities/enemies/TerroristCommander.ts`
+- Extends `Enemy`. `canBeStomped = false`. Higher `hitCost` (2).
+  Non-standard defeat: call a public `defeat()` that plays a surrender
+  animation (hands-up tween → fade) instead of the stomp squash.
+- Patrol pattern: horizontal bounce between `minX`/`maxX` like other enemies.
+  Slightly faster than Slime, larger sprite.
+- Add `'terrorist'` to the `type` union in `LevelConfig.enemies` (in
+  `LevelScene.ts`).
+- Add a `case 'terrorist'` in `LevelEnemySpawner.spawn()`.
+- Generate sprite in `SpriteGenerator` (or a new family file under
+  `src/systems/sprites/`).
+
+#### 1.2 Create `MissionItem` entity
+- **File**: `src/entities/MissionItem.ts`
+- Extends `Phaser.Physics.Arcade.Sprite`. Static body, glow tween.
+- Constructor: `(scene, x, y, texture, itemId: 'pistol' | 'keycard' | 'bomb_code')`.
+- Picked up on overlap with player → emits callback → destroyed.
+- Sprites generated procedurally (pistol = grey + barrel, keycard = small
+  rectangle, bomb_code = green data pad).
+
+#### 1.3 Add sprites for new entities
+- `SpriteGenerator`: add `enemy_terrorist`, `item_pistol`, `item_keycard`,
+  `item_bomb_code`, `bomb_device`, `door_sanctum_locked`, `door_sanctum_open`.
+- Keep it in existing sprite family files or create `src/systems/sprites/missionItems.ts`.
+
+#### 1.4 Add SFX events
+- **EventBus** (`GameEvents`):
+  - `'sfx:item_pickup'` — picking up a mission item
+  - `'sfx:bomb_disarm'` — bomb successfully disarmed
+  - `'sfx:boss_defeated'` — terrorist commander defeated
+  - `'sfx:hostage_freed'` — leadership rescued
+- Wire into `SFX_EVENTS` in `audioConfig.ts`.
+- Sound generators under `src/systems/sounds/`.
+
+### Phase 2 — Scene Integration
+
+#### 2.1 Extend `ExecutiveSuiteScene` with rescue state
+- Add private scene-local state:
+  ```ts
+  private rescueState = {
+    collected: new Set<'pistol' | 'keycard' | 'bomb_code'>(),
+    bombDisarmed: false,
+    bossDefeated: false,
+    leadershipFreed: false,
+  };
+  ```
+- Reset on every `create()` — no persistence.
+
+#### 2.2 Place mission items in the scene
+- Pistol: on a high catwalk or moving platform (hard to reach).
+- Key Card: near the terrorist's patrol zone (risky pickup).
+- Bomb Code: behind a small platforming puzzle on the mezzanine.
+- Create overlap collider with player → collect → update `rescueState`.
+
+#### 2.3 Place bomb device
+- Visual: `bomb_device` sprite near the inner sanctum door.
+- Zone-gated: register a `'bomb-zone'` in `ZoneManager`.
+- When player enters zone AND has `bomb_code` → show interact prompt.
+- On interact: open a timed mini-game (hold Interact while indicator sweeps — 
+  release in the green zone). Success → `bombDisarmed = true`, emit
+  `'sfx:bomb_disarm'`.  Failure → minor damage, retry.
+
+#### 2.4 Boss encounter
+- Place `TerroristCommander` via the enemy array in `getLevelConfig()`.
+- **Defeat condition**: player must have Pistol collected.  When player has
+  Pistol and stomps/overlaps the boss from above, instead of the normal damage
+  path, call `commander.defeat()`.  (Alternative: auto-defeat when all 3 items
+  are collected — simpler.)
+- On defeat: `bossDefeated = true`, emit `'sfx:boss_defeated'`.
+
+#### 2.5 Inner sanctum door
+- Add a second door entry in `ExecutiveSuiteScene.DOORS` or a custom locked
+  door sprite.
+- Door locked until `rescueState` fully complete (all 3 items + bomb + boss).
+- Visual: shows padlock overlay when locked, open texture when unlocked.
+- On interact (unlocked): transition to rescue cutscene or show an
+  info-dialog with leadership thank-you text + award bonus AU.
+
+#### 2.6 Mission HUD overlay
+- Small UI in top-right: 3 icon slots (pistol / keycard / code).
+- Grey when uncollected, coloured when collected.
+- Bomb status indicator (red → green).
+- Scene-local (created in `ExecutiveSuiteScene.create()`, not in shared HUD).
+
+### Phase 3 — Content & Polish
+
+#### 3.1 Info dialog content for leadership rescue
+- Add an info entry in `src/features/floors/executive/info.ts` with
+  `contentId: 'executive-hostage-rescued'`.
+- Text: leadership thanks, flavor about organizational resilience.
+
+#### 3.2 Achievement
+- Add `'hostage-rescue'` to `AchievementId` union and `ACHIEVEMENTS` array.
+- Label: "Die Hard". Description: "Rescue the C-suite leadership."
+- Secret achievement (hidden until unlocked).
+- Trigger in `ExecutiveSuiteScene` after `leadershipFreed = true`.
+
+#### 3.3 Audio
+- Tension music variant for the Executive Suite during active rescue
+  (before completion). Could be a second `SCENE_MUSIC` entry or a
+  `music:push` on scene entry when rescue is incomplete.
+- Victory chime / fanfare on leadership freed.
+
+#### 3.4 Bomb-disarm mini-game UI
+- Small overlay panel (like QuizDialog but simpler).
+- Indicator bar sweeps left→right. Green target zone in the middle.
+- Player holds Interact to "lock in" — if indicator is in the green zone on
+  release, success. 2-3 second sweep. Visual feedback (flash red/green).
+
+### Phase 4 — Testing
+
+#### 4.1 Unit tests
+- `TerroristCommander.test.ts` — patrol bounds, non-stompable, defeat().
+- `MissionItem.test.ts` — pickup callback, destroy on collect.
+- `ExecutiveSuiteScene` rescue state transitions (mock scene).
+
+#### 4.2 Playwright tests (opt-in)
+- Navigate to Executive Suite with full save.
+- Collect items, disarm bomb, defeat boss, enter sanctum.
+- Verify achievement toast and AU award.
+
+---
+
+## 4. Dependency Graph
+
+```
+1.1 TerroristCommander ──┐
+1.2 MissionItem ──────────┤
+1.3 Sprites ──────────────┼──▶ 2.1 Scene rescue state ──▶ 2.2 Place items
+1.4 SFX events ───────────┘                            ──▶ 2.3 Bomb device
+                                                       ──▶ 2.4 Boss encounter
+                                                       ──▶ 2.5 Inner sanctum door
+                                                       ──▶ 2.6 Mission HUD
+
+2.2–2.6 ──▶ 3.1 Info content
+         ──▶ 3.2 Achievement
+         ──▶ 3.3 Audio
+         ──▶ 3.4 Bomb UI
+
+3.* ──▶ 4.1 Unit tests
+     ──▶ 4.2 Playwright tests
+```
+
+---
+
+## 5. Risk & Considerations
+
+- **Scope**: This is a large feature. Consider shipping Phase 1+2 as a first
+  PR, then Phase 3+4 as follow-ups.
+- **SaveData**: Intentionally NOT persisted — rescue resets on scene re-entry.
+  If we later want persistence, extend `SaveData` and bump
+  `CURRENT_SAVE_VERSION`.
+- **Boss balance**: `TerroristCommander` should be challenging but fair.
+  Start with hitCost=2, speed=100, and tune after playtesting.
+- **Bomb mini-game**: Keep it simple (timed bar). Over-engineering the UI
+  risks scope creep (ironic).
+- **Existing scene layout**: The Executive Suite has limited horizontal space
+  (10 tiles ground + 4-tile mezzanine). Items and bomb need to fit without
+  cluttering the existing layout. May need to extend the world width or add
+  more catwalks.


### PR DESCRIPTION
Feature spec for a Die Hard-inspired hostage rescue mechanic on the Executive Suite floor (F4).

**Concept:** Player must collect 3 items (pistol, key card, bomb deactivation code), disarm a bomb, and defeat an external terrorist threat to free the C-suite leadership.

**Key mechanics:**
- 3 collectible items gating access to inner sanctum
- Patrolling terrorist guard (non-stompable, new enemy type)
- Bomb-disarming mini-puzzle
- Leadership rescue cutscene + AU reward

**This is a design spec only — no code changes.**

See \idea/bossbattle/jfb/F4-executive-hostage-feature.md\ for the full spec.