### PR TITLE
fix: non-null assertion for array access in WelcomeModal tests

### DIFF
--- a/src/ui/WelcomeModal.test.ts
+++ b/src/ui/WelcomeModal.test.ts
@@ -257,7 +257,7 @@ describe('WelcomeModal', () => {
       (c) => typeof c[2] === 'string' && c[3]?.fontStyle === 'bold' && c[3]?.fontSize === '30px',
     );
     expect(titleCalls.length).toBe(1);
-    expect(titleCalls[0][2]).toBe('How to Play');
+    expect(titleCalls[0]![2]).toBe('How to Play');
   });
 
   it('source: first-run — renders "Welcome, Architect!" title', () => {
@@ -267,7 +267,7 @@ describe('WelcomeModal', () => {
       (c) => typeof c[2] === 'string' && c[3]?.fontStyle === 'bold' && c[3]?.fontSize === '30px',
     );
     expect(titleCalls.length).toBe(1);
-    expect(titleCalls[0][2]).toBe('Welcome, Architect!');
+    expect(titleCalls[0]![2]).toBe('Welcome, Architect!');
   });
 
   it('source: help — calls onComplete when modal is closed (caller manages side effects)', () => {


### PR DESCRIPTION
## Summary

- `titleCalls[0]` typed as `T | undefined` under strict TS indexing — was causing `TS2532: Object is possibly 'undefined'` on CI
- Added `!` non-null assertions on lines 260 and 270 — safe because `expect(titleCalls.length).toBe(1)` is asserted immediately above both

## Root cause

Pre-existing TS error introduced in #422 ("How to Play" feature), caught when boss E2E PR #460 triggered a fresh CI build.

## Test plan

- [x] `tsc --noEmit` passes (verified in worktree with node_modules)
- [x] No logic change — pure type annotation fix

🤖 Generated with [Claude Code](https://claude.com/claude-code)