### PR TITLE
docs: sync __testHooks surface (add missing 4 members) in CLAUDE.md, copilot-instructions.md, setup-project.md

### DIFF
--- a/.github/copilot-instructions.md
+++ b/.github/copilot-instructions.md
@@ -141,7 +141,7 @@ Short index of where things live. Reach for these instead of re-implementing.
   2. Update `defaultState()`, `persist()`, `loadFromSave()`.
   3. Call `this.persist()` after any mutation that must survive a reload.
 - **Text resolution**: `main.ts` monkey-patches `scene.add.text` / `scene.make.text` to default to `resolution: 1.5` so glyphs stay crisp after FIT scaling. Elements that need maximum crispness (HUD AU counter in `CoinCounterController`, dialog title in `InfoDialog`, large menu headings in `MenuScene`) pass `resolution: 2` explicitly in their style object.
-- **Test-hook globals**: `main.ts` exposes `window.__game` (Phaser.Game) and `window.__testHooks` (`{ QuizDialog, canRetryQuiz, eventBus }`) whenever `VITE_EXPOSE_TEST_HOOKS !== 'false'` — default-on in dev, preview, and production. Playwright relies on both. Build with `VITE_EXPOSE_TEST_HOOKS=false` for a hardened bundle without the globals (see README "Build flags").
+- **Test-hook globals**: `main.ts` exposes `window.__game` (Phaser.Game) and `window.__testHooks` (`{ QuizDialog, canRetryQuiz, eventBus, exportSlot, importToSlot, SAVE_ENVELOPE_FORMAT, forceShowVirtualGamepad }`) whenever `VITE_EXPOSE_TEST_HOOKS !== 'false'` — default-on in dev, preview, and production. Playwright relies on all of them (see `tests/save-export-import.spec.ts` for the save hooks, `tests/touch.spec.ts` for `forceShowVirtualGamepad`). Build with `VITE_EXPOSE_TEST_HOOKS=false` for a hardened bundle without the globals (see README "Build flags").
 
 ## How to extend
 
@@ -212,9 +212,6 @@ Playwright helpers in `tests/helpers/playwright.ts`:
 - `seedFullProgressSave(page, { totalAU?, floorAU? })` — pre-populates the save slot and marks the elevator info dialog as seen so it doesn't swallow input.
 - `clearStorage(page)` — wipes localStorage before boot.
 - `attachErrorWatchers(page).assertClean()` — fails the test if any uncaught `pageerror`/console error leaked.
-
-`window.__testHooks` extras (available when `VITE_EXPOSE_TEST_HOOKS !== 'false'`):
-- `forceShowVirtualGamepad(visible: boolean)` — imperatively mount (`true`) or unmount (`false`) the virtual gamepad without writing localStorage. Use this to cover touch UI in Playwright tests on non-touch Chromium. `true` also shows the first-run hint if `TouchHintStore.hasSeen()` is still `false`.
 
 For detailed Playwright debugging recipes, see `.github/skills/debug-with-playwright.md`.
 

--- a/.github/skills/setup-project.md
+++ b/.github/skills/setup-project.md
@@ -68,7 +68,7 @@ From `package.json`:
 - **TypeScript strict, ES modules.** Do not add `.js` source files.
 - **No `public/assets/` directory.** Sprites and SFX are generated procedurally at runtime by `SpriteGenerator` and `SoundGenerator`. Static files: `public/music/` (MP3/OGG/WAV tracks) and `public/brand/` (the Norconsult Digital wordmark SVG, loaded as `lobby_logo` at boot).
 - **Filenames.** Scenes, entities, UI components, and systems use PascalCase filenames matching the exported class. Config / tooling files are lowercase.
