### PR TITLE
fix(ci): bump Node runtime to 22.22.2 in ci.yml and deploy.yml

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '22.20.0'
+          node-version: '22.22.2'
           cache: npm
 
       - run: npm ci
@@ -88,7 +88,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '22.20.0'
+          node-version: '22.22.2'
           cache: npm
 
       - run: npm ci
@@ -123,7 +123,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '22.20.0'
+          node-version: '22.22.2'
           cache: npm
 
       - run: npm ci

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,7 +26,7 @@ jobs:
 
       - uses: actions/setup-node@v6
         with:
-          node-version: '22.20.0'
+          node-version: '22.22.2'
           cache: npm
 
       - run: npm ci


### PR DESCRIPTION
## Why

`node-version: '22.20.0'` is two LTS patches behind current Node 22 LTS (22.22.2, released 2026-03-24). Staying current avoids accumulating security fixes and keeps the pinned version from drifting far enough to matter.

## What changed

- `.github/workflows/ci.yml:42` — `'22.20.0'` → `'22.22.2'` (lint-and-unit job)
- `.github/workflows/ci.yml:66` — `'22.20.0'` → `'22.22.2'` (size-budget job)
- `.github/workflows/ci.yml:90` — `'22.20.0'` → `'22.22.2'` (e2e job)
- `.github/workflows/deploy.yml:24` — `'22.20.0'` → `'22.22.2'` (build job)

## Evidence

- Node 22.22.2 release: https://nodejs.org/en/blog/release/v22.22.2 (2026-03-24)
- Node 22.20.0 release: https://nodejs.org/en/blog/release/v22.20.0 (2025-09-24)
- No `.nvmrc` exists; version is hardcoded in both workflows — both must be updated together.

## Verification

- [ ] CI green on this PR
- [ ] Required checks on `main` still match job names

---
_Generated by [Claude Code](https://claude.ai/code/session_0177wKBiPKQrbKjWgHCRupdR)_