### PR TITLE
fix(ci): pin node-version to 22.20.0 and fix boss E2E timing race

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: '22.20.0'
           cache: npm
 
       - run: npm ci
@@ -87,7 +87,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: '22.20.0'
           cache: npm
 
       - run: npm ci
@@ -122,7 +122,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: '22.20.0'
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: 22
+          node-version: '22.20.0'
           cache: npm
 
       - run: npm ci

--- a/tests/boss.spec.ts
+++ b/tests/boss.spec.ts
@@ -83,7 +83,7 @@ test.describe('Boss arena — CEO showdown', () => {
     const errors = attachErrorWatchers(page);
 
     await goToBossArena(page);
-    await page.waitForTimeout(300);
+    // waitForScene ensures create() finished and boss is constructed; no extra wait needed.
 
     const result = await page.evaluate(() => {
       const g = window.__game!;
@@ -122,7 +122,7 @@ test.describe('Boss arena — CEO showdown', () => {
     const errors = attachErrorWatchers(page);
 
     await goToBossArena(page);
-    await page.waitForTimeout(400);
+    // waitForScene ensures create() finished and boss is constructed; no extra wait needed.
 
     // Trigger defeat via the public method (same as HP reaching 0)
     await page.evaluate(() => {
@@ -135,10 +135,24 @@ test.describe('Boss arena — CEO showdown', () => {
       boss.triggerDefeat();
     });
 
-    // Stagger tween ~360ms, then defeatDialogue event fires showDefeatDialogue().
-    // showDefeatDialogue() shows line 0 immediately, then registers Interact
-    // (Enter) handler after 600ms. 3 Enter presses advance through the 3 lines.
-    await page.waitForTimeout(1100);
+    // Stagger tween fires defeatDialogue → showDefeatDialogue() registers the
+    // Interact handler after a 600ms delayedCall. Poll until it's wired up so
+    // Enter presses reliably advance the dialogue on slow CI runners.
+    // InputService stores handlers in a private Map<GameAction, Set>; TypeScript
+    // `private` is compile-time only so the map is accessible at runtime.
+    await page.waitForFunction(
+      () => {
+        const g = window.__game;
+        if (!g) return false;
+        const scene = g.scene.getScenes(true).find(
+          (s) => s.sys.settings.key === 'BossArenaScene',
+        ) as unknown as Record<string, unknown>;
+        const inputs = scene?.['inputs'] as { handlers?: Map<string, Set<unknown>> } | undefined;
+        return (inputs?.handlers?.get('Interact')?.size ?? 0) > 0;
+      },
+      undefined,
+      { timeout: 15_000 },
+    );
 
     for (let i = 0; i < 3; i++) {
       await page.keyboard.press('Enter');


### PR DESCRIPTION
## Summary

Two mechanical CI fixes:

- **`node-version: 22` → `'22.20.0'`** in `.github/workflows/ci.yml` (3 occurrences) and `.github/workflows/deploy.yml` (1 occurrence). Bare integer floats with each Node 22.x patch release, breaking reproducibility.
- **`tests/boss.spec.ts`**: replace `waitForTimeout(1100)` in the full-playthrough test with a deterministic `waitForFunction` that polls `InputService.handlers.get('Interact').size > 0`. The 1100 ms wait was a best-guess for the boss stagger tween (≈360 ms) + `delayedCall(600)` before the defeat-dialogue Enter handler is registered — not enough on slow CI runners. The poll waits until the handler is actually wired up before pressing Enter, eliminating the timing race. Also removed two smaller `waitForTimeout(300/400)` calls from other boss tests that `waitForScene` already covers.

## Test plan

- [x] `npm run typecheck` — clean
- [x] `npm run lint` — no errors
- [x] `npm run test:unit` — 1414 tests pass
- [x] All 4 boss tests pass locally (deterministic poll confirmed)

https://claude.ai/code/session_0117uXe44xUaD8TLdqRbSQN9