### PR TITLE
fix(ci): bump size-budget checkout and setup-node to v6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -67,9 +67,9 @@ jobs:
     permissions:
       contents: read
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
           node-version: 22
           cache: npm


### PR DESCRIPTION
## Why
`size-budget` job used `actions/checkout@v4` and `actions/setup-node@v4` while every other job in `ci.yml` already runs on `@v6`, creating silent version drift.

## What changed
- `.github/workflows/ci.yml:70` — `actions/checkout@v4` → `actions/checkout@v6`
- `.github/workflows/ci.yml:72` — `actions/setup-node@v4` → `actions/setup-node@v6`

## Evidence
- `actions/checkout@v6` (v6.0.2, 2026-02-04) is the current stable major: https://github.com/actions/checkout/releases
- `actions/setup-node@v6` (v6.2.0, 2026-01-15) is the current stable major: https://github.com/actions/setup-node/releases
- All other jobs (`changes`, `lint-and-unit`, `e2e`) already pin `@v6`; `size-budget` was the only outlier

## Verification
- [ ] CI green on this PR
- [ ] Required checks on `main` still match job names

---
_Generated by [Claude Code](https://claude.ai/code/session_01LEvo9UcTiM4eJeagE4CJbh)_