### PR TITLE
docs: add H hotkey to README controls table

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ A **Daily Challenge** mode is available from the main menu: each UTC day generat
 | I | Show info card for nearby zone |
 | Esc / P | Pause (during gameplay) |
 | M | Toggle audio mute (any scene) |
+| H | Show controls reference (any scene — pauses gameplay) |
 | 0–5 | Call elevator to floor (inside the cab) |
 | X | Attack — throw mug (boss arena) / fire pistol (executive rescue) |
 


### PR DESCRIPTION
The README controls table was missing `H`, even though `ShowControls` is bound in `bindings.ts` and wired from the menu, pause overlay, and level scenes (it pauses gameplay and opens the read-only controls modal).

I added one row after the mute shortcut, matching the wording in #717 and the call sites I checked in `LevelScene`, `PauseScene`, and `MenuScene`. Docs-only change.

Fixes #717
