### PR TITLE
fix(ci): match concurrency group to actual pull_request trigger

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,12 @@ permissions:
   contents: read
 
 concurrency:
-  # pull_request_target sets github.ref/sha to the BASE branch, so the old
-  # ref-based key would collapse all PR runs into a single group.  Use the PR
-  # number instead (unique per PR) and fall back to the push SHA on main.
-  group: ${{ github.event_name == 'pull_request_target' && format('ci-pr-{0}', github.event.pull_request.number) || github.event_name == 'merge_group' && format('ci-mq-{0}', github.event.merge_group.head_sha) || format('ci-push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+  # Group by PR number on pull_request events so superseded runs on the same
+  # PR are cancelled when a new push arrives; merge_group runs are grouped by
+  # head SHA; push events on main fall back to a unique-per-commit key so
+  # main builds never cancel one another.
+  group: ${{ github.event_name == 'pull_request' && format('ci-pr-{0}', github.event.pull_request.number) || github.event_name == 'merge_group' && format('ci-mq-{0}', github.event.merge_group.head_sha) || format('ci-push-{0}', github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   changes:


### PR DESCRIPTION
## Why

CI workflow `.github/workflows/ci.yml` is triggered by `pull_request:` (line 4), but the `concurrency` block (lines 13–17) gates on `github.event_name == 'pull_request_target'`. That condition can never be true for a `pull_request` event, so:

- PR runs always fall through to the per-commit fallback group `ci-push-${{ github.sha }}` (unique per push → no grouping)
- `cancel-in-progress` always evaluates to `false`

Net effect: superseded runs from rapid pushes accumulate instead of being cancelled. The code comment explicitly states the intent ("Use the PR number… unique per PR"), but the event name in the expression is wrong — it references `pull_request_target`, which the workflow doesn't even listen for.

## What changed

- `.github/workflows/ci.yml:13-17` — replaced both `pull_request_target` references with `pull_request` so PR concurrency grouping and cancel-in-progress actually take effect. Refreshed the stale comment.

## Evidence

- `on:` block at `.github/workflows/ci.yml:3-7` declares `pull_request:`, `push: branches: [main]`, `merge_group:` — no `pull_request_target` trigger
- GitHub Actions docs on [`github.event_name`](https://docs.github.com/en/actions/learn-github-actions/contexts#github-context): equals the literal event name; `pull_request` and `pull_request_target` are distinct events

## Verification

- [ ] CI green on this PR
- [ ] Required checks still match job names (`Lint + typecheck + unit tests`, `Playwright E2E complete`, `Bundle size budget`)

---
_Generated by [Claude Code](https://claude.ai/code/session_01JmXrtofJjcUsuoTazJpHP9)_