### PR TITLE
fix(ci): seed paths-filter 'code' filter with '**' to stop empty-include bug

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,14 +25,23 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # Detect whether this push/PR touches anything outside docs/**.
-      # If only docs/** changed, downstream jobs are skipped — skipped jobs
-      # satisfy required status checks, so doc-only PRs can still merge.
+      # Detect whether this push/PR touches anything outside docs/** and
+      # .github/workflows/**. If only those paths changed, downstream jobs
+      # are skipped — skipped jobs satisfy required status checks, so
+      # doc-only / workflow-only PRs can still merge.
+      #
+      # The leading '**' positive pattern is required: dorny/paths-filter
+      # only includes files matching at least one positive pattern, so a
+      # filter consisting solely of negations produces an empty include set
+      # and undefined output (observed: workflow-only PRs reporting
+      # code=true on #760 and the filter job hard-failing on #767). See
+      # https://github.com/dorny/paths-filter#filter-pattern-cheat-sheet.
       - uses: dorny/paths-filter@v4
         id: filter
         with:
           filters: |
             code:
+              - '**'
               - '!docs/**'
               - '!.github/workflows/**'
 


### PR DESCRIPTION
## Why

The `changes` job in `.github/workflows/ci.yml` (lines 20–37) gates the entire downstream pipeline (lint+unit, size, E2E shards, and the `Playwright E2E complete` fan-in) on the `code` output of `dorny/paths-filter@v4`. That filter is currently defined with **only negation patterns**:

```yaml
filters: |
  code:
    - '!docs/**'
    - '!.github/workflows/**'
```

Per dorny/paths-filter's documented semantics ([cheat sheet](https://github.com/dorny/paths-filter#filter-pattern-cheat-sheet)), the include set is the union of *positive* patterns; negations then subtract from that set. With no positive pattern, the include set is empty and the result is undefined. Issue #774 captured two concrete failure modes from this:

| PR | `Detect non-docs changes` | Net result |
|---|---|---|
| #760 (2026-05-21, workflow-only) | succeeded, but emitted `code=true` | Full E2E matrix ran and failed → `Playwright E2E complete` ❌ |
| #767 (2026-05-23, workflow-only) | **job failed** in ~4s | All downstream skipped → required check ❌ |

Both PRs only modified `.github/workflows/ci.yml` — exactly the case the negation was meant to skip.

## What changed

- `.github/workflows/ci.yml:33-43` — added `- '**'` as a leading positive pattern so the negations apply against the full file universe, and refreshed the comment to document why the seed is required.

```diff
       filters: |
         code:
+          - '**'
           - '!docs/**'
           - '!.github/workflows/**'
```

No job names changed — branch-protection required checks (`Lint + typecheck + unit tests`, `Playwright E2E complete`, `Bundle size budget`) are unaffected.

This PR deliberately does **not** touch the `concurrency:` block at lines 12–17 — that `pull_request_target` typo is already in flight on PRs #767, #760, #740, #657. Keeping this change isolated avoids a fifth conflicting concurrency-fix branch.

## Evidence

- Documented behaviour: dorny/paths-filter cheat sheet — "Files that match at least one pattern defined by the filters will be included."
- Workflow trigger list (`.github/workflows/ci.yml:3-7`) — confirms `.github/workflows/**` is a valid path to exclude (workflow-only PRs are common).
- Concrete failure runs:
  - #760: https://github.com/norconsult-digital/architect-elevator-game/actions/runs/26224895155
  - #767: https://github.com/norconsult-digital/architect-elevator-game/actions/runs/26332351231
- Issue #774 picks option A (this fix) as preferred over removing the gate.

## Verification

- [ ] CI green on this PR (note: because this PR is workflow-only, the `changes` filter is exercising itself — after the fix it should emit `code=false` and downstream jobs should skip cleanly; the `Playwright E2E complete` fan-in should report success via the `e2e == 'skipped'` branch in its script)
- [ ] Required checks still match job names (no job-name changes in this diff)
- [ ] Follow-up sanity check on a docs-only PR: downstream jobs skip and required checks pass

Closes #774 (option A).

---
_Generated by [Claude Code](https://claude.ai/code/session_01F7v2pNxZj8oN1L8qoX2AWb)_