### PR TITLE
Harden sourcemaps and docs-only CI gating

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,8 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
-      # Detect whether this push/PR touches anything outside docs/**.
-      # If only docs/** changed, downstream jobs are skipped — skipped jobs
+      # Detect whether this push/PR touches anything outside docs/workflows.
+      # If only docs/workflows changed, downstream jobs are skipped — skipped jobs
       # satisfy required status checks, so doc-only PRs can still merge.
       - uses: dorny/paths-filter@v4
         id: filter
@@ -34,6 +34,7 @@ jobs:
             code:
               - '**'
               - '!docs/**'
+              - '!.github/workflows/**'
 
   lint-and-unit:
     name: Lint + typecheck + unit tests

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,19 @@ jobs:
       - run: npm ci
       - run: npm run build
 
+      # Hidden sourcemaps make production stack traces debuggable without
+      # exposing source through the published GitHub Pages artifact.
+      - name: Upload production sourcemaps
+        uses: actions/upload-artifact@v7
+        with:
+          name: production-sourcemaps
+          path: dist/**/*.map
+          if-no-files-found: error
+          retention-days: 14
+
+      - name: Remove sourcemaps from Pages artifact
+        run: find dist -name '*.map' -delete
+
       - uses: actions/upload-pages-artifact@v5
         with:
           path: dist

--- a/README.md
+++ b/README.md
@@ -49,11 +49,13 @@ The CI `size-budget` job (`npm run size`) runs `scripts/check-size.cjs` after ev
 |-------|-------|-----------|
 | `dist/assets/index-*.js` (app chunk, gzipped) | 150 KB | App logic; well under today's size. |
 | `dist/assets/phaser-*.js` (engine chunk, gzipped) | 400 KB | Phaser 3.90 gzips to ~330 KB; guards against accidental engine duplication. |
-| Total `dist/` excluding `dist/music/**` (gzipped) | 700 KB | JS + HTML payload, minus streamed audio. |
-| Eager music assets (raw, from `STATIC_MUSIC_ASSETS`) | 700 KB | First-load audio; currently `music_menu` + `music_elevator_jazz` are eager (~size measured by `npm run size`). Remaining headroom shown by the size budget. |
-| **Total music assets** (raw, all `dist/music/**`) | **6.5 MB** | Guards against audio bloat; ~6.0 MB today after orphan cleanup. |
+| Total `dist/` excluding `dist/music/**` and `*.map` (gzipped) | 700 KB | JS + HTML payload, minus streamed audio and private diagnostic sourcemaps. |
+| Eager music assets (raw, from `STATIC_MUSIC_ASSETS`) | 750 KB | First-load audio; currently `music_menu` + `music_elevator_jazz` are eager (~size measured by `npm run size`). Remaining headroom shown by the size budget. |
+| **Total music assets** (raw, all `dist/music/**`) | **4 MB** | Guards against audio bloat after OGG re-encoding and orphan cleanup. |
 
 In addition to size budgets, the check fails if any audio file in `dist/music/` is **not declared** in `STATIC_MUSIC_ASSETS` (`src/config/audioConfig.ts`). This prevents orphaned tracks from accumulating unnoticed.
+
+Production builds emit hidden sourcemaps (`dist/assets/*.js.map`) so minified error stacks can be resolved during incident review. The deploy workflow uploads those maps as a private workflow artifact and removes them before publishing the GitHub Pages artifact; `npm run size` excludes `*.map` from player-facing payload budgets.
 
 If a PR genuinely needs more weight, raise the appropriate limit in `scripts/check-size.cjs` with a comment explaining why.
 

--- a/docs/ci-approval-policy.md
+++ b/docs/ci-approval-policy.md
@@ -52,7 +52,7 @@ In **Settings → Branches → `main` → Require status checks to pass before m
 Per-shard names are implementation details and can change over time. Branch protection
 must require only stable fan-in checks.
 
-For a docs-only PR (`docs/**` only), the shard jobs are intentionally skipped by `ci.yml` and `Playwright E2E complete` reports success via fan-in. This is expected and should still allow merge when required checks above are configured correctly.
+For a docs/workflows-only PR (`docs/**` or `.github/workflows/**` only), the shard jobs are intentionally skipped by `ci.yml` and `Playwright E2E complete` reports success via fan-in. This is expected and should still allow merge when required checks above are configured correctly.
 
 ## Optional API command to set required checks (maintainer token required)
 

--- a/scripts/check-size.cjs
+++ b/scripts/check-size.cjs
@@ -11,9 +11,9 @@
  * Budgets (update with deliberate justification):
  *   App chunk (index-*.js)         150 KB gzipped
  *   Phaser chunk (phaser-*.js)     400 KB gzipped
- *   Total dist/ (excl. music)      700 KB gzipped
- *   Eager music assets               2 MB raw
- *   Total music assets (all)       6.5 MB raw   ← guards against audio bloat
+ *   Total dist/ (excl. music/maps) 700 KB gzipped
+ *   Eager music assets             750 KB raw
+ *   Total music assets (all)         4 MB raw   ← guards against audio bloat
  *
  * Orphan check: every file in dist/music/ must be declared in
  * STATIC_MUSIC_ASSETS (src/config/audioConfig.ts).  Any undeclared file
@@ -192,14 +192,18 @@ const BUDGETS = /** @type {const} */ ([
     },
   },
   {
-    label:    'Total dist/ (excl. music)',
+    label:    'Total dist/ (excl. music/maps)',
     limitKB:  700,
     raw:      false,
     required: false,
     measure() {
       if (!fs.existsSync(DIST)) return { bytes: 0, found: false };
-      // Normalise path separators for the exclude check.
-      const files = walk(DIST, (f) => !f.replace(/\\/g, '/').includes('/dist/music/'));
+      // Normalise path separators for the exclude checks. Hidden sourcemaps
+      // are uploaded as private workflow artifacts, not served player payload.
+      const files = walk(DIST, (f) => {
+        const normalised = f.replace(/\\/g, '/');
+        return !normalised.includes('/dist/music/') && !normalised.endsWith('.map');
+      });
       return { bytes: files.reduce((s, f) => s + gzipSize(f), 0), found: true };
     },
   },

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -38,7 +38,7 @@ export default defineConfig({
   build: {
     outDir: 'dist',
     assetsDir: 'assets',
-    sourcemap: false,
+    sourcemap: 'hidden',
     target: 'es2020',
     rollupOptions: {
       output: {


### PR DESCRIPTION
## Summary
- Emit hidden production sourcemaps via Vite.
- Upload sourcemaps as a private workflow artifact, then remove them before publishing the Pages artifact.
- Exclude `*.map` files from player-facing size-budget totals.
- Treat workflow-only PRs like docs-only PRs for heavy CI gating.
- Sync README/check-size budget docs with current 750 KB eager music and 4 MB total music limits.

Closes #728.
Closes #774.
Closes #809.

## Validation
- `npm run typecheck` passed.
- `npm run lint` passed with pre-existing warnings.
- `npm run build && npm run size` passed.
- Hidden sourcemap contract verified: index/phaser `.js.map` files exist and built JS files contain no `sourceMappingURL` references.
- `npm run test:unit` was attempted repeatedly, but local Vitest runs hung before completion; no failure was observed before stopping.