### PR TITLE
Add Copilot agent automation

### DIFF
--- a/.github/workflows/copilot-issue-routing.yml
+++ b/.github/workflows/copilot-issue-routing.yml
@@ -1,0 +1,117 @@
+name: Copilot issue routing
+
+on:
+  issues:
+    types: [labeled]
+
+permissions:
+  contents: read
+  issues: write
+
+concurrency:
+  group: copilot-issue-${{ github.event.issue.number }}
+  cancel-in-progress: false
+
+jobs:
+  assign-to-copilot:
+    name: Assign labelled issue to Copilot
+    if: github.event.label.name == 'agent:ready' && github.actor != 'github-actions[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure agent labels exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh label create agent:assigned --color 0E8A16 --description "Assigned to Copilot coding agent" --force
+          gh label create agent:auto-merge --color 5319E7 --description "Eligible for guarded Copilot PR auto-merge" --force
+          gh label create agent:needs-human --color D93F0B --description "Agent routing needs maintainer attention" --force
+          gh label create agent:hold --color B60205 --description "Stop Copilot auto-merge for this work" --force
+
+      - name: Assign issue to Copilot coding agent
+        id: assign
+        env:
+          GH_TOKEN: ${{ secrets.COPILOT_AGENT_TOKEN }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+          BASE_BRANCH: ${{ github.event.repository.default_branch }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GH_TOKEN:-}" ]; then
+            echo "COPILOT_AGENT_TOKEN is not configured. Add a user token that can assign Copilot coding agent." >&2
+            exit 1
+          fi
+
+          OWNER="${GH_REPO%%/*}"
+          REPO="${GH_REPO#*/}"
+          REPOSITORY_JSON="$(gh api graphql \
+            -H 'GraphQL-Features: issues_copilot_assignment_api_support,coding_agent_model_selection' \
+            -f owner="$OWNER" \
+            -f repo="$REPO" \
+            -f query='
+              query($owner: String!, $repo: String!) {
+                repository(owner: $owner, name: $repo) {
+                  id
+                  suggestedActors(capabilities: [CAN_BE_ASSIGNED], first: 100) {
+                    nodes {
+                      login
+                      __typename
+                      ... on Bot { id }
+                      ... on User { id }
+                    }
+                  }
+                }
+              }
+            ')"
+
+          REPOSITORY_ID="$(jq -r '.data.repository.id // empty' <<<"$REPOSITORY_JSON")"
+          BOT_ID="$(jq -r '.data.repository.suggestedActors.nodes[]? | select(.login == "copilot-swe-agent") | .id' <<<"$REPOSITORY_JSON")"
+          if [ -z "$REPOSITORY_ID" ] || [ -z "$BOT_ID" ]; then
+            echo "Copilot coding agent is not available to this token/repository." >&2
+            exit 1
+          fi
+
+          jq -n \
+            --arg targetRepo "$GH_REPO" \
+            --arg baseBranch "$BASE_BRANCH" \
+            --arg instructions "Work from the issue title, body, and comments. Open a ready-for-review PR, link it to this issue, and add the agent:auto-merge label to the PR when implementation and tests are complete." \
+            '{
+              assignees: ["copilot-swe-agent[bot]"],
+              agent_assignment: {
+                target_repo: $targetRepo,
+                base_branch: $baseBranch,
+                custom_instructions: $instructions,
+                custom_agent: "",
+                model: ""
+              }
+            }' > assignment.json
+
+          gh api \
+            --method POST \
+            -H "Accept: application/vnd.github+json" \
+            -H "X-GitHub-Api-Version: 2022-11-28" \
+            "/repos/$GH_REPO/issues/$ISSUE_NUMBER/assignees" \
+            --input assignment.json
+
+      - name: Mark issue as routed
+        if: success()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          gh issue edit "$ISSUE_NUMBER" --add-label agent:assigned
+          gh issue comment "$ISSUE_NUMBER" --body "Assigned to GitHub Copilot coding agent. When Copilot opens a linked PR, the PR can auto-merge after required checks pass unless agent:hold is applied."
+
+      - name: Report routing failure
+        if: failure()
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          ISSUE_NUMBER: ${{ github.event.issue.number }}
+        run: |
+          set -euo pipefail
+          gh issue edit "$ISSUE_NUMBER" --add-label agent:needs-human
+          gh issue comment "$ISSUE_NUMBER" --body "Copilot routing failed. Check COPILOT_AGENT_TOKEN, Copilot coding-agent availability for this repository, and Actions logs."

