### PR TITLE
fix(ci): correct concurrency trigger name to enable PR run cancellation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,11 +10,11 @@ permissions:
   contents: read
 
 concurrency:
-  # pull_request_target sets github.ref/sha to the BASE branch, so the old
-  # ref-based key would collapse all PR runs into a single group.  Use the PR
-  # number instead (unique per PR) and fall back to the push SHA on main.
-  group: ${{ github.event_name == 'pull_request_target' && format('ci-pr-{0}', github.event.pull_request.number) || github.event_name == 'merge_group' && format('ci-mq-{0}', github.event.merge_group.head_sha) || format('ci-push-{0}', github.sha) }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+  # Group PR runs by PR number so consecutive pushes to the same PR collapse
+  # into one group (and the in-progress run gets cancelled). Merge-queue runs
+  # group by head SHA, and pushes to main group by push SHA — neither cancels.
+  group: ${{ github.event_name == 'pull_request' && format('ci-pr-{0}', github.event.pull_request.number) || github.event_name == 'merge_group' && format('ci-mq-{0}', github.event.merge_group.head_sha) || format('ci-push-{0}', github.sha) }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   changes:


### PR DESCRIPTION
## Why

`.github/workflows/ci.yml` triggers on `pull_request:` (line 4), but the `concurrency:` block (lines 12–17) gates everything on `github.event_name == 'pull_request_target'`:

```yaml
on:
  pull_request:
  push:
    branches: [main]
  merge_group:

concurrency:
  group: ${{ github.event_name == 'pull_request_target' && format('ci-pr-{0}', …) || github.event_name == 'merge_group' && … || format('ci-push-{0}', github.sha) }}
  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
```

`pull_request_target` is never set by this workflow, so the first branch of the ternary is dead and every PR event falls through to `ci-push-{github.sha}` — a unique group per commit. The result is:

1. Pushing a follow-up commit to a PR does **not** cancel the previous run (cancel-in-progress evaluates `false`).
2. Two simultaneous PRs that happen to share a SHA would also never collapse, but that's the lesser concern.

This matches the historical context: the workflow used to trigger on `pull_request_target` and was changed to `pull_request` (per the stale description in issue #639), but the concurrency block never followed. The comment text already describes the intended PR-number grouping; only the event-name literal was wrong.

## What changed

- `.github/workflows/ci.yml:13-17` — `'pull_request_target'` → `'pull_request'` (both occurrences) and rewrote the comment to describe current behaviour.

```diff
- group: ${{ github.event_name == 'pull_request_target' && format('ci-pr-{0}', github.event.pull_request.number) || … }}
- cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
+ group: ${{ github.event_name == 'pull_request' && format('ci-pr-{0}', github.event.pull_request.number) || … }}
+ cancel-in-progress: ${{ github.event_name == 'pull_request' }}
```

`merge_group` and `push`-to-`main` branches of the ternary are unchanged and still keep `cancel-in-progress: false` (the safe default for those events).

## Evidence

- Workflow triggers: `.github/workflows/ci.yml:3-7` lists `pull_request`, `push`, `merge_group` — no `pull_request_target`.
- `git log -S "pull_request_target" -- .github/workflows/ci.yml` shows the literal was introduced in #523 (commit `ff60d94`) and never updated when the trigger changed.
- GitHub Actions docs: a concurrency group condition that never matches the dispatched `github.event_name` is a no-op, and `cancel-in-progress` accepts a templated boolean that resolves at evaluation time.
- Cross-reference: issue #639 description quotes an older `pull_request_target` version of the file, confirming the trigger was changed at some point.

## Verification

- [ ] CI green on this PR
- [ ] Required checks still match job names (`Lint + typecheck + unit tests`, `Playwright E2E complete`, `Bundle size budget`) — none of the job names changed
- [ ] Push a second commit to this PR and confirm the previous CI run gets cancelled (sanity check that `cancel-in-progress` now fires)


---
_Generated by [Claude Code](https://claude.ai/code/session_01L3PS5NDwwYRHUTSv8WYXZh)_