### PR TITLE
docs: document boss floor convention exception

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ ships with zero image assets and only a handful of music files.
 | Bundler       | Vite                                                                             |
 | Framework     | Phaser 3 (Arcade physics)                                                        |
 | Config        | `src/config/` — `gameConfig`, `levelData`, `audioConfig`, plus barrel re-exports for per-floor info + quiz |
-| Floors        | `src/features/floors/<floor>/` — Scene + `info.ts` + `quiz.ts` (+ optional `enemies.ts`) co-located. Exceptions: `lobby/` ships only `info.ts` + `quiz.ts` (rendered inline by `ElevatorScene`); `boss/` ships `BossArenaScene.ts` plus boss-specific helpers (`bombDisarmStateMachine.ts`, `bossPhaseSelector.ts`, `projectilePattern.ts`) and no info/quiz content. |
+| Floors        | `src/features/floors/<floor>/` — Scene + `info.ts` + `quiz.ts` (+ optional `enemies.ts`) co-located.<br>Exceptions: `lobby/` ships only `info.ts` + `quiz.ts` (rendered inline by `ElevatorScene`).<br>`boss/` ships `BossArenaScene.ts` plus boss-specific helpers (`bombDisarmStateMachine.ts`, `bossPhaseSelector.ts`, `projectilePattern.ts`) and no info/quiz content. |
 | Scenes        | `src/scenes/` — infrastructure scenes only: `core/` (Boot, Menu, Settings, Controls, Pause, SaveSlot), `elevator/` |
 | Product scenes | `src/features/products/rooms/` — product content scenes (one per ISY room)   |
 | Entities      | `src/entities/` — gameplay objects (Player, Elevator, Token, Enemy)              |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -30,7 +30,7 @@ ships with zero image assets and only a handful of music files.
 | Bundler       | Vite                                                                             |
 | Framework     | Phaser 3 (Arcade physics)                                                        |
 | Config        | `src/config/` — `gameConfig`, `levelData`, `audioConfig`, plus barrel re-exports for per-floor info + quiz |
-| Floors        | `src/features/floors/<floor>/` — Scene + `info.ts` + `quiz.ts` (+ optional `enemies.ts`) co-located. Exception: `lobby/` ships only `info.ts` + `quiz.ts`; the lobby is rendered inline by `ElevatorScene`. |
+| Floors        | `src/features/floors/<floor>/` — Scene + `info.ts` + `quiz.ts` (+ optional `enemies.ts`) co-located. Exceptions: `lobby/` ships only `info.ts` + `quiz.ts` (rendered inline by `ElevatorScene`); `boss/` ships `BossArenaScene.ts` plus boss-specific helpers (`bombDisarmStateMachine.ts`, `bossPhaseSelector.ts`, `projectilePattern.ts`) and no info/quiz content. |
 | Scenes        | `src/scenes/` — infrastructure scenes only: `core/` (Boot, Menu, Settings, Controls, Pause, SaveSlot), `elevator/` |
 | Product scenes | `src/features/products/rooms/` — product content scenes (one per ISY room)   |
 | Entities      | `src/entities/` — gameplay objects (Player, Elevator, Token, Enemy)              |


### PR DESCRIPTION
## Summary
- update the CONTRIBUTING.md Floors convention row to list both `lobby/` and `boss/` as exceptions
- name the boss-specific helper files so contributors know where the arena logic lives

## Validation
- `npm run lint` *(blocked in this environment: installed Node is v12.22.9, but the repo's ESLint entrypoint uses optional chaining and requires a newer Node runtime)*
- `npm run typecheck` *(same Node runtime blocker as above)*

Closes #766
