### PR TITLE
fix: add no-duplicate-imports lint guard

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -38,6 +38,7 @@ export default [
       '@typescript-eslint/no-explicit-any': 'warn',
       '@typescript-eslint/no-empty-function': 'off',
       'no-empty': ['warn', { allowEmptyCatch: true }],
+      'no-duplicate-imports': ['error', { allowSeparateTypeImports: true }],
     },
   },
   {

--- a/src/scenes/core/BootScene.ts
+++ b/src/scenes/core/BootScene.ts
@@ -14,7 +14,6 @@ import { createAnalyticsService } from '../../systems/Analytics';
 import { setDailyState } from '../../systems/DailyChallenge';
 import { preloadInfoFor } from '../../config/info';
 import { preloadQuizFor } from '../../config/quiz';
-import { getWorldModifiers } from '../../systems/WorldModifiers';
 
 /** Count of static assets that failed to load during this boot pass. */
 let _bootAssetErrorCount = 0;


### PR DESCRIPTION
Adds 
o-duplicate-imports as an error in eslint.config.js (with llowSeparateTypeImports: true) and removes the duplicate getWorldModifiers import in BootScene.ts that triggered the rule.\n\nLocal checks: 
pm run lint (passes with existing warnings only) and 
pm run typecheck (passes).\n\ncloses #726