### PR TITLE
docs: fix analytics toggle name in README privacy section

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ To install the Claude GitHub App on a personal account:
 
 ## Privacy
 
-When the **Send anonymous gameplay data** toggle is enabled in Settings *and* the game is deployed with a configured analytics endpoint (`VITE_ANALYTICS_ENDPOINT`), the game sends anonymous telemetry to help us understand the player progression funnel. The data collected is strictly limited to:
+When the **Send analytics** toggle is enabled in Settings *and* the game is deployed with a configured analytics endpoint (`VITE_ANALYTICS_ENDPOINT`), the game sends anonymous telemetry to help us understand the player progression funnel. The data collected is strictly limited to:
 
 - **Event names** — which floors were entered, when a quiz was passed or failed, which achievements were unlocked, when a session started and ended.
 - **Aggregate numbers** — AU totals at milestone thresholds (sampled every 25 AU), quiz scores (pass/fail, not individual answers).

--- a/src/systems/Analytics.ts
+++ b/src/systems/Analytics.ts
@@ -4,7 +4,7 @@
  * Gated behind two independent conditions — both must be true before any
  * network request is ever made:
  *   1. `VITE_ANALYTICS_ENDPOINT` is set at build time (production-only env var).
- *   2. The player has explicitly enabled the "Send anonymous gameplay data"
+ *   2. The player has explicitly enabled the "Send analytics"
  *      toggle in Settings (`SettingsStore.analyticsConsent === true`).
  *
  * When the endpoint is absent, `AnalyticsService` is never created (returns null


### PR DESCRIPTION
Closes #781

Replaces 'Send anonymous gameplay data' with 'Send analytics' to match the actual UI label 'SEND ANALYTICS' in SettingsScene.ts.