### PR TITLE
fix(ui): correct win-condition copy in WelcomeModal to reference Boardroom/CEO

### DIFF
--- a/src/ui/WelcomeModal.test.ts
+++ b/src/ui/WelcomeModal.test.ts
@@ -64,6 +64,18 @@ vi.mock('../input', () => ({
   promptLabel: vi.fn(() => 'K'),
 }));
 
+vi.mock('../config/levelData', () => ({
+  LEVEL_DATA: {
+    boss: { auRequired: 28 },
+  },
+}));
+
+vi.mock('../config/gameConfig', () => ({
+  GAME_WIDTH: 800,
+  GAME_HEIGHT: 600,
+  FLOORS: { BOSS: 'boss' },
+}));
+
 // ---------------------------------------------------------------------------
 // Scene stub helpers
 // ---------------------------------------------------------------------------
@@ -313,5 +325,32 @@ describe('WelcomeModal', () => {
     // No onComplete provided — exercises the default parameter arrow function
     const modal = new WelcomeModal(scene as unknown as Phaser.Scene);
     expect(() => modal.close()).not.toThrow();
+  });
+
+  // -------------------------------------------------------------------------
+  // Win-condition copy correctness (#794)
+  // -------------------------------------------------------------------------
+
+  it('body copy references the Boardroom/CEO goal, not "100 AU"', () => {
+    const scene = makeScene();
+    new WelcomeModal(scene as unknown as Phaser.Scene, vi.fn());
+    const allTextArgs: string[] = (scene.add.text as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c[2])
+      .filter((t): t is string => typeof t === 'string');
+    const bodyCall = allTextArgs.find((t) => t.includes('Architecture Units'));
+    expect(bodyCall).toBeDefined();
+    expect(bodyCall).not.toMatch(/100 AU/);
+    expect(bodyCall).toMatch(/Boardroom/);
+    expect(bodyCall).toMatch(/CEO/);
+  });
+
+  it('body copy AU threshold is sourced from LEVEL_DATA (28), not a hardcoded literal', () => {
+    const scene = makeScene();
+    new WelcomeModal(scene as unknown as Phaser.Scene, vi.fn());
+    const allTextArgs: string[] = (scene.add.text as ReturnType<typeof vi.fn>).mock.calls
+      .map((c) => c[2])
+      .filter((t): t is string => typeof t === 'string');
+    const bodyCall = allTextArgs.find((t) => t.includes('Architecture Units'));
+    expect(bodyCall).toMatch(/28/);
   });
 });

--- a/src/ui/WelcomeModal.ts
+++ b/src/ui/WelcomeModal.ts
@@ -1,5 +1,6 @@
 import * as Phaser from 'phaser';
-import { GAME_WIDTH, GAME_HEIGHT } from '../config/gameConfig';
+import { GAME_WIDTH, GAME_HEIGHT, FLOORS } from '../config/gameConfig';
+import { LEVEL_DATA } from '../config/levelData';
 import { theme } from '../style/theme';
 import { ModalBase } from './ModalBase';
 import { isTouchPrimary } from './touchPrimary';
@@ -103,7 +104,8 @@ export class WelcomeModal extends ModalBase {
       'talk to people, and learn their architectural challenges.',
       '',
       'Collecting AU (Architecture Units) proves your expertise.',
-      'Reach 100 AU to graduate as a full architect!',
+      `Unlock every floor, reach the Boardroom, and defeat the CEO`,
+      `to graduate as a full architect! (${LEVEL_DATA[FLOORS.BOSS].auRequired} AU to reach the top)`,
       '',
       'CONTROLS',
       ...controlsRows,


### PR DESCRIPTION
The Welcome modal told every new player to 'Reach 100 AU to graduate as a full architect!' which is wrong on two counts: only ~36 token-AU exist across all floors, and the real win condition is defeating the CEO boss in the Boardroom (unlocked at 28 AU), not reaching 100 AU.

Replace the hardcoded line with a copy that states the real objective and sources the AU threshold directly from LEVEL_DATA[FLOORS.BOSS].auRequired so it cannot drift if the economy is rebalanced.

Add two new tests to WelcomeModal.test.ts asserting:
- body copy references Boardroom and CEO, does not contain '100 AU'
- body copy includes the AU threshold sourced from LEVEL_DATA (28)

Typecheck, lint (0 errors), and all 21 WelcomeModal unit tests pass.

Closes #794