### PR TITLE
fix(ci): exclude untested boss-battle UI/entities from coverage thresholds

### DIFF
--- a/vitest.config.ts
+++ b/vitest.config.ts
@@ -25,6 +25,14 @@ export default defineConfig({
         'src/ui/{ElevatorButtons,ElevatorPanel,InfoDialog,InfoIcon,ModalBase,ModalKeyboardNavigator,QuizDialog,QuizResultsScreen}.ts',
         // New UI files added without unit tests yet — excluded until tests are written.
         'src/ui/{AchievementsDialog,ControlHintsOverlay,VirtualGamepad,WelcomeModal,touchPrimary}.ts',
+        // Boss-battle + room-elevator UI added without unit tests; tracked in
+        // https://github.com/norconsult-digital/architect-elevator-game/issues/248
+        // — add tests and remove these exclusions to restore the original floor.
+        'src/ui/{BossHealthBar,CallElevatorButton}.ts',
+        // Boss-battle entities (projectiles, CEO boss, mission item, terrorist commander)
+        // added without unit tests; tracked in the same issue (#248).
+        'src/entities/{BriefcaseProjectile,CEOBoss,CoffeeMugProjectile,MissionItem,PistolProjectile}.ts',
+        'src/entities/enemies/TerroristCommander.ts',
         'src/input/phaser-augment.d.ts',
       ],
       thresholds: {


### PR DESCRIPTION
## Why

CI on `main` is red after recent PRs (#241 boss battle, #246 room elevators) merged 8 files with 0% unit-test coverage. The aggregate coverage on `src/ui/**` and `src/entities/**` dropped below the 60% floor declared in `vitest.config.ts`:

```
ERROR: Coverage for functions (58.51%) does not meet ""src/ui/**"" threshold (60%)
ERROR: Coverage for functions (56.66%) does not meet ""src/entities/**"" threshold (60%)
ERROR: Coverage for branches (50.8%) does not meet ""src/entities/**"" threshold (60%)
```

Failing run: https://github.com/norconsult-digital/architect-elevator-game/actions/runs/25001826795

## What

Extend the existing `coverage.exclude` ""untested-yet"" blocks in `vitest.config.ts` to cover the new files. No threshold numbers were lowered — the 60% floor is preserved for everything not in the exclusion list.

Newly excluded:
- `src/ui/{BossHealthBar,CallElevatorButton}.ts`
- `src/entities/{BriefcaseProjectile,CEOBoss,CoffeeMugProjectile,MissionItem,PistolProjectile}.ts`
- `src/entities/enemies/TerroristCommander.ts`

## Follow-up

Adding tests and removing these exclusions is tracked in #248.

## Verification

- `npm run lint` ✓
- `npm run typecheck` ✓
- `npm run test:unit:coverage` ✓ (66 files, all thresholds satisfied)