### PR TITLE
fix: correct bgm_menu extension in MusicPlugin skip-set test

### DIFF
--- a/src/plugins/MusicPlugin.test.ts
+++ b/src/plugins/MusicPlugin.test.ts
@@ -405,7 +405,7 @@ describe('MusicPlugin boot-failure skip-set', () => {
     // playOrLoad is NOT gated by _failedMusicKeys — the load is attempted
     expect(fakeScene.load.audio).toHaveBeenCalledWith(
       'music_menu',
-      expect.stringContaining('bgm_menu.mp3'),
+      expect.stringContaining('bgm_menu.ogg'),
     );
   });
 


### PR DESCRIPTION
## Summary

Line 408 of `src/plugins/MusicPlugin.test.ts` expected `bgm_menu.mp3` but `STATIC_MUSIC_ASSETS` has used `bgm_menu.ogg` since #423 converted the eager menu track to Vorbis. Align the test expectation with config.

## Change

```diff
- expect.stringContaining('bgm_menu.mp3'),
+ expect.stringContaining('bgm_menu.ogg'),
```

## Test plan

- [x] Single-character extension fix — no logic change
- [x] `STATIC_MUSIC_ASSETS` entry confirmed as `.ogg` in `src/config/audioConfig.ts:54`

🤖 Generated with [Claude Code](https://claude.com/claude-code)