### PR TITLE
fix(ci): trigger CI on merge_group events so queue can progress

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,6 +4,7 @@ on:
   pull_request_target:
   push:
     branches: [main]
+  merge_group:
 
 # Restrict the base-branch token to read-only so untrusted PR code cannot
 # exfiltrate it to modify the repository.
@@ -14,7 +15,7 @@ concurrency:
   # pull_request_target sets github.ref/sha to the BASE branch, so the old
   # ref-based key would collapse all PR runs into a single group.  Use the PR
   # number instead (unique per PR) and fall back to the push SHA on main.
-  group: ${{ github.event_name == 'pull_request_target' && format('ci-pr-{0}', github.event.pull_request.number) || format('ci-push-{0}', github.sha) }}
+  group: ${{ github.event_name == 'pull_request_target' && format('ci-pr-{0}', github.event.pull_request.number) || github.event_name == 'merge_group' && format('ci-mq-{0}', github.event.merge_group.head_sha) || format('ci-push-{0}', github.sha) }}
   cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
 
 jobs:


### PR DESCRIPTION
## Problem

The `main-merge-queue` ruleset uses ALLGREEN grouping strategy and waits for required status checks against the merge-group commit before merging. The CI workflow (`.github/workflows/ci.yml`) was only triggered on `pull_request_target` and `push`, so no jobs ran when the queue produced a `merge_group` event. Required checks never reported, the queue hit its 60-minute `check_response_timeout`, and PRs were silently evicted.

**Observed:** PR #582 was enqueued at position 6, all PR-level checks were green (CLEAN), then dropped from the queue without merging.

## Fix

- Add `merge_group:` trigger to `ci.yml` so CI runs against the queue's merge commit.
- Add a dedicated concurrency group keyed on `github.event.merge_group.head_sha` so queue runs don't collide with PR/push runs.

The existing checkout fallback (`github.event.pull_request.head.sha || github.sha`) already handles the merge_group case: `pull_request` is null, so it falls back to `github.sha` which is the queue's merge commit.

## Verification

- [ ] CI green on this PR
- [ ] After merge, re-enqueue a CLEAN PR (e.g. #582) and confirm it merges through the queue.