--- a/.github/workflows/copilot-pr-automerge.yml
+++ b/.github/workflows/copilot-pr-automerge.yml
@@ -1,0 +1,107 @@
+name: Copilot PR auto-merge
+
+on:
+  pull_request_target:
+    types: [opened, synchronize, reopened, ready_for_review, labeled, unlabeled]
+
+permissions:
+  contents: write
+  pull-requests: write
+  checks: read
+  issues: write
+
+concurrency:
+  group: copilot-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: false
+
+jobs:
+  enable-auto-merge:
+    name: Enable guarded Copilot auto-merge
+    if: github.event.pull_request.head.repo.full_name == github.repository && github.event.pull_request.user.type == 'Bot' && github.event.pull_request.user.login == 'copilot-swe-agent[bot]' && startsWith(github.event.pull_request.head.ref, 'copilot/') && github.event.pull_request.draft == false && !contains(github.event.pull_request.labels.*.name, 'agent:hold')
+    runs-on: ubuntu-latest
+    steps:
+      - name: Ensure agent labels exist
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          gh label create agent:auto-merge --color 5319E7 --description "Eligible for guarded Copilot PR auto-merge" --force
+          gh label create agent:hold --color B60205 --description "Stop Copilot auto-merge for this work" --force
+
+      - name: Verify repository auto-merge setting
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+        run: |
+          set -euo pipefail
+          ALLOW_AUTO_MERGE="$(gh api "repos/$GH_REPO" --jq '.allow_auto_merge')"
+          if [ "$ALLOW_AUTO_MERGE" != "true" ]; then
+            echo "Repository auto-merge is disabled. Enable Settings > General > Pull Requests > Allow auto-merge." >&2
+            exit 1
+          fi
+
+      - name: Evaluate auto-merge policy
+        id: policy
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          OWNER="${GH_REPO%%/*}"
+          REPO="${GH_REPO#*/}"
+          PR_JSON="$(gh api graphql \
+            -f owner="$OWNER" \
+            -f repo="$REPO" \
+            -F number="$PR_NUMBER" \
+            -f query='
+              query($owner: String!, $repo: String!, $number: Int!) {
+                repository(owner: $owner, name: $repo) {
+                  pullRequest(number: $number) {
+                    labels(first: 50) {
+                      nodes { name }
+                    }
+                    closingIssuesReferences(first: 20) {
+                      nodes {
+                        number
+                        labels(first: 50) {
+                          nodes { name }
+                        }
+                      }
+                    }
+                  }
+                }
+              }
+            ')"
+          HAS_HOLD="$(jq -r 'any(.data.repository.pullRequest.labels.nodes[]?; .name == "agent:hold")' <<<"$PR_JSON")"
+          HAS_PR_LABEL="$(jq -r 'any(.data.repository.pullRequest.labels.nodes[]?; .name == "agent:auto-merge")' <<<"$PR_JSON")"
+          HAS_READY_ISSUE="$(jq -r 'any(.data.repository.pullRequest.closingIssuesReferences.nodes[]?; any(.labels.nodes[]?; .name == "agent:ready"))' <<<"$PR_JSON")"
+
+          if [ "$HAS_HOLD" = "true" ]; then
+            echo "merge=false" >> "$GITHUB_OUTPUT"
+            echo "agent:hold present; auto-merge skipped."
+            exit 0
+          fi
+
+          if [ "$HAS_PR_LABEL" != "true" ] && [ "$HAS_READY_ISSUE" != "true" ]; then
+            echo "merge=false" >> "$GITHUB_OUTPUT"
+            echo "PR lacks agent:auto-merge and no closing issue has agent:ready; auto-merge skipped."
+            exit 0
+          fi
+
+          if [ "$HAS_PR_LABEL" != "true" ]; then
+            gh pr edit "$PR_NUMBER" --add-label agent:auto-merge
+          fi
+
+          echo "merge=true" >> "$GITHUB_OUTPUT"
+
+      - name: Enable auto-merge
+        if: steps.policy.outputs.merge == 'true'
+        env:
+          GH_TOKEN: ${{ github.token }}
+          GH_REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          gh pr merge "$PR_NUMBER" --auto --squash --delete-branch

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ In addition to size budgets, the check fails if any audio file in `dist/music/` 
 
 If a PR genuinely needs more weight, raise the appropriate limit in `scripts/check-size.cjs` with a comment explaining why.
 
