### PR TITLE
test(e2e): poll for paused scene status to fix shard 2 flake

### DIFF
--- a/tests/pause.spec.ts
+++ b/tests/pause.spec.ts
@@ -57,14 +57,21 @@ test.describe('Pause / Resume', () => {
 
     await page.screenshot({ path: `${SCREENSHOT_DIR}/pause-overlay.png` });
 
-    // The level scene should now be paused (status 6 = PAUSED in Phaser).
-    const levelPaused = await page.evaluate(() => {
-      const g = window.__game!;
-      const scene = g.scene.getScenes(true).find((s) => s.sys.settings.key === 'PlatformTeamScene');
-      // Phaser status 6 = PAUSED, 7 = SLEEPING. Both mean "not running".
-      return !!scene && (scene.sys.settings.status === 6 || scene.sys.settings.status === 7);
-    });
-    expect(levelPaused).toBe(true);
+    // The level scene should now be paused. Phaser's scene.pause() is queued
+    // by SceneManager and applied on the next step, so poll rather than read once.
+    // Status 6 = PAUSED, 7 = SLEEPING. Both mean "not running".
+    await page.waitForFunction(
+      () => {
+        const g = window.__game;
+        if (!g) return false;
+        const scene = g.scene
+          .getScenes(false)
+          .find((s) => s.sys.settings.key === 'PlatformTeamScene');
+        return !!scene && (scene.sys.settings.status === 6 || scene.sys.settings.status === 7);
+      },
+      undefined,
+      { timeout: 5_000 },
+    );
 
     errors.assertClean();
   });
@@ -142,13 +149,20 @@ test.describe('Pause / Resume', () => {
       { timeout: 5_000 },
     );
 
-    // The level scene should be paused.
-    const levelPaused = await page.evaluate(() => {
-      const g = window.__game!;
-      const scene = g.scene.getScenes(true).find((s) => s.sys.settings.key === 'PlatformTeamScene');
-      return !!scene && (scene.sys.settings.status === 6 || scene.sys.settings.status === 7);
-    });
-    expect(levelPaused).toBe(true);
+    // The level scene should be paused. Poll because Phaser's scene.pause()
+    // is queued and applied on the next step.
+    await page.waitForFunction(
+      () => {
+        const g = window.__game;
+        if (!g) return false;
+        const scene = g.scene
+          .getScenes(false)
+          .find((s) => s.sys.settings.key === 'PlatformTeamScene');
+        return !!scene && (scene.sys.settings.status === 6 || scene.sys.settings.status === 7);
+      },
+      undefined,
+      { timeout: 5_000 },
+    );
 
     errors.assertClean();
   });


### PR DESCRIPTION
## Problem

E2E shard 2 fails on 	ests/pause.spec.ts ([CI run](https://github.com/norconsult-digital/architect-elevator-game/actions/runs/25055538303)):

- `Esc pauses the level and PauseScene overlay appears` -> `expect(levelPaused).toBe(true)` (line 67) received `false`.
- `window blur auto-pauses the level scene` -> same assertion at line 151.

## Cause

Phaser's `scene.pause()` is dispatched through `SceneManager` and applied on the next step, not synchronously. The tests already wait for `PauseScene` to be active, then immediately read `sys.settings.status` of the parent level scene. On slow CI workers the parent's status (still `5` = RUNNING) had not transitioned to `6`/`7` yet, producing a one-frame race.

## Fix

Replace the synchronous `page.evaluate` + `expect` pair with `page.waitForFunction` polling the same status check. Same semantics, but tolerant of the SceneManager queue lag. No production code changed.

- Local: `npx playwright test tests/pause.spec.ts` -> 4 passed.
- `npm run typecheck` and `npm run lint` clean (only pre-existing warnings).