### PR TITLE
fix(test): align MusicPlugin executive prefetch assertion with .ogg asset

### DIFF
--- a/src/plugins/MusicPlugin.test.ts
+++ b/src/plugins/MusicPlugin.test.ts
@@ -484,7 +484,7 @@ describe('prefetchSceneMusic()', () => {
     prefetchSceneMusic(fakeScene as never, 'ExecutiveSuiteScene');
     expect(fakeScene.load.audio).toHaveBeenCalledWith(
       'music_executive',
-      expect.stringContaining('bossroom-battle-431358.mp3'),
+      expect.stringContaining('bossroom-battle.ogg'),
     );
     expect(fakeScene.load.start).toHaveBeenCalled();
   });


### PR DESCRIPTION
Unblocks merge queue: main CI failed after the deferred-music + eager-music PRs landed because MusicPlugin.test.ts still asserted the legacy ossroom-battle-431358.mp3 source filename. Asset path is now music/boss/bossroom-battle.ogg per udioConfig.ts. One-line test update; full vitest run on this branch passes locally.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>