-If Copilot-authored PR checks are stuck in `action_required`, see [docs/ci-approval-policy.md](docs/ci-approval-policy.md).
+If Copilot-authored PR checks are stuck in `action_required`, see [docs/ci-approval-policy.md](docs/ci-approval-policy.md). For label-gated Copilot issue routing and green-check auto-merge, see [docs/agent-automation.md](docs/agent-automation.md).
 
 ## Development
 

--- a/docs/agent-automation.md
+++ b/docs/agent-automation.md
@@ -1,0 +1,79 @@
+# Copilot agent automation
+
+This repository can route selected issues to GitHub Copilot coding agent and
+auto-merge the resulting PRs once branch protection says they are green.
+
+## Labels
+
+| Label | Meaning |
+| --- | --- |
+| `agent:ready` | Maintainer opt-in. Applying this to an issue starts Copilot routing. |
+| `agent:assigned` | Workflow successfully assigned the issue to Copilot. |
+| `agent:auto-merge` | PR is eligible for guarded auto-merge. |
+| `agent:hold` | Kill switch. Auto-merge skips the PR while this label is present. |
+| `agent:needs-human` | Routing failed or needs maintainer attention. |
+
+## Issue routing
+
+The `.github/workflows/copilot-issue-routing.yml` workflow runs only when an
+issue is labelled `agent:ready`. It assigns the issue to `copilot-swe-agent`
+with GitHub's Copilot assignment API and adds a comment explaining the next
+step.
+
+The workflow requires a repository secret named `COPILOT_AGENT_TOKEN`. GitHub's
+Copilot assignment API requires a user token, such as a fine-grained PAT or
+GitHub App user-to-server token, that can assign Copilot coding agent. For a
+fine-grained PAT, grant read access to metadata and read/write access to
+actions, contents, issues, and pull requests.
+
+The assignment call includes custom instructions asking Copilot to open a
+linked, ready-for-review PR and add `agent:auto-merge` when work and tests are
+complete.
+
+## PR auto-merge
+
+The `.github/workflows/copilot-pr-automerge.yml` workflow enables GitHub
+auto-merge for Copilot PRs only when all guards pass:
+
+- PR comes from this repository, not a fork.
+- PR author is the Copilot coding-agent bot.
+- PR branch starts with `copilot/`.
+- PR is not a draft.
+- PR does not have `agent:hold`.
+- PR has `agent:auto-merge`, or closes an issue labelled `agent:ready`.
+- Repository auto-merge is enabled.
+
+The workflow uses `pull_request_target` for metadata and API calls only. It
+does not check out or execute PR code. The merge command uses `gh pr merge
+--auto`, so branch protection and required status checks remain authoritative.
+When checks pass, GitHub merges the PR and closes it as merged.
+
+## Repository settings
+
+Enable **Settings > General > Pull Requests > Allow auto-merge**.
+
+Branch protection for `main` must require the stable checks from
+`docs/ci-approval-policy.md`:
+
+- `Lint + typecheck + unit tests`
+- `Playwright E2E complete`
+- optionally `Bundle size budget`
+
+For fully automatic merging, do not require pull request reviews on `main`.
+Required reviews will intentionally block auto-merge until a maintainer
+approves.
+
+## Maintainer workflow
+
+1. Write an issue with clear acceptance criteria and expected validation.
+2. Add `agent:ready`.
+3. Watch for `agent:assigned`.
+4. If Copilot opens a PR that should not merge automatically, add `agent:hold`.
+5. If a bad PR merges, revert the merge or open a follow-up fix. Do not use
+   stale auto-close rules to hide failed agent work.
+
+## Known constraints
+
+Copilot coding-agent assignment is a public-preview GitHub feature. If GitHub
+changes the bot login, branch naming, or assignment API, update both workflows
+and `src/config/agentAutomationWorkflow.test.ts`.

--- a/docs/ci-approval-policy.md
+++ b/docs/ci-approval-policy.md
@@ -41,6 +41,16 @@ In **Settings → Branches → `main` → Require status checks to pass before m
 Per-shard names are implementation details and can change over time. Branch protection
 must require only stable fan-in checks.
 
