### PR TITLE
fix: drop duplicate HIDE TUTORIALS toggle and repair Replay Tutorial e2e

### DIFF
--- a/src/scenes/core/SettingsScene.ts
+++ b/src/scenes/core/SettingsScene.ts
@@ -170,12 +170,6 @@ export class SettingsScene extends Phaser.Scene {
         set: (v) => settingsStore.setHideTutorials(v),
       },
       {
-        kind: 'toggle',
-        label: 'HIDE TUTORIALS',
-        get: () => settingsStore.read().hideTutorials,
-        set: (v) => settingsStore.setHideTutorials(v),
-      },
-      {
         kind: 'action',
         label: '[ CONTROLS ]',
         action: () => this.openControls(),

--- a/tests/menu.spec.ts
+++ b/tests/menu.spec.ts
@@ -1,6 +1,5 @@
-import { test, expect } from '@playwright/test';
+import { test } from '@playwright/test';
 import {
-  SCREENSHOT_DIR,
   attachErrorWatchers,
   clearStorage,
   navigateToElevator,
@@ -10,21 +9,6 @@ import {
 } from './helpers/playwright';
 
 test.describe('Menu scene', () => {
-  test('renders the title and start button', async ({ page }) => {
-    await clearStorage(page);
-    const errors = attachErrorWatchers(page);
-
-    await page.goto('/');
-    await waitForGame(page);
-    await waitForScene(page, 'MenuScene');
-
-    await expect(page).toHaveTitle(/Architect/i);
-    await expect(page.locator('canvas').first()).toBeVisible();
-
-    await page.screenshot({ path: `${SCREENSHOT_DIR}/01-menu.png`, fullPage: false });
-    errors.assertClean();
-  });
-
   test('continues from a seeded save into the elevator', async ({ page }) => {
     await clearStorage(page);
     await seedFullProgressSave(page);

--- a/tests/onboarding.spec.ts
+++ b/tests/onboarding.spec.ts
@@ -104,7 +104,11 @@ test.describe('Onboarding flow', () => {
     await page.keyboard.press('Enter');
     await waitForScene(page, 'SettingsScene');
 
-    // Press Enter to activate "Replay Tutorial" (first item = index 0).
+    // [ BACK ] is the last item (ArrowUp wraps from index 0), so two ArrowUps
+    // land on [ REPLAY TUTORIAL ] (second-from-last) without depending on the
+    // total item count.
+    await page.keyboard.press('ArrowUp');
+    await page.keyboard.press('ArrowUp');
     await page.keyboard.press('Enter');
 
     // Should return to MenuScene.


### PR DESCRIPTION
## Summary

E2E suite audit + a real bug fix it surfaced.

- **Bug:** `SettingsScene.buildItems()` had a duplicate `HIDE TUTORIALS` toggle. PR #336 re-added it during merge-conflict resolution after PR #337 had already landed it. The Settings panel rendered the row twice and pushed `[ REPLAY TUTORIAL ]` one slot lower in the list.
- **Failing test it broke:** `tests/onboarding.spec.ts` → "Settings scene has a Replay Tutorial button that resets onboarding". Even without the duplicate, the test was already wrong: comment claimed `// first item = index 0`, but `selectedIndex` defaults to 0 (MASTER VOLUME slider) and Enter on a slider is a no-op for `activate()`. The test then waited 30 s for `MenuScene` and timed out — twice (initial + retry).
- **Fix:** delete the duplicate item; navigate to `[ REPLAY TUTORIAL ]` via two `ArrowUp` wraps so the test no longer pins to a specific index.
- **Cleanup:** drop the trivial "renders the title and start button" test in `menu.spec.ts` — only asserted `<title>` regex and canvas visibility, both implicitly verified by every other spec on boot.

## Audit findings (no other action needed)

- **All other 23 tests pass.** No flakes, no other regressions.
- **Sharding stays at 2.** Projected per-shard CI wall-clock ~3.2 min, comfortably under the 5 min target. No matrix changes.
- **No other dead-weight tests.** `visual.spec.ts` is already CI-skipped via `testIgnore`. The remaining specs all earn their keep — see commit message for the full breakdown.

## Test plan

- [x] `npm run typecheck`
- [x] `npm run lint` (only pre-existing warnings)
- [x] `npm run test:unit` — 865 pass / 1 skipped
- [x] `CI=1 npx playwright test tests/onboarding.spec.ts tests/menu.spec.ts --reporter=list` — 4/4 pass, previously-failing test now runs in 16 s clean
- [ ] Full CI run on this PR — confirm both shards finish in <5 min and remaining 22 tests still pass

https://claude.ai/code/session_01TSyYDFDx5YkmEUKqwkx7PZ

---
_Generated by [Claude Code](https://claude.ai/code/session_01TSyYDFDx5YkmEUKqwkx7PZ)_