-- **Test-hook globals.** `src/main.ts` exposes `window.__game` (Phaser.Game) and `window.__testHooks` (`{ QuizDialog, canRetryQuiz, eventBus }`) whenever `VITE_EXPOSE_TEST_HOOKS !== 'false'` — default-on in dev, preview, and production. Playwright relies on both. Build with `VITE_EXPOSE_TEST_HOOKS=false` for a hardened bundle (see README "Build flags").
+- **Test-hook globals.** `src/main.ts` exposes `window.__game` (Phaser.Game) and `window.__testHooks` (`{ QuizDialog, canRetryQuiz, eventBus, exportSlot, importToSlot, SAVE_ENVELOPE_FORMAT, forceShowVirtualGamepad }`) whenever `VITE_EXPOSE_TEST_HOOKS !== 'false'` — default-on in dev, preview, and production. Playwright relies on all of them (see `tests/save-export-import.spec.ts` for the save hooks, `tests/touch.spec.ts` for `forceShowVirtualGamepad`). Build with `VITE_EXPOSE_TEST_HOOKS=false` for a hardened bundle (see README "Build flags").
 
 ## Adding new scenes / floors / content
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -141,7 +141,7 @@ Short index of where things live. Reach for these instead of re-implementing.
   2. Update `defaultState()`, `persist()`, `loadFromSave()`.
   3. Call `this.persist()` after any mutation that must survive a reload.
 - **Text resolution**: `main.ts` monkey-patches `scene.add.text` / `scene.make.text` to default to `resolution: 1.5` so glyphs stay crisp after FIT scaling. Elements that need maximum crispness (HUD AU counter in `CoinCounterController`, dialog title in `InfoDialog`, large menu headings in `MenuScene`) pass `resolution: 2` explicitly in their style object.
-- **Test-hook globals**: `main.ts` exposes `window.__game` (Phaser.Game) and `window.__testHooks` (`{ QuizDialog, canRetryQuiz, eventBus }`) whenever `VITE_EXPOSE_TEST_HOOKS !== 'false'` — default-on in dev, preview, and production. Playwright relies on both. Build with `VITE_EXPOSE_TEST_HOOKS=false` for a hardened bundle without the globals (see README "Build flags").
+- **Test-hook globals**: `main.ts` exposes `window.__game` (Phaser.Game) and `window.__testHooks` (`{ QuizDialog, canRetryQuiz, eventBus, exportSlot, importToSlot, SAVE_ENVELOPE_FORMAT, forceShowVirtualGamepad }`) whenever `VITE_EXPOSE_TEST_HOOKS !== 'false'` — default-on in dev, preview, and production. Playwright relies on all of them (see `tests/save-export-import.spec.ts` for the save hooks, `tests/touch.spec.ts` for `forceShowVirtualGamepad`). Build with `VITE_EXPOSE_TEST_HOOKS=false` for a hardened bundle without the globals (see README "Build flags").
 
 ## How to extend
 
@@ -212,9 +212,6 @@ Playwright helpers in `tests/helpers/playwright.ts`:
 - `seedFullProgressSave(page, { totalAU?, floorAU? })` — pre-populates the save slot and marks the elevator info dialog as seen so it doesn't swallow input.
 - `clearStorage(page)` — wipes localStorage before boot.
 - `attachErrorWatchers(page).assertClean()` — fails the test if any uncaught `pageerror`/console error leaked.
-
-`window.__testHooks` extras (available when `VITE_EXPOSE_TEST_HOOKS !== 'false'`):
-- `forceShowVirtualGamepad(visible: boolean)` — imperatively mount (`true`) or unmount (`false`) the virtual gamepad without writing localStorage. Use this to cover touch UI in Playwright tests on non-touch Chromium. `true` also shows the first-run hint if `TouchHintStore.hasSeen()` is still `false`.
 
 For detailed Playwright debugging recipes, see `.github/skills/debug-with-playwright.md`.
 


### PR DESCRIPTION
Closes #772

Updates the canonical `{ QuizDialog, canRetryQuiz, eventBus }` listing to the full 7-member surface in all 3 files. Removes the now-redundant `forceShowVirtualGamepad` extras block.

SYNC NOTICE invariant preserved — CLAUDE.md and .github/copilot-instructions.md remain byte-identical except first-line title.