+## Copilot agent auto-merge
+
+The Copilot agent automation in [agent-automation.md](agent-automation.md)
+uses GitHub auto-merge rather than direct merges. Branch protection remains the
+gate: the auto-merge request only completes after the required checks above pass.
+
+For fully automatic Copilot-agent PRs, keep required pull request reviews
+disabled on `main`. If reviews are required, auto-merge will wait for a
+maintainer approval and is no longer fully automatic.
+
 ## Optional API command to set required checks (maintainer token required)
 
 ```bash

--- a/src/config/agentAutomationWorkflow.test.ts
+++ b/src/config/agentAutomationWorkflow.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest';
+
+import autoMergeWorkflow from '../../.github/workflows/copilot-pr-automerge.yml?raw';
+import issueRoutingWorkflow from '../../.github/workflows/copilot-issue-routing.yml?raw';
+
+describe('Copilot issue routing workflow', () => {
+  it('routes only explicitly labelled issues to Copilot', () => {
+    expect(issueRoutingWorkflow).toContain('issues:');
+    expect(issueRoutingWorkflow).toContain('types: [labeled]');
+    expect(issueRoutingWorkflow).toContain("github.event.label.name == 'agent:ready'");
+    expect(issueRoutingWorkflow).toContain('COPILOT_AGENT_TOKEN');
+  });
+
+  it('uses the Copilot coding-agent assignment API', () => {
+    expect(issueRoutingWorkflow).toContain('GraphQL-Features: issues_copilot_assignment_api_support,coding_agent_model_selection');
+    expect(issueRoutingWorkflow).toContain('copilot-swe-agent');
+    expect(issueRoutingWorkflow).toContain('copilot-swe-agent[bot]');
+    expect(issueRoutingWorkflow).toContain('agent_assignment');
+  });
+
+  it('surfaces routing failures for human follow-up', () => {
+    expect(issueRoutingWorkflow).toContain('agent:assigned');
+    expect(issueRoutingWorkflow).toContain('agent:needs-human');
+  });
+});
+
+describe('Copilot PR auto-merge workflow', () => {
+  it('uses pull_request_target only for metadata orchestration', () => {
+    expect(autoMergeWorkflow).toContain('pull_request_target:');
+    expect(autoMergeWorkflow).not.toContain('actions/checkout');
+  });
+
+  it('keeps privileged auto-merge behind Copilot PR guards', () => {
+    expect(autoMergeWorkflow).toContain('github.event.pull_request.head.repo.full_name == github.repository');
+    expect(autoMergeWorkflow).toContain("github.event.pull_request.user.type == 'Bot'");
+    expect(autoMergeWorkflow).toContain("github.event.pull_request.user.login == 'copilot-swe-agent[bot]'");
+    expect(autoMergeWorkflow).toContain("startsWith(github.event.pull_request.head.ref, 'copilot/')");
+    expect(autoMergeWorkflow).toContain('github.event.pull_request.draft == false');
+    expect(autoMergeWorkflow).toContain("!contains(github.event.pull_request.labels.*.name, 'agent:hold')");
+  });
+
+  it('requires agent opt-in before enabling auto-merge', () => {
+    expect(autoMergeWorkflow).toContain('agent:auto-merge');
+    expect(autoMergeWorkflow).toContain('agent:ready');
+    expect(autoMergeWorkflow).toContain('allow_auto_merge');
+  });
+
+  it('uses GitHub auto-merge instead of direct immediate merge', () => {
+    expect(autoMergeWorkflow).toContain('gh pr merge "$PR_NUMBER" --auto --squash --delete-branch');
+  });
+});

--- a/src/scenes/core/BootScene.ts
+++ b/src/scenes/core/BootScene.ts
@@ -14,7 +14,6 @@ import { createAnalyticsService } from '../../systems/Analytics';
 import { setDailyState } from '../../systems/DailyChallenge';
 import { preloadInfoFor } from '../../config/info';
 import { preloadQuizFor } from '../../config/quiz';
-import { getWorldModifiers } from '../../systems/WorldModifiers';
 
 /** Count of static assets that failed to load during this boot pass. */
 let _bootAssetErrorCount = 0;


### PR DESCRIPTION
## Summary
- Add label-gated Copilot issue routing workflow using GitHub's Copilot assignment API.
- Add guarded Copilot PR auto-merge workflow that never checks out PR code under pull_request_target.
- Document labels, required repository settings, rollback, and branch-protection interaction.
- Add raw workflow policy tests and remove a duplicate BootScene import that blocked typecheck.

## Validation
- `npm run typecheck` passed.
- `npm run lint` passed with existing warnings.
- `npx vitest run src\config\agentAutomationWorkflow.test.ts src\config\ciWorkflow.test.ts --reporter=verbose` passed.
- Full `npm run test:unit` repeatedly hung before executing/completing the suite in this worktree; stopped after long waits.