### PR TITLE
docs: fix analytics toggle label in README to match UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ To install the Claude GitHub App on a personal account:
 
 ## Privacy
 
-When the **Send anonymous gameplay data** toggle is enabled in Settings *and* the game is deployed with a configured analytics endpoint (`VITE_ANALYTICS_ENDPOINT`), the game sends anonymous telemetry to help us understand the player progression funnel. The data collected is strictly limited to:
+When the **Send analytics** toggle is enabled in Settings *and* the game is deployed with a configured analytics endpoint (`VITE_ANALYTICS_ENDPOINT`), the game sends anonymous telemetry to help us understand the player progression funnel. The data collected is strictly limited to:
 
 - **Event names** — which floors were entered, when a quiz was passed or failed, which achievements were unlocked, when a session started and ended.
 - **Aggregate numbers** — AU totals at milestone thresholds (sampled every 25 AU), quiz scores (pass/fail, not individual answers).

--- a/src/systems/Analytics.ts
+++ b/src/systems/Analytics.ts
@@ -4,7 +4,7 @@
  * Gated behind two independent conditions — both must be true before any
  * network request is ever made:
  *   1. `VITE_ANALYTICS_ENDPOINT` is set at build time (production-only env var).
- *   2. The player has explicitly enabled the "Send anonymous gameplay data"
+ *   2. The player has explicitly enabled the "Send analytics"
  *      toggle in Settings (`SettingsStore.analyticsConsent === true`).
  *
  * When the endpoint is absent, `AnalyticsService` is never created (returns null


### PR DESCRIPTION
Fixes #781

## Summary

The README Privacy section referred to the analytics toggle as **Send anonymous gameplay data**, but the actual UI label in SettingsScene.ts is `SEND ANALYTICS` (prose form: *Send analytics*). This caused a documentation drift where users reading the README could not find the named toggle in Settings.

## Changes

- **README.md** (line 126): Changed `Send anonymous gameplay data` → `Send analytics` to match the existing prose form already used on line 75 and the actual UI label.
- **src/systems/Analytics.ts** (line 7): Updated the JSDoc comment to consistently reference `Send analytics`.

## Verification

- `grep -rn "Send anonymous gameplay data" .` returns zero hits.
- All README references now consistently use `Send analytics`.
- The source label in SettingsScene.ts is unchanged.
- No functional changes — docs-only fix.