### PR TITLE
chore(ci): cancel in-progress Pages deploy when newer run starts

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -11,8 +11,12 @@ permissions:
   id-token: write
 
 concurrency:
+  # Cancel any in-progress Pages deploy when a new one starts so the latest
+  # commit on main always wins. Trade-off: an interrupted upload-pages-artifact
+  # / deploy-pages run may leave the previous deployment live until the newer
+  # run completes; acceptable since we redeploy on every main push.
   group: pages
-  cancel-in-progress: false
+  cancel-in-progress: true
 
 jobs:
   build:


### PR DESCRIPTION
Switches deploy.yml concurrency to cancel-in-progress: true so a fresh push to main supersedes any queued/running Pages deploy. Latest commit wins; queued stale builds are dropped.