### PR TITLE
fix: add non-null assertion for array access in WelcomeModal tests

### DIFF
--- a/src/ui/WelcomeModal.test.ts
+++ b/src/ui/WelcomeModal.test.ts
@@ -257,7 +257,7 @@ describe('WelcomeModal', () => {
       (c) => typeof c[2] === 'string' && c[3]?.fontStyle === 'bold' && c[3]?.fontSize === '30px',
     );
     expect(titleCalls.length).toBe(1);
-    expect(titleCalls[0][2]).toBe('How to Play');
+    expect(titleCalls[0]![2]).toBe('How to Play');
   });
 
   it('source: first-run — renders "Welcome, Architect!" title', () => {
@@ -267,7 +267,7 @@ describe('WelcomeModal', () => {
       (c) => typeof c[2] === 'string' && c[3]?.fontStyle === 'bold' && c[3]?.fontSize === '30px',
     );
     expect(titleCalls.length).toBe(1);
-    expect(titleCalls[0][2]).toBe('Welcome, Architect!');
+    expect(titleCalls[0]![2]).toBe('Welcome, Architect!');
   });
 
   it('source: help — calls onComplete when modal is closed (caller manages side effects)', () => {


### PR DESCRIPTION
titleCalls[0] is T | undefined under strict TS indexing; the assertion on .length is sufficient to know it exists — add ! to satisfy the checker.